### PR TITLE
Use solar_powerwall for string data

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,9 @@
 # RELEASE NOTES
 
-## v0.7.13 - Strings
+## v0.7.12 - Cachefile and Vitals
 
-* Added logic to pull string data from `/api/solar_powerwall` API if vitals data is not available.
-
-## v0.7.12 - Cachefile Option
-
+* Added logic to pull string data from `/api/solar_powerwall` API if vitals data is not available by @jasonacox in #76.
+* Added alerts from `/api/solar_powerwall` when vitals not present by @DerickJohnson in #75. The vitals API is not present in firmware versions > 23.44, this provides a workaround to get alerts.
 * Allow customization of the cachefile location and name by @emptywee in #74 via `cachefile` parameter.
 
 ```python

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.7.13 - Strings
+
+* Added logic to pull string data from `/api/solar_powerwall` API if vitals data is not available.
+
 ## v0.7.12 - Cachefile Option
 
 * Allow customization of the cachefile location and name by @emptywee in #74 via `cachefile` parameter.

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -555,19 +555,19 @@ class Powerwall(object):
                 # else
         # If no devices found pull from /api/solar_powerwall
         if not v:
-            # Build a device map
-            devmap = []
+            # Build a string map: A, B, C, D, A1, B2, etc.
+            string_map = []
             for number in ['','1','2','3','4','5','6','7','8']:
                 for letter in ['A','B','C','D']:
-                    devmap.append(letter + number)
-            payload = self.poll('/api/solar_powerwall', jsonformat=True)
-            if payload is not None and 'pvac_status' in payload:
+                    string_map.append(letter + number)
+            payload = self.poll('/api/solar_powerwall', jsonformat=True) or {}
+            if payload and 'pvac_status' in payload:
                 # Strings are in PVAC status section
                 pvac = payload['pvac_status']
                 if 'string_vitals' in pvac:
                     i = 0
                     for string in pvac['string_vitals']:
-                        name = devmap[i]
+                        name = string_map[i]
                         result[name] = {}
                         result[name]['Connected'] = string['connected']
                         result[name]['Voltage'] = string['measured_voltage']

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -553,6 +553,28 @@ class Powerwall(object):
                     # for   
                     deviceidx += 1
                 # else
+        # If no devices found pull from /api/solar_powerwall
+        if not v:
+            # Build a device map
+            devmap = []
+            for number in ['','1','2','3','4','5','6','7','8']:
+                for letter in ['A','B','C','D']:
+                    devmap.append(letter + number)
+            payload = self.poll('/api/solar_powerwall', jsonformat=True)
+            if payload is not None and 'pvac_status' in payload:
+                # Strings are in PVAC status section
+                pvac = payload['pvac_status']
+                if 'string_vitals' in pvac:
+                    i = 0
+                    for string in pvac['string_vitals']:
+                        name = devmap[i]
+                        result[name] = {}
+                        result[name]['Connected'] = string['connected']
+                        result[name]['Voltage'] = string['measured_voltage']
+                        result[name]['Current'] = string['current']
+                        result[name]['Power'] = string['measured_power']
+                        i += 1
+        # Return result
         if (jsonformat):
             json_out = json.dumps(result, indent=4, sort_keys=True)
             return json_out

--- a/pypowerwall/cloud.py
+++ b/pypowerwall/cloud.py
@@ -808,6 +808,9 @@ class TeslaCloud:
         elif api == '/api/troubleshooting/problems':
             data = json.loads('{"problems":[]}')
 
+        elif api == '/api/solar_powerwall':
+            data = json.loads('{}')
+
         else:
             data = {"ERROR": f"Unknown API: {api}"}
 


### PR DESCRIPTION
Adds logic to pull string data from `/api/solar_powerwall` API if vitals data is not available.

This applies to Firmware > 23.44 and owners of Powerwall+ systems (integrated inverters). The API seems to only return the string attached tot he first Powerwall+ system. This will be changed out if we discover a way to get all strings.