### PR TITLE
Add support for backup switch.

### DIFF
--- a/proxy/server.py
+++ b/proxy/server.py
@@ -175,6 +175,24 @@ class handler(BaseHTTPRequestHandler):
                     fcv["METER_Y_CTA_I"] = d['METER_Y_CTA_I']
                     fcv["METER_Y_CTB_I"] = d['METER_Y_CTB_I']
                     fcv["METER_Y_CTC_I"] = d['METER_Y_CTC_I']
+                if device.startswith('TEMSA'):
+                    # This is a Backup Switch
+                    # Sync Freq
+                    fcv["ISLAND_FreqL1_Load"] = d['ISLAND_FreqL1_Load']
+                    fcv["ISLAND_FreqL2_Load"] = d['ISLAND_FreqL2_Load']
+                    fcv["ISLAND_FreqL3_Load"] = d['ISLAND_FreqL3_Load']
+                    fcv["ISLAND_FreqL1_Main"] = d['ISLAND_FreqL1_Main']
+                    fcv["ISLAND_FreqL2_Main"] = d['ISLAND_FreqL2_Main']
+                    fcv["ISLAND_FreqL3_Main"] = d['ISLAND_FreqL3_Main']
+                    # Sync Voltages
+                    fcv["ISLAND_VL1N_Load"] = d['ISLAND_VL1N_Load']
+                    fcv["ISLAND_VL2N_Load"] = d['ISLAND_VL2N_Load']
+                    fcv["ISLAND_VL3N_Load"] = d['ISLAND_VL3N_Load']
+                    fcv["METER_Z_VL1G"] = d["METER_Z_VL1G"]
+                    fcv["METER_Z_VL2G"] = d["METER_Z_VL2G"]
+                    # Sync Current
+                    fcv["METER_Z_CTA_I"] = d['METER_X_CTA_I']
+                    fcv["METER_Z_CTB_I"] = d['METER_X_CTB_I']
             fcv["grid_status"] = pw.grid_status(type="numeric")
             message = json.dumps(fcv)
         elif self.path == '/pod':


### PR DESCRIPTION
Here is a sample output for backup switch:
    "TEMSA--1624171-00-E--TG121161002JDY": {
        "ISLAND_FreqL1_Load": 60.010000000000005,
        "ISLAND_FreqL1_Main": 60.010000000000005,
        "ISLAND_FreqL2_Load": 60.0,
        "ISLAND_FreqL2_Main": 60.010000000000005,
        "ISLAND_FreqL3_Load": 0.0,
        "ISLAND_FreqL3_Main": 0.0,
        "ISLAND_GridConnected": true,
        "ISLAND_GridState": "ISLAND_GridState_Grid_Compliant",
        "ISLAND_L1L2PhaseDelta": -180.0,
        "ISLAND_L1L3PhaseDelta": -256.0,
        "ISLAND_L1MicrogridOk": true,
        "ISLAND_L2L3PhaseDelta": -256.0,
        "ISLAND_L2MicrogridOk": true,
        "ISLAND_L3MicrogridOk": false,
        "ISLAND_PhaseL1_Main_Load": 0.0,
        "ISLAND_PhaseL2_Main_Load": 0.0,
        "ISLAND_PhaseL3_Main_Load": -256.0,
        "ISLAND_ReadyForSynchronization": true,
        "ISLAND_VL1N_Load": 123.0,
        "ISLAND_VL1N_Main": 123.0,
        "ISLAND_VL2N_Load": 123.5,
        "ISLAND_VL2N_Main": 123.5,
        "ISLAND_VL3N_Load": 0.0,
        "ISLAND_VL3N_Main": 0.0,
        "METER_Z_CTA_I": 3.24,
        "METER_Z_CTA_InstReactivePower": -232.0,
        "METER_Z_CTA_InstRealPower": -15.0,
        "METER_Z_CTB_I": 3.48,
        "METER_Z_CTB_InstReactivePower": -308.0,
        "METER_Z_CTB_InstRealPower": -64.0,
        "METER_Z_LifetimeEnergyNetExport": 158623.0,
        "METER_Z_LifetimeEnergyNetImport": 959474.0,
        "METER_Z_VL1G": 123.53,
        "METER_Z_VL2G": 123.75,
        "componentParentDin": "STSTSM--1538000-25-F--TG121227001DD3",
        "firmwareVersion": "bce98cade591cb",
        "lastCommunicationTime": 1650038403,
        "manufacturer": "TESLA",
        "partNumber": "1624171-00-E",
        "serialNumber": "TG121161002JDY",
        "teslaEnergyEcuAttributes": {
            "ecuType": 300
        }
    },