### PR TITLE
add alert PVS_a036_PvArcLockout

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,7 @@ Example Output: [here](https://github.com/jasonacox/pypowerwall/blob/main/docs/v
     * PVS_a027_Mci2PvVoltage
     * PVS_a031_Mci3PvVoltage
     * PVS_a032_Mci4PvVoltage
+    * PVS_a036_PvArcLockout
     * PVS_a039_SelfTestRelayFault
     * PVS_a048_DcSensorIrrationalFault
     * PVS_a050_RelayCoilIrrationalWarning


### PR DESCRIPTION
I lost solar production yesterday and this project was very helpful in checking the internal state, since there were no errors displayed in the Tesla app or local UI.

My alerts for PVS are
  "alerts": [
    "PVS_a036_PvArcLockout",
    "PVS_a058_MciOpenOnFault",
    "PVS_a059_MciOpen"
  ]

PVS_a036_PvArcLockout is not documented yet so I'm adding it in case it helps anyone. Last month a similar issue happened and Tesla came out and replaced MCIs
