### PR TITLE
Fix 404 handling #65 #57

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.7.6 - 404 Bug Fix
+
+* Fix Critical Bug - 404 HTTP Status Code Handling (Issue https://github.com/jasonacox/pypowerwall/issues/65).
+
 ## v0.7.5 - Cloud Mode Setup
 
 * Added optional email address argument to Cloud Mode setup (`python -m pypowerwall setup -email=<email>`) by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/64 to streamline Powerwall-Dashboard setup script.

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-alpine
 WORKDIR /app
-RUN pip3 install pypowerwall==0.7.5 bs4
+RUN pip3 install pypowerwall==0.7.6 bs4
 COPY . .
 CMD ["python3", "server.py"]
 EXPOSE 8675 

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,9 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t39 (12 Jan 2023)
+
+* Fix Critical Bug - 404 HTTP Status Code Handling (Issue https://github.com/jasonacox/pypowerwall/issues/65).
+
 ### Proxy t36 (30 Dec 2023)
 
 * Add `PW_AUTH_PATH` to set location for cloud auth and site files.

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -42,7 +42,7 @@ import signal
 import ssl
 from transform import get_static, inject_js
 
-BUILD = "t38"
+BUILD = "t39"
 ALLOWLIST = [
     '/api/status', '/api/site_info/site_name', '/api/meters/site',
     '/api/meters/solar', '/api/sitemaster', '/api/powerwalls', 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -74,7 +74,7 @@ import sys
 from . import tesla_pb2           # Protobuf definition for vitals
 from . import cloud               # Tesla Cloud API
 
-version_tuple = (0, 7, 5)
+version_tuple = (0, 7, 6)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 
@@ -294,6 +294,10 @@ class Powerwall(object):
                 return None
             except:
                 log.debug('ERROR Unknown error connecting to Powerwall at %s' % url)
+                return None
+            if r.status_code == 404:
+                # API not found or no longer supported
+                log.debug('ERROR Powerwall API not found at %s' % url)
                 return None
             if r.status_code >= 400 and r.status_code < 500:
                 # Session Expired - Try to get a new one unless we already tried

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="refresh" content="5;url=https://github.com/jasonacox/pypowerwall">
+    <meta name="description" content="Python module to interface with Tesla Energy Gateways for Powerwall and Solar Power Data.">
+    <meta name="keywords" content="Tesla, Powerwall, Solar, Energy, Gateway, Python, API, Module, Library, Open Source">
+    <meta name="author" content="Jason A. Cox">
+    <meta name="robots" content="index,follow">
+    <title>pyPowerwall</title>
+    <style>
+        body {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: space-between;
+            min-height: 100vh;
+            margin: 0;
+            overflow: hidden; /* Prevent shapes from overflowing the window */
+        }
+
+        .container {
+            text-align: center;
+            margin: auto; /* Center container horizontally */
+        }
+
+        .title {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-size: 3em;
+            font-weight: bold;
+            margin-bottom: 20px; /* Add some space between the title and the description */ 
+        }
+
+        .description {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-size: 1.5em;
+            font-weight: lighter;
+            color: gray;
+            margin-bottom: 20px; /* Add some space between the description and the timer */
+        }
+
+        .timer {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-size: 1.2em;
+            color: red;
+        }
+
+        .tiny-text {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-size: 0.8em;
+            position: fixed;
+            bottom: 0;
+            width: 100%;
+            text-align: center;
+            background-color: #f0f0f0; /* Background color for better visibility */
+            padding: 5px;
+        }
+
+        .shape {
+            position: absolute;
+            width: 20px;
+            height: 20px;
+            background-color: green;
+            border-radius: 50%;
+            animation: float 5s infinite linear; /* Adjust animation duration as needed */
+        }
+
+	@keyframes float {
+            0% {
+                transform: translateY(0) translateX(-50vw);
+            }
+            25% {
+                transform: translateY(100vh) translateX(-25vw);
+            }
+            50% {
+                transform: translateY(0) translateX(0vw);
+            }
+            75% {
+                transform: translateY(100vh) translateX(25vw);
+            }
+            100% {
+                transform: translateY(0) translateX(50vw);
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="title">pyPowerwall</div>
+        <div class="description">Python module to interface with Tesla Energy Gateways for Powerwall and Solar Power Data.</div>
+        <div class="timer" id="countdown">5</div>
+    </div>
+    
+    <div class="tiny-text">
+        (c) 2024 by Jason A. Cox - Open Source Project - <a href="https://github.com/jasonacox/pypowerwall" target="_blank">https://github.com/jasonacox/pypowerwall</a>
+    </div>
+
+    <!-- Animated shape(s) -->
+    <div class="shape"></div>
+
+    <script>
+        // Countdown timer
+        let countdownElement = document.getElementById("countdown");
+        let countdown = 5;
+
+        function updateCountdown() {
+            countdownElement.textContent = countdown;
+            countdown--;
+
+            if (countdown < 0) {
+                clearInterval(timerInterval);
+                countdownElement.textContent = "Redirecting...";
+            }
+        }
+
+        let timerInterval = setInterval(updateCountdown, 1000);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This PR fixes bug in pypowerwall related to API calls and 404 HTTP status codes handling.

Powerwall Firmware version 23.44.0 has eliminated /api/devices/vitals resulting in a 404 response from the Powerwall Gateway (TEG) when this is requested. There is a bug in the pypowerwall code that will treat this 404 like an authentication failure which will result in attempts to log in over and over, eventually hitting the rate limit. This is especially impactful for those using the proxy for things like Powerwall-Dashboard as the rate limit will prohibit other data gathering.

Related issue: https://github.com/jasonacox/pypowerwall/issues/57

Closes #65 