### PR TITLE
Handle 503 Errors and Disabled Powerwall APIs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # RELEASE NOTES
 
+## v0.8.2 - 503 Error Handling
+
+* Added 5 minute cooldown for HTTP 503 Service Unavailable errors from API calls.
+* Proxy: Added DISABLED API handling logic.
+
 ## v0.8.1 - Set battery reserve, operation mode
 
 * Added `get_mode()`, `set_mode()`,`set_reserve()`,and `set_operation()` function to set battery operation mode and/or reserve level by @emptywee in https://github.com/jasonacox/pypowerwall/pull/78. Likely won't work in the local mode.

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,13 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t53 (11 Apr 2024)
+
+* Add DISABLED API handling logic.
+
+### Proxy t52 (5 Apr 2024)
+
+*  Update to pyPowerwall proxy v0.8.1
+
 ### Proxy t51 (18 Mar 2024)
 
 * Update to pypowerwall 0.8.0

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -46,7 +46,7 @@ import pypowerwall
 from pypowerwall import parse_version
 from transform import get_static, inject_js
 
-BUILD = "t52"
+BUILD = "t53"
 ALLOWLIST = [
     '/api/status', '/api/site_info/site_name', '/api/meters/site',
     '/api/meters/solar', '/api/sitemaster', '/api/powerwalls',
@@ -56,6 +56,9 @@ ALLOWLIST = [
     '/api/customer', '/api/meters', '/api/installer', '/api/networks',
     '/api/system/networks', '/api/meters/readings', '/api/synchrometer/ct_voltage_references',
     '/api/troubleshooting/problems', '/api/auth/toggle/supported', '/api/solar_powerwall',
+]
+DISABLED = [
+    '/api/customer/registration',
 ]
 web_root = os.path.join(os.path.dirname(__file__), "web")
 
@@ -435,6 +438,9 @@ class Handler(BaseHTTPRequestHandler):
             # Simulate old API call and respond with empty list
             message = '{"problems": []}'
             # message = pw.poll('/api/troubleshooting/problems') or '{"problems": []}'
+        elif self.path in DISABLED:
+            # Disabled API Calls
+            message = '{"status": "404 Response - API Disabled"}'
         elif self.path in ALLOWLIST:
             # Allowed API Calls - Proxy to Powerwall
             message: str = pw.poll(self.path, jsonformat=True)

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -90,7 +90,7 @@ from pypowerwall.pypowerwall_base import parse_version, PyPowerwallBase
 
 urllib3.disable_warnings()  # Disable SSL warnings
 
-version_tuple = (0, 8, 1)
+version_tuple = (0, 8, 2)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/local/pypowerwall_local.py
+++ b/pypowerwall/local/pypowerwall_local.py
@@ -193,6 +193,11 @@ class PyPowerwallLocal(PyPowerwallBase):
             elif 400 <= r.status_code < 500:
                 log.error('Unhandled HTTP response code %s at %s' % (r.status_code, url))
                 return None
+            elif r.status_code == 503:
+                log.error('503 Service Unavailable at %s - Activating 5 minute API cooldown' % url)
+                self.pwcachetime[api] = time.perf_counter() + 300
+                self.pwcache[api] = None
+                return None
             elif r.status_code >= 500:
                 log.error('Server-side problem at Powerwall API (status code %s) at %s' % (r.status_code, url))
                 return None


### PR DESCRIPTION
* This adds a 5m cooldown for 503 Service Unavailable errors from APIs - As seen with `/api/solar_powerwall` in https://github.com/jasonacox/Powerwall-Dashboard/pull/462 
* Proxy: Adds list of API that have been removed and ignores them (currnetly only `/api/customer/registration`) as reported  in https://github.com/jasonacox/Powerwall-Dashboard/pull/462 