### PR TITLE
v0.7.7 - Battery Data and Network Scanner

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.7.7 - Battery Data
+
+* Proxy: Use /api/system_status battery blocks data to augment /pod and /freq macro data APIs.
+
 ## v0.7.6 - 404 Bug Fix
 
 * Fix Critical Bug - 404 HTTP Status Code Handling (Issue https://github.com/jasonacox/pypowerwall/issues/65).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,9 @@
 # RELEASE NOTES
 
-## v0.7.7 - Battery Data
+## v0.7.7 - Battery Data and Network Scanner
 
-* Proxy: Use /api/system_status battery blocks data to augment /pod and /freq macro data APIs.
+* Proxy: Use /api/system_status battery blocks data to augment /pod and /freq macro data APIs @jasonacox in https://github.com/jasonacox/pypowerwall/pull/67
+* Network Scanner: Improve network scan speed by scanning multiple hosts simultaneously by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/67
 
 ## v0.7.6 - 404 Bug Fix
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,8 +2,8 @@
 
 ## v0.7.7 - Battery Data and Network Scanner
 
-* Proxy: Use /api/system_status battery blocks data to augment /pod and /freq macro data APIs @jasonacox in https://github.com/jasonacox/pypowerwall/pull/67
-* Network Scanner: Improve network scan speed by scanning multiple hosts simultaneously by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/67
+* Proxy t40: Use /api/system_status battery blocks data to augment /pod and /freq macro data APIs by @jasonacox in https://github.com/jasonacox/pypowerwall/pull/67 thanks to @ceeeekay in https://github.com/jasonacox/Powerwall-Dashboard/discussions/402#discussioncomment-8193776
+* Network Scanner: Improve network scan speed by scanning multiple hosts simultaneously by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/67. The number of hosts to scan simultaneously can be adjusted using the optional `-hosts=` argument (default = 30, maximum = 100), e.g. `python -m pypowerwall scan -hosts=50`
 
 ## v0.7.6 - 404 Bug Fix
 
@@ -26,7 +26,7 @@ pw = pypowerwall.Powerwall(HOST, PASSWORD, EMAIL, TIMEZONE, authmode="token")
 ```
 
 Proxy
-* The above option is extended to the pyPowerwall Proxy via the envrionmental variable `PW_AUTH_MODE` set to cookie (default) or token.
+* The above option is extended to the pyPowerwall Proxy via the environmental variable `PW_AUTH_MODE` set to cookie (default) or token.
 
 Powerwall Network Scanner
 * Added optional IP address argument to network scanner by @mcbirse in https://github.com/jasonacox/pypowerwall/pull/63. The Scan Function can now accept an additional argument `-ip=` to override the host IP address detection (`python -m pypowerwall scan -ip=192.168.1.100`). This may be useful where the host IP address/network cannot be detected correctly, for instance if pypowerwall is running inside a container.
@@ -206,7 +206,7 @@ pw.grid_status()
 ## v0.2.0 - Tesla Protocol Buffer Scheme Update
 
 * PyPI 0.2.0
-* Breaking change to Protobuf schemea (PR #2) including:
+* Breaking change to Protobuf schema (PR #2) including:
 * Files `tesla.proto` and `tesla_pb2.py`
 * Impacted output from function `vitals()` and [examples/vitals.py](examples/vitals.py).
 
@@ -214,7 +214,7 @@ pw.grid_status()
 
 * PyPI 0.1.4
 * Changed "Network Scan" default timeout to 400ms for better detection.
-* Added Tesla App style "Battery Level Percentage" Conversion option to `level()` to convert the level reading to the 95% scale used by the App. Ths converts the battery level percentage to be consistent with the Tesla App:
+* Added Tesla App style "Battery Level Percentage" Conversion option to `level()` to convert the level reading to the 95% scale used by the App. This converts the battery level percentage to be consistent with the Tesla App:
 
 ```python
 >>> pw.level(scale=True)

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-alpine
 WORKDIR /app
-RUN pip3 install pypowerwall==0.7.6 bs4
+RUN pip3 install pypowerwall==0.7.7 bs4
 COPY . .
 CMD ["python3", "server.py"]
 EXPOSE 8675 

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,6 +1,10 @@
 ## pyPowerwall Proxy Release Notes
 
-### Proxy t39 (12 Jan 2023)
+### Proxy t40 (20 Jan 2024)
+
+* Use /api/system_status battery blocks data to augment /pod and /freq macro data APIs.
+
+### Proxy t39 (12 Jan 2024)
 
 * Fix Critical Bug - 404 HTTP Status Code Handling (Issue https://github.com/jasonacox/pypowerwall/issues/65).
 

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -265,7 +265,25 @@ class handler(BaseHTTPRequestHandler):
             # Frequency, Current, Voltage and Grid Status
             fcv = {}
             idx = 1
+            # Pull freq, current, voltage of each Powerwall via system_status
+            d = pw.system_status() or {}
+            if "battery_blocks" in d:
+                for block in d["battery_blocks"]:
+                    fcv["PW%d_name" % idx] = None # Placeholder for vitals
+                    fcv["PW%d_PINV_Fout" % idx] = get_value(block, "f_out")
+                    fcv["PW%d_PINV_VSplit1" % idx] = None # Placeholder for vitals
+                    fcv["PW%d_PINV_VSplit2" % idx] = None # Placeholder for vitals
+                    fcv["PW%d_PackagePartNumber" % idx] = get_value(block, "PackagePartNumber")
+                    fcv["PW%d_PackageSerialNumber" % idx] = get_value(block, "PackageSerialNumber")
+                    fcv["PW%d_p_out" % idx] = get_value(block, "p_out")
+                    fcv["PW%d_q_out" % idx] = get_value(block, "q_out")
+                    fcv["PW%d_v_out" % idx] = get_value(block, "v_out")
+                    fcv["PW%d_f_out" % idx] = get_value(block, "f_out")
+                    fcv["PW%d_i_out" % idx] = get_value(block, "i_out")
+                    idx = idx + 1
+            # Pull freq, current, voltage of each Powerwall via vitals if available
             vitals = pw.vitals() or {}
+            idx = 1
             for device in vitals:
                 d = vitals[device]
                 if  device.startswith('TEPINV'):
@@ -283,10 +301,52 @@ class handler(BaseHTTPRequestHandler):
             fcv["grid_status"] = pw.grid_status(type="numeric")
             message = json.dumps(fcv)
         elif self.path == '/pod':
-            # Battery Data
+            # Powerwall Battery Data
             pod = {}
-            idx = 1
+            # Get Individual Powerwall Battery Data
+            d = pw.system_status() or {}
+            if "battery_blocks" in d:
+                idx = 1
+                for block in d["battery_blocks"]:
+                    # Vital Placeholders
+                    pod["PW%d_name" % idx] = None
+                    pod["PW%d_POD_ActiveHeating" % idx] = None
+                    pod["PW%d_POD_ChargeComplete" % idx] = None
+                    pod["PW%d_POD_ChargeRequest" % idx] = None
+                    pod["PW%d_POD_DischargeComplete" % idx] = None
+                    pod["PW%d_POD_PermanentlyFaulted" % idx] = None
+                    pod["PW%d_POD_PersistentlyFaulted" % idx] = None
+                    pod["PW%d_POD_enable_line" % idx] = None
+                    pod["PW%d_POD_available_charge_power" % idx] = None
+                    pod["PW%d_POD_available_dischg_power" % idx] = None
+                    pod["PW%d_POD_nom_energy_remaining" % idx] = None
+                    pod["PW%d_POD_nom_energy_to_be_charged" % idx] = None
+                    pod["PW%d_POD_nom_full_pack_energy" % idx] = None
+                    # Additional System Status Data
+                    pod["PW%d_POD_nom_energy_remaining" % idx] = get_value(block, "nominal_energy_remaining") # map
+                    pod["PW%d_POD_nom_full_pack_energy" % idx] = get_value(block, "nominal_full_pack_energy") # map
+                    pod["PW%d_PackagePartNumber" % idx] = get_value(block, "PackagePartNumber")
+                    pod["PW%d_PackageSerialNumber" % idx] = get_value(block, "PackageSerialNumber")
+                    pod["PW%d_pinv_state" % idx] = get_value(block, "pinv_state")
+                    pod["PW%d_pinv_grid_state" % idx] = get_value(block, "pinv_grid_state")
+                    pod["PW%d_p_out" % idx] = get_value(block, "p_out")
+                    pod["PW%d_q_out" % idx] = get_value(block, "q_out")
+                    pod["PW%d_v_out" % idx] = get_value(block, "v_out")
+                    pod["PW%d_f_out" % idx] = get_value(block, "f_out")
+                    pod["PW%d_i_out" % idx] = get_value(block, "i_out")
+                    pod["PW%d_energy_charged" % idx] = get_value(block, "energy_charged")
+                    pod["PW%d_energy_discharged" % idx] = get_value(block, "energy_discharged")
+                    pod["PW%d_off_grid" % idx] = int(get_value(block, "off_grid"))
+                    pod["PW%d_vf_mode" % idx] = int(get_value(block, "vf_mode"))
+                    pod["PW%d_wobble_detected" % idx] = int(get_value(block, "wobble_detected"))
+                    pod["PW%d_charge_power_clamped" % idx] = int(get_value(block, "charge_power_clamped"))
+                    pod["PW%d_backup_ready" % idx] = int(get_value(block, "backup_ready"))
+                    pod["PW%d_OpSeqState" % idx] = get_value(block, "OpSeqState")
+                    pod["PW%d_version" % idx] = get_value(block, "version")
+                    idx = idx + 1
+            # Augment with Vitals Data if available
             vitals = pw.vitals() or {}
+            idx = 1
             for device in vitals:
                 d = vitals[device]
                 if  device.startswith('TEPOD'):
@@ -304,8 +364,8 @@ class handler(BaseHTTPRequestHandler):
                     pod["PW%d_POD_nom_energy_to_be_charged" % idx] = get_value(d, 'POD_nom_energy_to_be_charged')
                     pod["PW%d_POD_nom_full_pack_energy" % idx] = get_value(d, 'POD_nom_full_pack_energy')
                     idx = idx + 1
+            # Aggregate data
             pod["backup_reserve_percent"] = pw.get_reserve()
-            d = pw.system_status() or {}
             pod["nominal_full_pack_energy"] = get_value(d,'nominal_full_pack_energy')
             pod["nominal_energy_remaining"] = get_value(d,'nominal_energy_remaining')            
             pod["time_remaining_hours"] = pw.get_time_remaining()

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -348,21 +348,21 @@ class handler(BaseHTTPRequestHandler):
             vitals = pw.vitals() or {}
             idx = 1
             for device in vitals:
-                d = vitals[device]
+                v = vitals[device]
                 if  device.startswith('TEPOD'):
                     pod["PW%d_name" % idx] = device
-                    pod["PW%d_POD_ActiveHeating" % idx] = int(get_value(d, 'POD_ActiveHeating'))
-                    pod["PW%d_POD_ChargeComplete" % idx] = int(get_value(d, 'POD_ChargeComplete'))
-                    pod["PW%d_POD_ChargeRequest" % idx] = int(get_value(d, 'POD_ChargeRequest'))
-                    pod["PW%d_POD_DischargeComplete" % idx] = int(get_value(d, 'POD_DischargeComplete'))
-                    pod["PW%d_POD_PermanentlyFaulted" % idx] = int(get_value(d, 'POD_PermanentlyFaulted'))
-                    pod["PW%d_POD_PersistentlyFaulted" % idx] = int(get_value(d, 'POD_PersistentlyFaulted'))
-                    pod["PW%d_POD_enable_line" % idx] = int(get_value(d,'POD_enable_line'))
-                    pod["PW%d_POD_available_charge_power" % idx] = get_value(d,'POD_available_charge_power')
-                    pod["PW%d_POD_available_dischg_power" % idx] = get_value(d, 'POD_available_dischg_power')
-                    pod["PW%d_POD_nom_energy_remaining" % idx] = get_value(d, 'POD_nom_energy_remaining')
-                    pod["PW%d_POD_nom_energy_to_be_charged" % idx] = get_value(d, 'POD_nom_energy_to_be_charged')
-                    pod["PW%d_POD_nom_full_pack_energy" % idx] = get_value(d, 'POD_nom_full_pack_energy')
+                    pod["PW%d_POD_ActiveHeating" % idx] = int(get_value(v, 'POD_ActiveHeating'))
+                    pod["PW%d_POD_ChargeComplete" % idx] = int(get_value(v, 'POD_ChargeComplete'))
+                    pod["PW%d_POD_ChargeRequest" % idx] = int(get_value(v, 'POD_ChargeRequest'))
+                    pod["PW%d_POD_DischargeComplete" % idx] = int(get_value(v, 'POD_DischargeComplete'))
+                    pod["PW%d_POD_PermanentlyFaulted" % idx] = int(get_value(v, 'POD_PermanentlyFaulted'))
+                    pod["PW%d_POD_PersistentlyFaulted" % idx] = int(get_value(v, 'POD_PersistentlyFaulted'))
+                    pod["PW%d_POD_enable_line" % idx] = int(get_value(v,'POD_enable_line'))
+                    pod["PW%d_POD_available_charge_power" % idx] = get_value(v,'POD_available_charge_power')
+                    pod["PW%d_POD_available_dischg_power" % idx] = get_value(v, 'POD_available_dischg_power')
+                    pod["PW%d_POD_nom_energy_remaining" % idx] = get_value(v, 'POD_nom_energy_remaining')
+                    pod["PW%d_POD_nom_energy_to_be_charged" % idx] = get_value(v, 'POD_nom_energy_to_be_charged')
+                    pod["PW%d_POD_nom_full_pack_energy" % idx] = get_value(v, 'POD_nom_full_pack_energy')
                     idx = idx + 1
             # Aggregate data
             pod["backup_reserve_percent"] = pw.get_reserve()

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -42,7 +42,7 @@ import signal
 import ssl
 from transform import get_static, inject_js
 
-BUILD = "t39"
+BUILD = "t40"
 ALLOWLIST = [
     '/api/status', '/api/site_info/site_name', '/api/meters/site',
     '/api/meters/solar', '/api/sitemaster', '/api/powerwalls', 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -74,7 +74,7 @@ import sys
 from . import tesla_pb2           # Protobuf definition for vitals
 from . import cloud               # Tesla Cloud API
 
-version_tuple = (0, 7, 6)
+version_tuple = (0, 7, 7)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -22,7 +22,7 @@ from . import cloud
 AUTHFILE = ".pypowerwall.auth"
 authpath = os.getenv("PW_AUTH_PATH", "")
 timeout = 1.0
-hosts = 32
+hosts = 30
 state = 0
 color = True
 ip = None
@@ -43,7 +43,7 @@ for i in sys.argv:
         try:
             hosts = int(i[7:])
         except:
-            hosts = 32
+            hosts = 30
     elif(i.lower()[0:7] == "-email="):
         email = i[7:]
     else:
@@ -78,7 +78,7 @@ if(state == 2):
     print("      timeout               (Scan option) Seconds to wait per host [Default=%0.1f]" % (timeout))
     print("      -nocolor              (Scan option) Disable color text output.")
     print("      -ip=<ip>              (Scan option) IP address within network to scan.")
-    print("      -hosts=<hosts>        (Scan option) Max no. of hosts to scan simultaneously [Default=%d]" % (hosts))
+    print("      -hosts=<hosts>        (Scan option) Number of hosts to scan simultaneously [Default=%d]" % (hosts))
     print("      -email=<email>        (Setup option) Email address for Tesla Login.")
     print("      -h                    Show usage.")
     print("")

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -43,7 +43,7 @@ for i in sys.argv:
         try:
             hosts = int(i[7:])
         except:
-            hosts = 30
+            state = 2
     elif(i.lower()[0:7] == "-email="):
         email = i[7:]
     else:

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -22,6 +22,7 @@ from . import cloud
 AUTHFILE = ".pypowerwall.auth"
 authpath = os.getenv("PW_AUTH_PATH", "")
 timeout = 1.0
+hosts = 32
 state = 0
 color = True
 ip = None
@@ -38,6 +39,11 @@ for i in sys.argv:
         color = False
     elif(i.lower()[0:4] == "-ip="):
         ip = i[4:]
+    elif(i.lower()[0:7] == "-hosts="):
+        try:
+            hosts = int(i[7:])
+        except:
+            hosts = 32
     elif(i.lower()[0:7] == "-email="):
         email = i[7:]
     else:
@@ -48,7 +54,7 @@ for i in sys.argv:
 
 # State 0 = Run Scan
 if(state == 0):
-    scan.scan(color, timeout, ip)
+    scan.scan(color, timeout, hosts, ip)
 
 # State 1 = Cloud Mode Setup
 if(state == 1):
@@ -65,13 +71,14 @@ if(state == 1):
 if(state == 2):
     print("pyPowerwall [%s]\n" % (pypowerwall.version))
     print("Usage:\n")
-    print("    python -m pypowerwall [command] [<timeout>] [-nocolor] [-ip=<ip>] [-email=<email>] [-h]")
+    print("    python -m pypowerwall [command] [<timeout>] [-nocolor] [-ip=<ip>] [-hosts=<hosts>] [-email=<email>] [-h]")
     print("")
     print("      command = scan        Scan local network for Powerwall gateway.")
     print("      command = setup       Setup Tesla Login for Cloud Mode access.")
     print("      timeout               (Scan option) Seconds to wait per host [Default=%0.1f]" % (timeout))
     print("      -nocolor              (Scan option) Disable color text output.")
     print("      -ip=<ip>              (Scan option) IP address within network to scan.")
+    print("      -hosts=<hosts>        (Scan option) Max no. of hosts to scan simultaneously [Default=%d]" % (hosts))
     print("      -email=<email>        (Setup option) Email address for Tesla Login.")
     print("      -h                    Show usage.")
     print("")

--- a/pypowerwall/scan.py
+++ b/pypowerwall/scan.py
@@ -21,6 +21,7 @@ import ipaddress
 import requests
 import threading
 import json
+import time
 
 # Backward compatability for python2
 try:
@@ -61,7 +62,11 @@ def scanIP(color, timeout, addr):
     a_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     a_socket.settimeout(timeout)
     location = (str(addr), 443)
-    result_of_check = a_socket.connect_ex(location)
+    while True:
+        result_of_check = a_socket.connect_ex(location)
+        if not result_of_check == socket.errno.EAGAIN:
+            break
+        time.sleep(0.1)
     if result_of_check == 0:
         # Check to see if it is a Powerwall
         url = 'https://%s/api/status' % addr


### PR DESCRIPTION
## Proxy v0.7.7 t40 - Battery Vitals Update

* Proxy: Use /api/system_status battery blocks data to augment /pod and /freq macro data APIs. 

This update will help address some of the data lost with the removal of the `vitals` data starting with Firmware 23.44.0 as raised in https://github.com/jasonacox/Powerwall-Dashboard/discussions/402. 

## pyPowerwall v0.7.7 - Network Scanner Update

* Network Scanner: Improve network scan speed by scanning multiple hosts simultaneously. The number of hosts to scan simultaneously can be adjusted using the optional `-hosts=` argument (default = 30, maximum = 100), e.g. `python -m pypowerwall scan -hosts=50`