### PR TITLE
Add Bearer Token Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ and call function to poll data.  Here is an example:
 
  Classes
     Powerwall(host, password, email, timezone, pwcacheexpire, timeout, poolmaxsize, 
-              cloudmode, siteid, authpath)
+              cloudmode, siteid, authpath, authmode)
 
  Parameters
     host                      # Hostname or IP of the Tesla gateway
@@ -136,6 +136,7 @@ and call function to poll data.  Here is an example:
     cloudmode = False         # If True, use Tesla cloud for data (default is False)
     siteid                    # If cloudmode is True, use this siteid (default is None)  
     authpath                  # Path to cloud auth and site cache files (default is "")
+    authmode = "cookie"       # "cookie" (default) or "token" - use cookie or bearer token for auth
 
  Functions 
     poll(api, json, force)    # Return data from Powerwall api (dict if json=True, bypass cache force=True)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,8 @@ import pypowerwall
 pw = pypowerwall.Powerwall(HOST, PASSWORD, EMAIL, TIMEZONE, authmode="token")
 ```
 
+Powerwall Network Scanner
+* Added optional IP address argument to network scanner by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/63. The Scan Function can now accept an additional argument `-ip=` to override the host IP address detection (`python -m pypowerwall scan -ip=192.168.1.100`). This may be useful where the host IP address/network cannot be detected correctly, for instance if pypowerwall is running inside a container.
 
 ## v0.7.3 - Cloud Mode Setup
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,7 @@
 
 ## v0.7.4 - Bearer Token Auth
 
+pyPowerwall Updates
 * This release adds the ability to use a Bearer Token for Authentication for the local Powerwall gateway API calls. This is selectable by defining `authmode='token'` in the initialization. The default mode uses the existing `AuthCookie` and `UserRecord` method.
 
 ```python
@@ -9,6 +10,9 @@ import pypowerwall
 
 pw = pypowerwall.Powerwall(HOST, PASSWORD, EMAIL, TIMEZONE, authmode="token")
 ```
+
+Proxy
+* The above option is extended to the pyPowerwall Proxy via the envrionmental variable `PW_AUTH_MODE` set to cookie (default) or token.
 
 Powerwall Network Scanner
 * Added optional IP address argument to network scanner by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/63. The Scan Function can now accept an additional argument `-ip=` to override the host IP address detection (`python -m pypowerwall scan -ip=192.168.1.100`). This may be useful where the host IP address/network cannot be detected correctly, for instance if pypowerwall is running inside a container.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,16 @@
 # RELEASE NOTES
 
+## v0.7.4 - Bearer Token Auth
+
+* This release adds the ability to use a Bearer Token for Authentication for the local Powerwall gateway API calls. This is selectable by defining `authmode='token'` in the initialization. The default mode uses the existing `AuthCookie` and `UserRecord` method.
+
+```python
+import pypowerwall
+
+pw = pypowerwall.Powerwall(HOST, PASSWORD, EMAIL, TIMEZONE, authmode="token")
+```
+
+
 ## v0.7.3 - Cloud Mode Setup
 
 * Setup will now check for `PW_AUTH_PATH` environmental variable to set the path for `.pypowerwall.auth` and `.pypowerwall.site` by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/62

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -24,6 +24,7 @@ authpath = os.getenv("PW_AUTH_PATH", "")
 timeout = 1.0
 state = 0
 color = True
+ip = None
 
 for i in sys.argv:
     if(i==sys.argv[0]):
@@ -34,6 +35,8 @@ for i in sys.argv:
         state = 1
     elif(i.lower() == "-nocolor"):
         color = False
+    elif(i.lower()[0:4] == "-ip="):
+        ip = i[4:]
     else:
         try:
             timeout = float(i)
@@ -42,7 +45,7 @@ for i in sys.argv:
 
 # State 0 = Run Scan
 if(state == 0):
-    scan.scan(color, timeout)
+    scan.scan(color, timeout, ip)
 
 # State 1 = Cloud Mode Setup
 if(state == 1):

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -68,6 +68,7 @@ if(state == 2):
     print("      command = setup       Setup Tesla Login for Cloud Mode access.")
     print("      timeout               Seconds to wait per host [Default=%0.1f]" % (timeout))
     print("      -nocolor              Disable color text output.")
+    print("      -ip=<ip>              (Scan option) IP address within network to scan.")
     print("      -h                    Show usage.")
     print("")
 

--- a/pypowerwall/cloud.py
+++ b/pypowerwall/cloud.py
@@ -835,7 +835,7 @@ class TeslaCloud:
             while True:
                 response = input("\n  Email address: ").strip()
                 if "@" not in response:
-                    print("  - Error: Invalid email address\n")
+                    print("  - Error: Invalid email address")
                 else:
                     tuser = response
                     break
@@ -852,7 +852,7 @@ class TeslaCloud:
                 code_verifier = tesla.new_code_verifier()
 
                 try:
-                    print("Open the below address in your browser to login.\n")
+                    print("\nOpen the below address in your browser to login.\n")
                     print(tesla.authorization_url(state=state, code_verifier=code_verifier))
                 except Exception as err:
                     log.error(f"Connection failure - {repr(err)}")

--- a/pypowerwall/cloud.py
+++ b/pypowerwall/cloud.py
@@ -931,6 +931,7 @@ if __name__ == "__main__":
 
     # Test code
     set_debug(False)
+    tuser = None
     # Check for .pypowerwall.auth file
     if os.path.isfile(AUTHFILE):
         # Read the json file
@@ -961,9 +962,9 @@ if __name__ == "__main__":
 
     print("Connected to Tesla Cloud")   
 
-    #print("\nSite Data")
-    #sites = cloud.getsites()
-    #print(sites)
+    print("\nSite Data")
+    sites = cloud.getsites()
+    print(sites)
 
     #print("\Battery")
     #r = cloud.get_battery()

--- a/pypowerwall/scan.py
+++ b/pypowerwall/scan.py
@@ -35,7 +35,7 @@ def getmyIP():
     s.close()
     return r
 
-def scan(color=True, timeout=0.4):
+def scan(color=True, timeout=0.4, ip=None):
     """
     pyPowerwall Network Scanner
 
@@ -62,7 +62,8 @@ def scan(color=True, timeout=0.4):
 
     # Fetch my IP address and assume /24 network
     try: 
-        ip = getmyIP()
+        if ip is None:
+            ip = getmyIP()
         network = ipaddress.IPv4Interface(u''+ip+'/24').network
     except:
         print(alert + 'ERROR: Unable to get your IP address and network automatically.' + normal)


### PR DESCRIPTION
This release adds the ability to use a Bearer Token for auth for local Powerwall gateway API calls. This is selectable by defining `authmode='token'` in the initialization. The default mode uses the existing `AuthCookie` and `UserRecord` method.

```python
import pypowerwall

pw = pypowerwall.Powerwall(HOST, PASSWORD, EMAIL, TIMEZONE, authmode="token")
```

This could potentially help with Issue #57 (untested)