### PR TITLE
Adding alternate alerts when vitals not present

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,29 @@
 # RELEASE NOTES
 
+## v0.7.12 - Cachefile and Alerts
+
+* Added alerts from `/api/solar_powerwall` when vitals not present by @DerickJohnson in #75. The vitals API is not present in firmware versions > 23.44, this provides a workaround to get alerts.
+* Allow customization of the cachefile location and name by @emptywee in #74 via `cachefile` parameter.
+
+```python
+# Example
+import pypowerwall
+pw = pypowerwall.Powerwall(
+     host="10.1.2.30",
+     password="secret",
+     email="me@example.com",
+     timezone="America/Los_Angeles",
+     pwcacheexpire=5, 
+     timeout=5, 
+     poolmaxsize=10,
+     cloudmode=False, 
+     siteid=None, 
+     authpath="", 
+     authmode="cookie",
+     cachefile=".powerwall",
+     )
+```
+
 ## v0.7.11 - Cooldown Mode
 
 * Updated logic to disable vitals API calls for Firmware 23.44.0+

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -695,11 +695,13 @@ class Powerwall(object):
                             item[device] = i
                             alerts.append(item)
         elif not devices and alertsonly is True:
-            data = self.poll('/api/solar_powerwall', jsonformat=True)
-            for alert, value in data['pvac_alerts'].items():
+            data = self.poll('/api/solar_powerwall', jsonformat=True) or {}
+            pvac_alerts = data.get('pvac_alerts') or {}
+            for alert, value in pvac_alerts.items():
                 if value is True:
                     alerts.append(alert)
-            for alert, value in data['pvs_alerts'].items():
+            pvs_alerts = data.get('pvs_alerts') or {}
+            for alert, value in pvs_alerts.items():
                 if value is True:
                     alerts.append(alert)
 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -683,15 +683,26 @@ class Powerwall(object):
         """
         alerts = []
         devices = self.vitals() or {}
-        for device in devices:
-            if 'alerts' in devices[device]:
-                for i in devices[device]['alerts']:
-                    if(alertsonly):
-                        alerts.append(i)
-                    else:
-                        item = {}
-                        item[device] = i
-                        alerts.append(item)
+
+        if devices:
+            for device in devices:
+                if 'alerts' in devices[device]:
+                    for i in devices[device]['alerts']:
+                        if(alertsonly):
+                            alerts.append(i)
+                        else:
+                            item = {}
+                            item[device] = i
+                            alerts.append(item)
+        elif not devices and alertsonly is True:
+            data = self.poll('/api/solar_powerwall', jsonformat=True)
+            for alert, value in data['pvac_alerts'].items():
+                if value is True:
+                    alerts.append(alert)
+            for alert, value in data['pvs_alerts'].items():
+                if value is True:
+                    alerts.append(alert)
+
         if (jsonformat):
             json_out = json.dumps(alerts, indent=4, sort_keys=True)
             return json_out

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -74,7 +74,7 @@ import sys
 from . import tesla_pb2           # Protobuf definition for vitals
 from . import cloud               # Tesla Cloud API
 
-version_tuple = (0, 7, 11)
+version_tuple = (0, 7, 12)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -684,6 +684,11 @@ class Powerwall(object):
         alerts = []
         devices = self.vitals() or {}
 
+        """
+        The vitals API is not present in firmware versions > 23.44, this 
+        is a workaround to get alerts from the /api/solar_powerwall endpoint
+        for newer firmware versions
+        """
         if devices:
             for device in devices:
                 if 'alerts' in devices[device]:


### PR DESCRIPTION
This will utilize the /api/solar_powerwall endpoint to populate the alerts array if devices (through vitals) are not present. Let me know if you want it simplified to not include the outer 'if'. I included it for clarity, to show the distinct paths, but it can also be simplified if needed (since it won't loop through devices that aren't present).

I also only used the fallback if alertsonly was true, since we don't have device specific information in that setup.

This should be automatically picked up by the alerts/pw endpoint since the format is the same.

I tested it locally using the /alerts endpoint, but might be good to validate that it still uses vitals if they are present (it should). I am on the later firmware where it's no longer present (23.44). 

Let me know if you'd like anything changed!