### PR TITLE
ignore sites that are not complete set up

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.7.8 - Cloud Setup Fix
+
+* Fix enumeration of energy sites during `cloud mode` setup to handle incomplete sites with Unknown names or types by @dcgibbons inhttps://github.com/jasonacox/pypowerwall/pull/72 
+
 ## v0.7.7 - Battery Data and Network Scanner
 
 * Proxy t40: Use /api/system_status battery blocks data to augment /pod and /freq macro data APIs by @jasonacox in https://github.com/jasonacox/pypowerwall/pull/67 thanks to @ceeeekay in https://github.com/jasonacox/Powerwall-Dashboard/discussions/402#discussioncomment-8193776

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## v0.7.8 - Cloud Setup Fix
 
-* Fix enumeration of energy sites during `cloud mode` setup to handle incomplete sites with Unknown names or types by @dcgibbons inhttps://github.com/jasonacox/pypowerwall/pull/72 
+* Fix enumeration of energy sites during `cloud mode` setup to handle incomplete sites with Unknown names or types by @dcgibbons in https://github.com/jasonacox/pypowerwall/pull/72 
 
 ## v0.7.7 - Battery Data and Network Scanner
 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -74,7 +74,7 @@ import sys
 from . import tesla_pb2           # Protobuf definition for vitals
 from . import cloud               # Tesla Cloud API
 
-version_tuple = (0, 7, 7)
+version_tuple = (0, 7, 8)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/cloud.py
+++ b/pypowerwall/cloud.py
@@ -906,8 +906,11 @@ class TeslaCloud:
             else:
                 sitelabel = " "
             siteids.append(s["energy_site_id"])
-            print(" %s%d - %s (%s) - Type: %s" % (sitelabel, idx, s["site_name"], 
+            try:
+                print(" %s%d - %s (%s) - Type: %s" % (sitelabel, idx, s["site_name"],
                     s["energy_site_id"], s["resource_type"]))
+            except KeyError:
+                pass
             idx += 1
         # Ask user to select a site
         while True:

--- a/pypowerwall/cloud.py
+++ b/pypowerwall/cloud.py
@@ -906,11 +906,12 @@ class TeslaCloud:
             else:
                 sitelabel = " "
             siteids.append(s["energy_site_id"])
-            try:
+            if "site_name" in s and "resource_type" in s:
                 print(" %s%d - %s (%s) - Type: %s" % (sitelabel, idx, s["site_name"],
                     s["energy_site_id"], s["resource_type"]))
-            except KeyError:
-                pass
+            else:
+                print(" %s%d - %s (%s) - Type: %s" % (sitelabel, idx, "Unknown",
+                    s["energy_site_id"], "Unknown"))
             idx += 1
         # Ask user to select a site
         while True:


### PR DESCRIPTION
While Tesla is trying to figure out how to properly set up my two-gateway and three-powerwall system, they created a blank Site on my account with no devices attach. In this scenario pypowerwall will crash trying to display information about sites during the site selection menu creation.

This patch just skips those if that fails. I suspect you might want another way of fixing it, but sharing this for discussion. It does work in the case I'm seeing right now (I have 2 sites at the moment, including this bogus one).

Photo of Tesla app for context attached.

![IMG_6870](https://github.com/jasonacox/pypowerwall/assets/250931/ee59a90e-acb9-4d43-8784-a26feb5cb1ac)
