### PR TITLE
v0.7.3 - Cloud Mode Setup

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # RELEASE NOTES
 
+## v0.7.3 - Cloud Mode Setup
+
+* Setup will now check for `PW_AUTH_PATH` environmental variable to set the path for `.pypowerwall.auth` and `.pypowerwall.site` by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/62
+* Move signal handler to capture SIGTERM when proxy halts due to config error by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/62. This ensures a containerized proxy will exit without delay when stopping or restarting the container.
+
 ## v0.7.2 - Cloud Auth Path
 
 * Add pypowerwall setting to define path to cloud auth cache and site files in the initialization. It will default to current directory.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 ## v0.7.3 - Cloud Mode Setup
 
 * Setup will now check for `PW_AUTH_PATH` environmental variable to set the path for `.pypowerwall.auth` and `.pypowerwall.site` by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/62
-* Move signal handler to capture SIGTERM when proxy halts due to config error by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/62. This ensures a containerized proxy will exit without delay when stopping or restarting the container.
+* Proxy t37 - Move signal handler to capture SIGTERM when proxy halts due to config error by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/62. This ensures a containerized proxy will exit without delay when stopping or restarting the container.
 
 ## v0.7.2 - Cloud Auth Path
 

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-alpine
 WORKDIR /app
-RUN pip3 install pypowerwall==0.7.2 bs4
+RUN pip3 install pypowerwall==0.7.3 bs4
 COPY . .
 CMD ["python3", "server.py"]
 EXPOSE 8675 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -72,7 +72,7 @@ import sys
 from . import tesla_pb2           # Protobuf definition for vitals
 from . import cloud               # Tesla Cloud API
 
-version_tuple = (0, 7, 2)
+version_tuple = (0, 7, 3)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -14,11 +14,13 @@
 # Modules
 import pypowerwall
 import sys
+import os
 from . import scan
 from . import cloud
 
 # Global Variables
 AUTHFILE = ".pypowerwall.auth"
+authpath = os.getenv("PW_AUTH_PATH", "")
 timeout = 1.0
 state = 0
 color = True
@@ -46,7 +48,7 @@ if(state == 0):
 if(state == 1):
     print("pyPowerwall [%s] - Cloud Mode Setup\n" % (pypowerwall.version))
     # Run Setup
-    c = cloud.TeslaCloud(None)
+    c = cloud.TeslaCloud(None, authpath=authpath)
     if c.setup():
         print("Setup Complete. Auth file %s ready to use." % (AUTHFILE))
     else:

--- a/pypowerwall/cloud.py
+++ b/pypowerwall/cloud.py
@@ -48,7 +48,7 @@ COUNTER_MAX = 64               # Max counter value for SITE_DATA API
 SITE_CONFIG_TTL = 59           # Site config cache TTL in seconds
 
 # pypowerwall cloud module version
-version_tuple = (0, 0, 3)
+version_tuple = (0, 0, 4)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 
@@ -813,9 +813,9 @@ class TeslaCloud:
         print("-" * 60)
         tuser = ""
         # Check for .pypowerwall.auth file
-        if os.path.isfile(AUTHFILE):
-            print("  Found existing Tesla Cloud setup file ({})".format(AUTHFILE))
-            with open(AUTHFILE) as json_file:
+        if os.path.isfile(self.authfile):
+            print("  Found existing Tesla Cloud setup file ({})".format(self.authfile))
+            with open(self.authfile) as json_file:
                 try:
                     data = json.load(json_file)
                     tuser = list(data.keys())[0]
@@ -824,7 +824,7 @@ class TeslaCloud:
                     response = input("\n  Overwrite existing file? [y/N]: ").strip()
                     if response.lower() == "y":
                         tuser = ""
-                        os.remove(AUTHFILE)
+                        os.remove(self.authfile)
                     else:
                         self.email = tuser
                 except Exception as err:
@@ -844,7 +844,7 @@ class TeslaCloud:
             self.email = tuser
 
             # Create Tesla instance
-            tesla = Tesla(self.email, cache_file=AUTHFILE)
+            tesla = Tesla(self.email, cache_file=self.authfile)
 
             if not tesla.authorized:
                 # Login to Tesla account and cache token
@@ -860,7 +860,7 @@ class TeslaCloud:
                 print("\nAfter login, paste the URL of the 'Page Not Found' webpage below.\n")
 
                 tesla.close()
-                tesla = Tesla(self.email, state=state, code_verifier=code_verifier, cache_file=AUTHFILE)
+                tesla = Tesla(self.email, state=state, code_verifier=code_verifier, cache_file=self.authfile)
 
                 if not tesla.authorized:
                     try:
@@ -885,8 +885,8 @@ class TeslaCloud:
         print("-"*60)
 
         # Check for existing site file
-        if os.path.isfile(SITEFILE):
-            with open(SITEFILE) as file:
+        if os.path.isfile(self.sitefile):
+            with open(self.sitefile) as file:
                 try:
                     self.siteid = int(file.read())
                 except:
@@ -922,7 +922,7 @@ class TeslaCloud:
         self.site = sites[self.siteindex]
         print("\nSelected site %d - %s (%s)" % (self.siteindex+1, sites[self.siteindex]["site_name"], self.siteid))
         # Write the site id to the sitefile
-        with open(SITEFILE, "w") as f:
+        with open(self.sitefile, "w") as f:
             f.write(str(self.siteid))
         
         return True


### PR DESCRIPTION
## v0.7.3 - Cloud Mode Setup

* Setup will now check for `PW_AUTH_PATH` environmental variable to set the path for `.pypowerwall.auth` and `.pypowerwall.site`
* Proxy t37 - Move signal handler to capture SIGTERM when proxy halts due to config error. This ensures a containerized proxy will exit without delay when stopping or restarting the container.
