### PR TITLE
Allow customization of the cachefile location and name

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,28 @@
 # RELEASE NOTES
 
+## v0.7.12 - Cachefile Option
+
+* Allow customization of the cachefile location and name by @emptywee in #74 via `cachefile` parameter.
+
+```python
+# Example
+import pypowerwall
+pw = pypowerwall.Powerwall(
+     host="10.1.2.30",
+     password="secret",
+     email="me@example.com",
+     timezone="America/Los_Angeles",
+     pwcacheexpire=5, 
+     timeout=5, 
+     poolmaxsize=10,
+     cloudmode=False, 
+     siteid=None, 
+     authpath="", 
+     authmode="cookie",
+     cachefile=".powerwall",
+     )
+```
+
 ## v0.7.11 - Cooldown Mode
 
 * Updated logic to disable vitals API calls for Firmware 23.44.0+

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -103,7 +103,7 @@ class ConnectionError(Exception):
 class Powerwall(object):
     def __init__(self, host="", password="", email="nobody@nowhere.com", 
                  timezone="America/Los_Angeles", pwcacheexpire=5, timeout=5, poolmaxsize=10, 
-                 cloudmode=False, siteid=None, authpath="", authmode="cookie"):
+                 cloudmode=False, siteid=None, authpath="", authmode="cookie", cachefile=".powerwall"):
         """
         Represents a Tesla Energy Gateway Powerwall device.
 
@@ -120,11 +120,11 @@ class Powerwall(object):
             siteid       = If cloudmode is True, use this siteid (default is None)  
             authpath     = Path to cloud auth and site cache files (default current directory)
             authmode     = "cookie" (default) or "token" - use cookie or bearer token for authorization
-
+            cachefile    = Path to cache file (default current directory)
         """
 
         # Attributes
-        self.cachefile = ".powerwall"  # Stores auth session information
+        self.cachefile = cachefile  # Stores auth session information
         self.host = host
         self.password = password
         self.email = email

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -32,7 +32,8 @@
     siteid = None             # If cloudmode is True, use this siteid (default is None)
     authpath = ""             # Path to cloud auth and site files (default current directory)
     authmode = "cookie"       # "cookie" (default) or "token" - use cookie or bearer token for auth
-
+    cachefile = ".powerwall"  # Path to cache file (default current directory)
+    
  Functions 
     poll(api, json, force)    # Return data from Powerwall api (dict if json=True, bypass cache force=True)
     level()                   # Return battery power level percentage
@@ -74,7 +75,7 @@ import sys
 from . import tesla_pb2           # Protobuf definition for vitals
 from . import cloud               # Tesla Cloud API
 
-version_tuple = (0, 7, 11)
+version_tuple = (0, 7, 12)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 


### PR DESCRIPTION
Hi,

I am using your library in my home stackstorm-based automation actions/workflows and needed to move the cache file outside the "current directory" of the action runners for safety and security. Had to extend your class and override the init, but then I thought to try to get this little change to upstream, so here it is. Hope you will accept this PR. Thanks!