### PR TITLE
v0.8.4

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.8.4 - Set Reserve
+
+* Updated `set_reserve(level)` logic to handle levels from 0 to 100. Identified by @spoonwzd in #85
+
 ## v0.8.3 - Error Handling
 
 * Added additional error handling logic to clean up exceptions.

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -204,21 +204,27 @@ docker restart pypowerwall
 
 APIs
 
-* Set Mode: `/control/mode?token=$PW_CONTROL_SECRET&value=self_consumption` 
-* Set Reserve: `/control/reserve?token=$PW_CONTROL_SECRET&value=20`
+* Use `GET` method to read and `POST` to set.
+* Mode: `/control/mode` value=$MODE token=$PW_CONTROL_SECRET
+* Reserve: `/control/reserve` value=$RESERVE token=$PW_CONTROL_SECRET
 
 Examples
 
 ```bash
+export MODE=self_consumption
+export RESERVE=20
+export PW_CONTROL_SECRET=mySecretKey
+
 # Set Mode
-curl "http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET&value=self_consumption"
+curl -X POST -d "value=$MODE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/mode
 
 # Set Reserve
-curl "http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET&value=20"
+curl -X POST -d "value=$RESERVE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/reserve
 
-# Omit Value to Read Settings
-curl "http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET"
-curl "http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET"
+# Read Settings
+curl http://localhost:8675/control/mode
+curl http://localhost:8675/control/reserve
+```
 ```
 
 ## Release Notes

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,20 +1,26 @@
 ## pyPowerwall Proxy Release Notes
 
-### Proxy t54 (13 Apr 2024)
+### Proxy t55 (4 May 2024)
 
 * Fix `/pod` API to add `time_remaining_hours` and `backup_reserve_percent` for cloud mode.
-* Added GET command APIs to set backup reserve and operating mode settings. Requires setting `PW_CONTROL_SECRET`. Use with caution.
+* Replaced t54 - Move control to POST see https://github.com/jasonacox/pypowerwall/issues/87
+* Added GET APIs to retrieve backup reserve and operating mode settings
+* Added POST command APIs to set backup reserve and operating mode settings. **Requires setting `PW_CONTROL_SECRET` for the proxy. Use with caution.**
 
 ```bash
 # Set Mode
-curl http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET&value=self_consumption
+export MODE=self_consumption
+export RESERVE=20
+export PW_CONTROL_SECRET=mySecretKey
+
+curl -X POST -d "value=$MODE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/mode
 
 # Set Reserve
-curl http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET&value=20
+curl -X POST -d "value=$RESERVE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/reserve
 
-# Omit Value to Read Settings
-curl http://localhost:8675/control/mode?token=$PW_CONTROL_SECRET
-curl http://localhost:8675/control/reserve?token=$PW_CONTROL_SECRET
+# Read Settings
+curl http://localhost:8675/control/mode
+curl http://localhost:8675/control/reserve
 ```
 
 ### Proxy t53 (11 Apr 2024)

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -190,6 +190,7 @@ else:
     log.info("pyPowerwall Proxy Server - Local Mode")
     log.info("Connected to Energy Gateway %s (%s)" % (host, pw.site_name().strip()))
 
+pw_control = None
 if control_secret:
     log.info("Control Commands Activating - WARNING: Use with caution!")
     try:
@@ -204,6 +205,9 @@ if control_secret:
         control_secret = ""
     if pw_control:
         log.info("Control Mode Enabled: Cloud Mode Connected")
+    else:
+        log.error("Control Mode Failed: Unable to connect to cloud - Run Setup")
+        control_secret = None
 
 class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
     daemon_threads = True

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -98,6 +98,7 @@ control_secret = os.getenv("PW_CONTROL_SECRET", "")
 proxystats = {
     'pypowerwall': "%s Proxy %s" % (pypowerwall.version, BUILD),
     'gets': 0,
+    'posts': 0,
     'errors': 0,
     'timeout': 0,
     'uri': {},
@@ -226,6 +227,70 @@ class Handler(BaseHTTPRequestHandler):
         # replace function to avoid lookup delays
         hostaddr, hostport = self.client_address[:2]
         return hostaddr
+    
+    def do_POST(self):
+        global proxystats
+        contenttype = 'application/json'
+        message = '{"error": "Invalid Request"}'
+        if self.path.startswith('/control'):
+            # curl -X POST -d "value=20&token=1234" http://localhost:8675/control/reserve
+            # curl -X POST -d "value=backup&token=1234" http://localhost:8675/control/mode
+            message = None
+            if not control_secret:
+                message = '{"error": "Control Commands Disabled - Set PW_CONTROL_SECRET to enable"}'
+            else:
+                try:
+                    action = urlparse(self.path).path.split('/')[2]
+                    post_data = self.rfile.read(int(self.headers['Content-Length']))
+                    query_params = parse_qs(post_data.decode('utf-8'))
+                    value = query_params.get('value', [''])[0]
+                    token = query_params.get('token', [''])[0]
+                except Exception as e:
+                    message = '{"error": "Control Command Error: Invalid Request"}'
+                    log.error(f"Control Command Error: {e}")
+                if not message:
+                    # Check if unable to connect to cloud
+                    if pw_control.client is None:
+                        message = '{"error": "Control Command Error: Unable to connect to cloud mode - Run Setup"}'
+                        log.error("Control Command Error: Unable to connect to cloud mode - Run Setup")
+                    else:
+                        if token == control_secret:
+                            if action == 'reserve':
+                                # ensure value is an integer
+                                if not value:
+                                    # return current reserve level in json string
+                                    message = '{"reserve": %s}' % pw_control.get_reserve()
+                                elif value.isdigit():
+                                    message = json.dumps(pw_control.set_reserve(int(value)))
+                                    log.info(f"Control Command: Set Reserve to {value}")
+                                else:
+                                    message = '{"error": "Control Command Value Invalid"}'
+                            elif action == 'mode':
+                                if not value:
+                                    # return current mode in json string
+                                    message = '{"mode": "%s"}' % pw_control.get_mode()
+                                elif value in ['self_consumption', 'backup', 'autonomous']:
+                                    message = json.dumps(pw_control.set_mode(value))
+                                    log.info(f"Control Command: Set Mode to {value}")
+                                else:
+                                    message = '{"error": "Control Command Value Invalid"}'
+                            else:
+                                message = '{"error": "Invalid Command Action"}'
+                        else:
+                            message = '{"unauthorized": "Control Command Token Invalid"}'
+        if "error" in message:
+            self.send_response(400)
+            proxystats['errors'] = proxystats['errors'] + 1
+        elif "unauthorized" in message:
+            self.send_response(401)
+        else:
+            self.send_response(200)
+            proxystats['posts'] = proxystats['posts'] + 1
+        self.send_header('Content-type', contenttype)
+        self.send_header('Content-Length', str(len(message)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(message.encode("utf8"))
 
     def do_GET(self):
         global proxystats

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -90,7 +90,7 @@ from pypowerwall.pypowerwall_base import parse_version, PyPowerwallBase
 
 urllib3.disable_warnings()  # Disable SSL warnings
 
-version_tuple = (0, 8, 3)
+version_tuple = (0, 8, 4)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 
@@ -563,15 +563,16 @@ class Powerwall(object):
         Set battery operation mode and reserve level.
 
         Args:
-            level:   Set battery reserve level in percents (range of 5-100 is accepted)
+            level:   Set battery reserve level in percents (range of 0-100 is accepted)
             mode:    Set battery operation mode (self_consumption, backup, autonomous, etc.)
             jsonformat:  Set to True to receive json formatted string
 
         Returns:
             Dictionary with operation results, if jsonformat is False, else a JSON string
         """
-        if level and (level < 5 or level > 100):
-            raise InvalidBatteryReserveLevelException('Level can be in range of 5 to 100 only.')
+        if level and (level < 0 or level > 100):
+            log.error(f"Level can be in range of 0 to 100 only.")
+            return None
 
         if not level:
             level = self.get_reserve()
@@ -598,6 +599,7 @@ class Powerwall(object):
             type == "numeric" return -1 (Syncing), 0 (DOWN), 1 (UP)
         """
         if type not in ['json', 'string', 'numeric']:
+            log.error(f"Invalid value for parameter 'type': {type}")
             raise ValueError("Invalid value for parameter 'type': " + str(type))
 
         payload: dict = self.poll('/api/system_status/grid_status')

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -538,7 +538,7 @@ class Powerwall(object):
         Set battery reserve level.
 
         Args:
-            level:   Set battery reserve level in percents (range of 5-100 is accepted)
+            level:   Set battery reserve level in percents (range of 0-100 is accepted)
 
         Returns:
             Dictionary with operation results.
@@ -574,20 +574,17 @@ class Powerwall(object):
             log.error(f"Level can be in range of 0 to 100 only.")
             return None
 
-        if not level:
+        if level is None:
             level = self.get_reserve()
 
         if not mode:
             mode = self.get_mode()
 
-        # If level is 0, set it to False - Disable reserve
-        if level == 0:
-            level = False
-
         payload = {
-            'backup_reserve_percent': level,
+            'backup_reserve_percent': level if level > 0 else False,
             'real_mode': mode
         }
+        log.debug(f"Setting operation: {payload}")
 
         result = self.post(api='/api/operation', payload=payload, din=self.din(), jsonformat=jsonformat)
         return result

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -580,6 +580,10 @@ class Powerwall(object):
         if not mode:
             mode = self.get_mode()
 
+        # If level is 0, set it to False - Disable reserve
+        if level == 0:
+            level = False
+
         payload = {
             'backup_reserve_percent': level,
             'real_mode': mode


### PR DESCRIPTION
## Library Update for v0.8.4

Update set_reserve(level) logic to handle levels from 0 to 100 
Closes #85

## Proxy Update for t55

Update API to use POST method for `mode` and `reserve` setting changes.
Closes #87 

* Fix `/pod` API to add `time_remaining_hours` and `backup_reserve_percent` for cloud mode.
* Replaced t54 - Move control to POST see https://github.com/jasonacox/pypowerwall/issues/87
* Added GET APIs to retrieve backup reserve and operating mode settings
* Added POST command APIs to set backup reserve and operating mode settings. **Requires setting `PW_CONTROL_SECRET` for the proxy. Use with caution.**


```bash
export MODE=self_consumption
export RESERVE=20
export PW_CONTROL_SECRET=mySecretKey

# Set Mode
curl -X POST -d "value=$MODE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/mode

# Set Reserve
curl -X POST -d "value=$RESERVE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/reserve

# Read Settings
curl http://localhost:8675/control/mode
curl http://localhost:8675/control/reserve
```
