### PR TITLE
V0.8.3 - Control APIs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.8.3 - Error Handling
+
+* Added additional error handling logic to clean up exceptions.
+
 ## v0.8.2 - 503 Error Handling
 
 * Added 5 minute cooldown for HTTP 503 Service Unavailable errors from API calls.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 ## v0.8.3 - Error Handling
 
 * Added additional error handling logic to clean up exceptions.
+* Proxy: Added command APIs for setting backup reserve and operating mode.
 
 ## v0.8.2 - 503 Error Handling
 

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -192,7 +192,7 @@ docker run \
     -e PW_HOST='IP_of_Powerwall_Gateway' \
     -e PW_TIMEZONE='America/Los_Angeles' \
     -e TZ='America/Los_Angeles' \
-    -e PW_CONTROL_SECRET='YourSecretToken` \
+    -e PW_CONTROL_SECRET='YourSecretToken' \
     --name pypowerwall \
     --restart unless-stopped \
     jasonacox/pypowerwall

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -211,14 +211,14 @@ Examples
 
 ```bash
 # Set Mode
-curl http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET&value=self_consumption
+curl "http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET&value=self_consumption"
 
 # Set Reserve
-curl http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET&value=20
+curl "http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET&value=20"
 
 # Omit Value to Read Settings
-curl http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET
-curl http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET
+curl "http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET"
+curl "http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET"
 ```
 
 ## Release Notes

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -5,7 +5,7 @@
 * Fix `/pod` API to add `time_remaining_hours` and `backup_reserve_percent` for cloud mode.
 * Added GET command APIs to set backup reserve and operating mode settings. Requires setting `PW_CONTROL_SECRET`. Use with caution.
 
-```
+```bash
 # Set Mode
 curl http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET&value=self_consumption
 

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,22 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t54 (13 Apr 2024)
+
+* Fix `/pod` API to add `time_remaining_hours` and `backup_reserve_percent` for cloud mode.
+* Added GET command APIs to set backup reserve and operating mode settings. Requires setting `PW_CONTROL_SECRET`. Use with caution.
+
+```
+# Set Mode
+curl http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET&value=self_consumption
+
+# Set Reserve
+curl http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET&value=20
+
+# Omit Value to Read Settings
+curl http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET
+curl http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET
+```
+
 ### Proxy t53 (11 Apr 2024)
 
 * Add DISABLED API handling logic.

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,2 +1,2 @@
-pypowerwall==0.8.2
+pypowerwall==0.8.3
 bs4==0.0.2

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -28,6 +28,13 @@
     /strings data.
     Set: PW_EMAIL and leave PW_HOST blank to use this mode.
 
+ Control Mode
+    An optional mode is to enable control commands to set backup reserve
+    percentage and mode of the Powerwall.  This requires that you set
+    and use the PW_CONTROL_SECRET environmental variable.  This mode
+    is disabled by default and should be used with caution.
+    Set: PW_CONTROL_SECRET to enable this mode.
+
 """
 import datetime
 import json

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -489,6 +489,7 @@ class Handler(BaseHTTPRequestHandler):
                                 else:
                                     if value.isdigit():
                                         message = json.dumps(pw_control.set_reserve(int(value)))
+                                        log.info(f"Control Command: Set Reserve to {value}")
                                     else:
                                         message = '{"error": "Control Command Value Invalid"}'
                             elif action == 'mode':
@@ -498,6 +499,7 @@ class Handler(BaseHTTPRequestHandler):
                                 else:
                                     if value in ['self_consumption', 'backup', 'autonomous']:
                                         message = json.dumps(pw_control.set_mode(value))
+                                        log.info(f"Control Command: Set Mode to {value}")
                                     else:
                                         message = '{"error": "Control Command Value Invalid"}'
                             else:

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -602,6 +602,10 @@ class Powerwall(object):
 
         payload: dict = self.poll('/api/system_status/grid_status')
 
+        if payload is None:
+            log.error(f"Failed to get /api/system_status/grid_status")
+            return None
+
         if type == "json":
             return json.dumps(payload, indent=4, sort_keys=True)
 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -90,7 +90,7 @@ from pypowerwall.pypowerwall_base import parse_version, PyPowerwallBase
 
 urllib3.disable_warnings()  # Disable SSL warnings
 
-version_tuple = (0, 8, 2)
+version_tuple = (0, 8, 3)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 
@@ -613,7 +613,7 @@ class Powerwall(object):
                    'SystemMicroGridFaulted': {'string': 'DOWN', 'numeric': 0},
                    'SystemWaitForUser': {'string': 'DOWN', 'numeric': 0}}
 
-        grid_status = payload['grid_status']
+        grid_status = payload.get('grid_status')
         status = gridmap.get(grid_status, {}).get(type)
         if status is None:
             log.debug(f"ERROR unable to parse payload '{payload}' for grid_status of type: {type}")


### PR DESCRIPTION
* Added additional error handling logic to clean up exceptions #81
* Proxy: Fix `/pod` API to add `time_remaining_hours` and `backup_reserve_percent` for cloud mode.
* Added control APIs to set backup reserve and operating mode settings. Requires setting `PW_CONTROL_SECRET`. Use with caution! Closes #79

```bash
# Set Mode
curl http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET&value=self_consumption

# Set Reserve
curl http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET&value=20

# Omit Value to Read Settings
curl http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET
curl http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET
```