### PR TITLE
v0.7.2 - Add cloud mode configuration setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ and call function to poll data.  Here is an example:
  set_debug(True, color=True)
 
  Classes
-    Powerwall(host, password, email, timezone, pwcacheexpire, timeout, poolmaxsize)
+    Powerwall(host, password, email, timezone, pwcacheexpire, timeout, poolmaxsize, 
+              cloudmode, siteid, authpath)
 
  Parameters
     host                      # Hostname or IP of the Tesla gateway
@@ -133,6 +134,8 @@ and call function to poll data.  Here is an example:
     poolmaxsize = 10          # Pool max size for http connection re-use (persistent
                                 connections disabled if zero)
     cloudmode = False         # If True, use Tesla cloud for data (default is False)
+    siteid                    # If cloudmode is True, use this siteid (default is None)  
+    authpath                  # Path to cloud auth and site cache files (default is "")
 
  Functions 
     poll(api, json, force)    # Return data from Powerwall api (dict if json=True, bypass cache force=True)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,15 +2,17 @@
 
 ## v0.7.2 - Cloud Auth Path
 
-* Add pypowerwall setting to define path to cloud auth cache and site files. It will default to current directory.
+* Add pypowerwall setting to define path to cloud auth cache and site files in the initialization. It will default to current directory.
+* Add pypowerwall setting to define energy site id in the initialization. It will default to None.
 
 ```python
 import pypowerwall
 
-pw = pypowerwall.Powerwall(email="email@example.com",cloudmode=True,authpath=".auth")
+pw = pypowerwall.Powerwall(email="email@example.com",cloudmode=True,siteid=1234567,authpath=".auth")
 ```
 
 * Proxy will now use `PW_AUTH_PATH` as an environmental variable to set the path for `.pypowerwall.auth` and `.pypowerwall.site`.
+* Proxy also has `PW_SITEID` as an environmental variable to set `siteid`.
 
 ## v0.7.1 - Tesla Cloud Mode
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,17 @@
 # RELEASE NOTES
 
+## v0.7.2 - Cloud Auth Path
+
+* Add pypowerwall setting to define path to cloud auth cache and site files. It will default to current directory.
+
+```python
+import pypowerwall
+
+pw = pypowerwall.Powerwall(email="email@example.com",cloudmode=True,authpath=".auth")
+```
+
+* Proxy will now use `PW_AUTH_PATH` as an environmental variable to set the path for `.pypowerwall.auth` and `.pypowerwall.site`.
+
 ## v0.7.1 - Tesla Cloud Mode
 
 * Simulate Powerwall Energy Gateway via Tesla Cloud API calls. In `cloudmode` API calls to pypowerwall APIs will result in calls made to the Tesla API to fetch the data.

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,9 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t36 (30 Dec 2023)
+
+* Add `PW_AUTH_PATH` to set location for cloud auth and site files.
+
 ### Proxy t35 (29 Dec 2023)
 
 * Add `cloudmode` support for pypowerwall v0.7.1. 

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -42,7 +42,7 @@ import signal
 import ssl
 from transform import get_static, inject_js
 
-BUILD = "t35"
+BUILD = "t36"
 ALLOWLIST = [
     '/api/status', '/api/site_info/site_name', '/api/meters/site',
     '/api/meters/solar', '/api/sitemaster', '/api/powerwalls', 
@@ -71,6 +71,7 @@ https_mode = os.getenv("PW_HTTPS", "no")
 port = int(os.getenv("PW_PORT", "8675"))
 style = os.getenv("PW_STYLE", "clear") + ".js"
 siteid = os.getenv("PW_SITEID", None)
+authpath = os.getenv("PW_AUTH_PATH", "")
 
 # Global Stats
 proxystats = {}
@@ -86,7 +87,7 @@ proxystats['uptime'] = ""
 proxystats['mem'] = 0
 proxystats['site_name'] = ""
 proxystats['cloudmode'] = False
-proxystats['siteid'] = 0
+proxystats['siteid'] = None
 proxystats['counter'] = 0
 
 if https_mode == "yes":
@@ -128,7 +129,8 @@ def get_value(a, key):
 # Connect to Powerwall
 # TODO: Add support for multiple Powerwalls
 try:
-    pw = pypowerwall.Powerwall(host,password,email,timezone,cache_expire,timeout,pool_maxsize)
+    pw = pypowerwall.Powerwall(host,password,email,timezone,cache_expire,
+                               timeout,pool_maxsize,siteid=siteid,authpath=authpath)
 except Exception as e:
     log.error(e)
     log.error("Fatal Error: Unable to connect. Please fix config and restart.")

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -15,7 +15,8 @@
     * Can use Tesla Cloud API instead of local Powerwall Gateway (if enabled)
 
  Classes
-    Powerwall(host, password, email, timezone, pwcacheexpire, timeout, poolmaxsize, cloudmode, authpath)
+    Powerwall(host, password, email, timezone, pwcacheexpire, timeout, poolmaxsize, 
+        cloudmode, siteid, authpath)
 
  Parameters
     host                      # Hostname or IP of the Tesla gateway
@@ -27,6 +28,7 @@
     poolmaxsize = 10          # Pool max size for http connection re-use (persistent
                                 connections disabled if zero)
     cloudmode = False         # If True, use Tesla cloud for data (default is False)
+    siteid = None             # If cloudmode is True, use this siteid (default is None)
     authpath = ""             # Path to cloud auth and site files (default current directory)
 
  Functions 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -15,7 +15,7 @@
     * Can use Tesla Cloud API instead of local Powerwall Gateway (if enabled)
 
  Classes
-    Powerwall(host, password, email, timezone, pwcacheexpire, timeout, poolmaxsize, cloudmode)
+    Powerwall(host, password, email, timezone, pwcacheexpire, timeout, poolmaxsize, cloudmode, authpath)
 
  Parameters
     host                      # Hostname or IP of the Tesla gateway
@@ -27,6 +27,7 @@
     poolmaxsize = 10          # Pool max size for http connection re-use (persistent
                                 connections disabled if zero)
     cloudmode = False         # If True, use Tesla cloud for data (default is False)
+    authpath = ""             # Path to cloud auth and site files (default current directory)
 
  Functions 
     poll(api, json, force)    # Return data from Powerwall api (dict if json=True, bypass cache force=True)
@@ -69,7 +70,7 @@ import sys
 from . import tesla_pb2           # Protobuf definition for vitals
 from . import cloud               # Tesla Cloud API
 
-version_tuple = (0, 7, 1)
+version_tuple = (0, 7, 2)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 
@@ -96,7 +97,9 @@ class ConnectionError(Exception):
     pass
 
 class Powerwall(object):
-    def __init__(self, host="", password="", email="nobody@nowhere.com", timezone="America/Los_Angeles", pwcacheexpire=5, timeout=5, poolmaxsize=10, cloudmode=False):
+    def __init__(self, host="", password="", email="nobody@nowhere.com", 
+                 timezone="America/Los_Angeles", pwcacheexpire=5, timeout=5, poolmaxsize=10, 
+                 cloudmode=False, siteid=None, authpath=""):
         """
         Represents a Tesla Energy Gateway Powerwall device.
 
@@ -110,6 +113,8 @@ class Powerwall(object):
             timeout      = Seconds for the timeout on http requests
             poolmaxsize  = Pool max size for http connection re-use (persistent connections disabled if zero)
             cloudmode    = If True, use Tesla cloud for data (default is False)
+            siteid       = If cloudmode is True, use this siteid (default is None)  
+            authpath     = Path to cloud auth and site cache files (default current directory)
 
         """
 
@@ -126,13 +131,15 @@ class Powerwall(object):
         self.pwcache = {}                       # holds the cached data for api
         self.pwcacheexpire = pwcacheexpire      # seconds to expire cache 
         self.cloudmode = cloudmode              # cloud mode or local mode (default)
+        self.siteid = siteid                    # siteid for cloud mode
+        self.authpath = authpath                # path to auth and site cache files
         self.Tesla = None                       # cloud object for cloud connection
 
         # Check for cloud mode
         if self.cloudmode or self.host == "":
             self.cloudmode = True
             log.debug('Tesla cloud mode enabled')
-            self.Tesla = cloud.TeslaCloud(self.email, pwcacheexpire, timeout)
+            self.Tesla = cloud.TeslaCloud(self.email, pwcacheexpire, timeout, siteid, authpath)
             # Check to see if we can connect to the cloud
             if not self.Tesla.connect():
                 err = "Unable to connect to Tesla Cloud - run pypowerwall setup"

--- a/pypowerwall/cloud.py
+++ b/pypowerwall/cloud.py
@@ -48,7 +48,7 @@ COUNTER_MAX = 64               # Max counter value for SITE_DATA API
 SITE_CONFIG_TTL = 59           # Site config cache TTL in seconds
 
 # pypowerwall cloud module version
-version_tuple = (0, 0, 2)
+version_tuple = (0, 0, 3)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 
@@ -82,9 +82,7 @@ def lookup(data, keylist):
     return data
 
 class TeslaCloud:
-    def __init__(self, email, pwcacheexpire=5, timeout=5, siteid=None):
-        self.authfile = AUTHFILE
-        self.sitefile = SITEFILE
+    def __init__(self, email, pwcacheexpire=5, timeout=5, siteid=None, authpath=""):
         self.email = email
         self.timeout = timeout
         self.site = None
@@ -96,6 +94,10 @@ class TeslaCloud:
         self.siteindex = 0                      # site index to use
         self.siteid = siteid                    # site id to use
         self.counter = 0                        # counter for SITE_DATA API
+        self.authpath = authpath                # path to cloud auth and site files
+
+        self.authfile = os.path.join(authpath, AUTHFILE)
+        self.sitefile = os.path.join(authpath, SITEFILE)
 
         if self.siteid is None:
             # Check for site file
@@ -107,7 +109,8 @@ class TeslaCloud:
                         self.siteid = 0
             else:
                 self.siteindex = 0
-
+        log.debug(f" -- cloud: Using site {self.siteid} for {self.email}")
+  
         # Check for auth file
         if not os.path.exists(self.authfile):
             log.debug("WARNING: Missing auth file %s - run setup" % self.authfile)
@@ -148,7 +151,7 @@ class TeslaCloud:
                     found = True
                     break
             if not found:
-                log.error("Site %d not found for %s" % (self.siteid, self.email))
+                log.error("Site %r not found for %s" % (self.siteid, self.email))
                 return False
         # Set site
         self.site = sites[self.siteindex]


### PR DESCRIPTION
This adds the option to set file path for cloud auth (`.pypowerwall.auth`) and site (`.pypowerwall.site`) cache files:
* API - The initializer now has `authpath` which defaults to current directory (`authpath=""`)
* Proxy - An environmental variable `PW_AUTH_PATH` is added which defaults to current directory.

This also adds the option to specify the energy site ID (`siteid`):
* API - The  initializer now has `siteid` which defaults to None.
* Proxy - The existing environmental variable `PW_SITEID` is available to set the `siteid`.

This will provide more flexibility to run the pypowerwall proxy in a container for cloud mode support.