### PR TITLE
Pass through Powerwall Web interface and customize for iframe displays

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-alpine
 WORKDIR /app
-RUN pip3 install pypowerwall==0.4.0
+RUN pip3 install pypowerwall==0.4.0 bs4
 COPY . .
 CMD ["python3", "server.py"]
 EXPOSE 8675 

--- a/proxy/transform.py
+++ b/proxy/transform.py
@@ -1,0 +1,50 @@
+import os
+
+from bs4 import BeautifulSoup as Soup
+
+import logging
+logging.basicConfig(
+    format='%(asctime)s [%(name)s] [%(levelname)s] %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+logger = logging.getLogger(os.path.basename(__file__))
+if os.environ.get("LOG_LEVEL", "").lower() == "debug":
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
+
+
+def get_static(web_root, fpath):
+    if fpath.split('?')[0] == "/":
+        fpath = "index.html"
+    if fpath.startswith("/"):
+        fpath = fpath[1:]
+    freq = os.path.join(web_root, fpath)
+    if os.path.exists(freq):
+        if freq.lower().endswith(".js"):
+            ftype = "application/javascript"
+        elif freq.lower().endswith(".css"):
+            ftype = "text/css"
+        elif freq.lower().endswith(".png"):
+            ftype = "image/png"
+        elif freq.lower().endswith(".html"):
+            ftype = "text/html"
+        else:
+            ftype = "text/plain"
+
+        with open(freq, 'rb') as f:
+            return f.read(), ftype
+
+    return None, None
+
+
+def inject_js(htmlsrc, *args):
+    soup = Soup(htmlsrc, 'html.parser')
+
+    for fpath in args:
+        logger.debug("Inserting Javascript file: {}".format(fpath))
+
+        script = soup.new_tag('script')
+        script['type'] = 'text/javascript'
+        script['src'] = fpath
+        soup.body.append(script)
+
+    return str(soup)

--- a/proxy/web/customize.js
+++ b/proxy/web/customize.js
@@ -1,0 +1,80 @@
+'use strict'
+
+// Clear IndexedDB to prevent auth hangup in the proxied Powerwall web app.
+window.indexedDB.databases().then((dbs) => {
+    dbs.forEach(db => { window.indexedDB.deleteDatabase(db.name) });
+});
+
+function injectScriptAndUse() {
+    return new Promise((resolve, reject) => {
+        var body = document.getElementsByTagName("body")[0];
+        var script = document.createElement("script");
+        script.src = "//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js";
+        script.onload = function () {
+            resolve();
+        };
+        body.appendChild(script);
+    });
+}
+
+injectScriptAndUse().then(() => {
+    console.log("Applying Dakboard customization");
+    triggerOnMutation(formatPowerwallForDakboard);
+});
+
+function triggerOnMutation(cb) {
+    // Create an observer instance
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (mutation) {
+            var newNodes = mutation.addedNodes; // DOM NodeList
+            if (newNodes !== null) { // If there are new nodes added
+                if (cb) cb();
+            }
+        });
+    });
+
+    // Configuration of the observer:
+    var config = {
+        attributes: true,
+        childList: true,
+        subtree: true,
+    };
+
+    var target = $("#root")[0];
+
+    // Pass in the target node, as well as the observer options
+    observer.observe(target, config);
+}
+
+function formatPowerwallForDakboard() {
+    // Hide elements.
+    $('.overview-menu, #logout, .footer, .compact-btn-row, .toast-list, .power-flow-header').hide();
+
+    // Set alignment
+    $('.core-layout__viewport').css({
+        padding: 0,
+        margin: 0,
+    });
+
+    $('.power-flow-header').css({
+        "padding-top": 0,
+    });
+
+    $('.power-flow-grid').css({
+        width: "100%",
+        left: 0,
+        right: 0,
+        margin: 0,
+        "padding-top": 0,
+        "position": "fixed",
+    });
+
+    // Set colors
+    $('body').css({
+        "background-color": "black",
+    });
+
+    $('.power-flow-grid.active').css({
+        "background-color": "#000",
+    });
+}


### PR DESCRIPTION
Hello,

This PR adds support to the proxy feature of pypowerwall to proxy access to the Powerwall web interface and customize it's appearance. 

This lets you run the proxy on a local network and create iframe widgets for displays like Dakboard.

![image](https://user-images.githubusercontent.com/323725/169588247-f12aa2ad-e126-4771-a5e9-4a438de1f5f4.png)
