### PR TITLE
Use HTTP persistent connections for API requests

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -4,7 +4,7 @@
 
 This pyPowerwall Caching Proxy handles authentication to the Powerwall Gateway and will proxy API calls to /api/meters/aggregates (power metrics), /api/system_status/soe (battery level), and many others (see [HELP](https://github.com/jasonacox/pypowerwall/blob/main/proxy/HELP.md) for full list). With the instructions below, you can containerize this proxy and run it as an endpoint for tools like telegraf to pull metrics without needing to authenticate.
 
-Because pyPowerwall is designed to cache the auth and high frequency API calls, this will reduce the load on the Gateway and prevent crash/restart issues that can happen if too many session are created on the Gateway.
+Because pyPowerwall is designed to cache the auth and high frequency API calls, while also utilising HTTP persistent connections, this will reduce the load on the Gateway and prevent crash/restart issues that can happen if too many session are created on the Gateway.
 
 Docker: docker pull [jasonacox/pypowerwall](https://hub.docker.com/r/jasonacox/pypowerwall)
 


### PR DESCRIPTION
Implemented the use of HTTP persistent connections for API requests by default (refer issue #20)

- Requests to Gateway will now re-use persistent http connections which reduces load and increases response time
- Default connection `poolmaxsize=10` to align with Session object defaults. Note: pool use applies to multi-threaded use of pyPowerwall only, e.g. as with the pyPowerwall Proxy Server
- Added env `PW_POOL_MAXSIZE` to proxy server to allow this to be controlled (persistent connections disabled if set to zero)
- Added env `PW_TIMEOUT` to proxy server to also allow timeout on requests to be adjusted
- For release prep, pyPowerwall version changed to v0.6.0 and proxy version to t17 (release notes still required)