### PR TITLE
Revise error handling of SITE_DATA request

### DIFF
--- a/tools/set-mode.py
+++ b/tools/set-mode.py
@@ -207,12 +207,9 @@ def tesla_login(email):
                 if args.debug: print(f"Get SITE_DATA for Site ID {siteid}")
                 data = battery.api('SITE_DATA')
                 if args.debug: print(data)
-                if isinstance(data, teslapy.JsonDict) and 'response' in data:
-                    sitetime = isoparse(data['response']['timestamp'])
-                else:
-                    sitetime = "No 'live status' returned"
-            except Exception as err:
-                sys.exit(f"ERROR: Failed to retrieve SITE_DATA - {err}")
+                sitetime = isoparse(data['response']['timestamp'])
+            except:
+                sitetime = "No 'live status' returned"
 
             # Add site if site id not already in the list
             if siteid not in sitelist:

--- a/tools/set-reserve.py
+++ b/tools/set-reserve.py
@@ -223,12 +223,9 @@ def tesla_login(email):
                 if args.debug: print(f"Get SITE_DATA for Site ID {siteid}")
                 data = battery.api('SITE_DATA')
                 if args.debug: print(data)
-                if isinstance(data, teslapy.JsonDict) and 'response' in data:
-                    sitetime = isoparse(data['response']['timestamp'])
-                else:
-                    sitetime = "No 'live status' returned"
-            except Exception as err:
-                sys.exit(f"ERROR: Failed to retrieve SITE_DATA - {err}")
+                sitetime = isoparse(data['response']['timestamp'])
+            except:
+                sitetime = "No 'live status' returned"
 
             # Add site if site id not already in the list
             if siteid not in sitelist:


### PR DESCRIPTION
Revised error handling of SITE_DATA request due to issues noted in [#12](https://github.com/jasonacox/Powerwall-Dashboard/issues/12#issuecomment-1380981134) when multiple sites are linked to the Tesla account.

As the SITE_DATA request is only used to retrieve the current system time from the Powerwall, this has been revised so if any exception occurs when trying to fetch this, the script will no longer exit.