### PR TITLE
Add grid_status responses for syncing to off-grid

### DIFF
--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -602,7 +602,9 @@ class Powerwall(object):
 
         map = {'SystemGridConnected': {'string': 'UP', 'numeric': 1}, 
                'SystemIslandedActive': {'string': 'DOWN', 'numeric': 0}, 
-               'SystemTransitionToGrid': {'string': 'SYNCING', 'numeric': -1}}
+               'SystemTransitionToGrid': {'string': 'SYNCING', 'numeric': -1},
+               'SystemTransitionToIsland': {'string': 'SYNCING', 'numeric': -1},
+               'SystemIslandedReady': {'string': 'SYNCING', 'numeric': -1}}
         try:
             grid_status = payload['grid_status']
             return map[grid_status][type]


### PR DESCRIPTION
Added `SystemTransitionToIsland` and `SystemIslandedReady` to map, as these can be returned when transitioning to off-grid (more details in issue #7 )