### PR TITLE
v0.7.5 - Cloud Mode Setup

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # RELEASE NOTES
 
+## v0.7.5 - Cloud Mode Setup
+
+* Added optional email address argument to Cloud Mode setup (`python -m pypowerwall setup -email=<email>`) by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/64 to streamline Powerwall-Dashboard setup script.
+* Updated network scanner output to advise Powerwall 3 is supported in Cloud Mode by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/64
+
 ## v0.7.4 - Bearer Token Auth
 
 pyPowerwall Updates

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-alpine
 WORKDIR /app
-RUN pip3 install pypowerwall==0.7.4 bs4
+RUN pip3 install pypowerwall==0.7.5 bs4
 COPY . .
 CMD ["python3", "server.py"]
 EXPOSE 8675 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -74,7 +74,7 @@ import sys
 from . import tesla_pb2           # Protobuf definition for vitals
 from . import cloud               # Tesla Cloud API
 
-version_tuple = (0, 7, 4)
+version_tuple = (0, 7, 5)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -25,6 +25,7 @@ timeout = 1.0
 state = 0
 color = True
 ip = None
+email = None
 
 for i in sys.argv:
     if(i==sys.argv[0]):
@@ -37,6 +38,8 @@ for i in sys.argv:
         color = False
     elif(i.lower()[0:4] == "-ip="):
         ip = i[4:]
+    elif(i.lower()[0:7] == "-email="):
+        email = i[7:]
     else:
         try:
             timeout = float(i)
@@ -52,7 +55,7 @@ if(state == 1):
     print("pyPowerwall [%s] - Cloud Mode Setup\n" % (pypowerwall.version))
     # Run Setup
     c = cloud.TeslaCloud(None, authpath=authpath)
-    if c.setup():
+    if c.setup(email):
         print("Setup Complete. Auth file %s ready to use." % (AUTHFILE))
     else:
         print("ERROR: Failed to setup Tesla Cloud Mode")
@@ -62,13 +65,14 @@ if(state == 1):
 if(state == 2):
     print("pyPowerwall [%s]\n" % (pypowerwall.version))
     print("Usage:\n")
-    print("    python -m pypowerwall [command] [<timeout>] [-nocolor] [-h]")
+    print("    python -m pypowerwall [command] [<timeout>] [-nocolor] [-ip=<ip>] [-email=<email>] [-h]")
     print("")
     print("      command = scan        Scan local network for Powerwall gateway.")
     print("      command = setup       Setup Tesla Login for Cloud Mode access.")
-    print("      timeout               Seconds to wait per host [Default=%0.1f]" % (timeout))
-    print("      -nocolor              Disable color text output.")
+    print("      timeout               (Scan option) Seconds to wait per host [Default=%0.1f]" % (timeout))
+    print("      -nocolor              (Scan option) Disable color text output.")
     print("      -ip=<ip>              (Scan option) IP address within network to scan.")
+    print("      -email=<email>        (Setup option) Email address for Tesla Login.")
     print("      -h                    Show usage.")
     print("")
 

--- a/pypowerwall/cloud.py
+++ b/pypowerwall/cloud.py
@@ -48,7 +48,7 @@ COUNTER_MAX = 64               # Max counter value for SITE_DATA API
 SITE_CONFIG_TTL = 59           # Site config cache TTL in seconds
 
 # pypowerwall cloud module version
-version_tuple = (0, 0, 4)
+version_tuple = (0, 0, 5)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 
@@ -805,7 +805,7 @@ class TeslaCloud:
 
         return data
     
-    def setup(self):
+    def setup(self, email=None):
         """
         Set up the Tesla Cloud connection
         """
@@ -832,13 +832,17 @@ class TeslaCloud:
 
         if tuser == "":
             # Create new AUTHFILE
-            while True:
-                response = input("\n  Email address: ").strip()
-                if "@" not in response:
-                    print("  - Error: Invalid email address")
-                else:
-                    tuser = response
-                    break
+            if email not in (None, "") and "@" in email:
+                tuser = email.strip()
+                print(f"\n  Email address: {tuser}")
+            else:
+                while True:
+                    response = input("\n  Email address: ").strip()
+                    if "@" not in response:
+                        print("  - Error: Invalid email address")
+                    else:
+                        tuser = response
+                        break
 
             # Update the Tesla User
             self.email = tuser

--- a/pypowerwall/scan.py
+++ b/pypowerwall/scan.py
@@ -126,9 +126,9 @@ def scan(color=True, timeout=0.4, ip=None):
                         # Expected response from PW3 {"code":403,"error":"Unable to GET to resource","message":"User does not have adequate access rights"}
                         if "User does not have adequate access rights" in g.text:
                             # Found PW3
-                            print(dim + ' - ' + subbold + 'Found Powerwall 3 [Currently Unsupported]')
+                            print(dim + ' - ' + subbold + 'Found Powerwall 3 [Supported in Cloud Mode only]')
                             discovered[addr] = 'Powerwall-3'
-                            firmware[addr] = 'Currently Unsupported - See https://tinyurl.com/pw3support'
+                            firmware[addr] = 'Supported in Cloud Mode only - See https://tinyurl.com/pw3support'
                         else:
                             # Not a Powerwall
                             print(dim + ' - Not a Powerwall')


### PR DESCRIPTION
## v0.7.5 - Cloud Mode Setup

* Added optional email address argument to Cloud Mode setup (`python -m pypowerwall setup -email=<email>`) to streamline Powerwall-Dashboard setup script.
* Updated network scanner output to advise Powerwall 3 is supported in Cloud Mode.