### PR TITLE
v0.10.3 - TEDAPI Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,23 @@ python3 -m pypowerwall setup
 
 ### Local Setup - Option 1
 
-The Tesla Powerwall, Powerwall 2 and Powerwall+ have a local LAN based API that you can use to monitor your Powerwall. It requires that you (or your installer) have the IP address (see scan above) and set up *Customer Login* credentials on your Powerwall Gateway. That is all that is needed to connect. Unfortunately, Powerwall 3 does not have a local API but you can access it via the cloud (options 2 and 3).
+The Tesla Powerwall, Powerwall 2 and Powerwall+ have a local LAN based API that you can use to monitor your Powerwall. It requires that you (or your installer) have the IP address (see scan above) and set up *Customer Login* credentials on your Powerwall Gateway. That is all that is needed to connect. Unfortunately, the Powerwall 3 does not have a local API but you can access it via the cloud (see options 2 and 3).
+
+Extended Device Vitals Metrics: With version v0.10.0+, pypowerwall can be set to access the TEDAPI on the Gateway to pull additional metrics. However, you will need the Gateway Password (often found on the QR sticker on the Powerwall Gateway). Additionally, your computer will need network access to the Gateway IP (192.168.91.1). You can have your computer join the Gateway local WiFi or you can add a route:
+
+```bash
+# Example - Change 192.168.0.100 to the IP address of Powerwall Gateway on your LAN
+
+# Linux Ubuntu and RPi - Can add to /etc/rc.local for persistence 
+sudo ip route add 192.168.91.1 via 192.168.0.100
+
+# MacOS 
+sudo route add -host 192.168.91.1 192.168.0.100 # Temporary 
+networksetup -setadditionalroutes Wi-Fi 192.168.91.1 255.255.255.255 192.168.0.100 # Persistent
+
+# Windows - Using persistence flag - Administrator Shell
+route -p add 192.168.91.1 mask 255.255.255.255 192.168.0.100
+```
 
 ### FleetAPI Setup - Option 2
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,21 @@
 # RELEASE NOTES
 
+## v0.10.3 - TEDAPI Connect
+
+* Update `setup.py` to include dependencies on `protobuf>=3.20.0`.
+* Add TEDAPI `connect()` logic to better validate Gateway endpoint access.
+* Add documentation for TEDAPI setup.
+* Update CLI to support TEDAPI calls.
+
+```bash
+# Connect to TEDAPI and pull data
+python3 -m pypowerwall tedapi
+
+# Direct call to TEDAPI class test function (optional password)
+python3 -m pypowerwall.tedapi GWPASSWORD
+python3 -m pypowerwall.tedapi --debug
+```
+
 ## v0.10.2 - FleetAPI Hotfix
 
 * Fix FleetAPI setup script as raised in https://github.com/jasonacox/pypowerwall/issues/98.

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,9 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t60 (9 Jun 2024)
+
+* Add error handling for `/csv` API to accommodate `None` data points.
+
 ### Proxy t59 (8 Jun 2024)
 
 * Minor fix to send less ambiguous debug information during client disconnects.

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,2 +1,2 @@
-pypowerwall==0.10.2
+pypowerwall==0.10.3
 bs4==0.0.2

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -55,7 +55,7 @@ from pypowerwall.fleetapi.fleetapi import CONFIGFILE
 from transform import get_static, inject_js
 from urllib.parse import urlparse, parse_qs
 
-BUILD = "t59"
+BUILD = "t60"
 ALLOWLIST = [
     '/api/status', '/api/site_info/site_name', '/api/meters/site',
     '/api/meters/solar', '/api/sitemaster', '/api/powerwalls',
@@ -330,7 +330,7 @@ class Handler(BaseHTTPRequestHandler):
         elif self.path == '/csv':
             # Grid,Home,Solar,Battery,Level - CSV
             contenttype = 'text/plain; charset=utf-8'
-            batterylevel = pw.level()
+            batterylevel = pw.level() or 0
             grid = pw.grid() or 0
             solar = pw.solar() or 0
             battery = pw.battery() or 0

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -17,7 +17,7 @@
 
  Classes
     Powerwall(host, password, email, timezone, pwcacheexpire, timeout, poolmaxsize, 
-        cloudmode, siteid, authpath, authmode)
+        cloudmode, siteid, authpath, authmode, cachefile, fleetapi, auto_select, retry_modes, gw_pwd)
 
  Parameters
     host                      # Hostname or IP of the Tesla gateway
@@ -36,6 +36,8 @@
     fleetapi = False          # If True, use Tesla FleetAPI for data (default is False)
     auth_path = ""            # Path to configfile (default current directory)
     auto_select = False       # If True, select the best available mode to connect (default is False)
+    retry_modes = False       # If True, retry connection to Powerwall
+    gw_pwd = None             # TEG Gateway password (used for local mode access to tedapi)
     
  Functions 
     poll(api, json, force)    # Return data from Powerwall api (dict if json=True, bypass cache force=True)

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -82,7 +82,7 @@ from json import JSONDecodeError
 from typing import Union, Optional
 import time
 
-version_tuple = (0, 10, 2)
+version_tuple = (0, 10, 3)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -41,6 +41,8 @@ setup_args.add_argument("-email", type=str, default=email, help="Email address f
 
 setup_args = subparsers.add_parser("fleetapi", help='Setup Tesla FleetAPI for Cloud Mode access')
 
+setup_args = subparsers.add_parser("tedapi", help='Test TEDAPI connection to Powerwall Gateway')
+
 scan_args = subparsers.add_parser("scan", help='Scan local network for Powerwall gateway')
 scan_args.add_argument("-timeout", type=float, default=timeout,
                        help=f"Seconds to wait per host [Default={timeout:.1f}]")
@@ -96,6 +98,7 @@ if command == 'setup':
     else:
         print("ERROR: Failed to setup Tesla Cloud Mode")
         exit(1)
+
 # FleetAPI Mode Setup
 elif command == 'fleetapi':
     from pypowerwall import PyPowerwallFleetAPI
@@ -108,6 +111,12 @@ elif command == 'fleetapi':
     else:
         print("Setup Aborted.")
         exit(1)
+
+# TEDAPI Test
+elif command == 'tedapi':
+    from pypowerwall.tedapi.__main__ import run_tedapi_test
+    run_tedapi_test(auto=True, debug=args.debug)
+
 # Run Scan
 elif command == 'scan':
     from pypowerwall import scan
@@ -118,6 +127,7 @@ elif command == 'scan':
     hosts = args.hosts
     timeout = args.timeout
     scan.scan(color, timeout, hosts, ip)
+
 # Set Powerwall Mode
 elif command == 'set':
     # If no arguments, print usage
@@ -146,6 +156,7 @@ elif command == 'set':
         current = float(pw.level())
         print("Setting Powerwall Reserve to Current Charge Level %s" % current)
         pw.set_reserve(current)
+
 # Get Powerwall Mode
 elif command == 'get':
     import pypowerwall

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -88,6 +88,7 @@ class TEDAPI:
         self.pwcooldown = 0
         self.gw_ip = host
         self.din = None
+        self.pw3 = False # Powerwall 3 Gateway only supports TEDAPI
         if not gw_pwd:
             raise ValueError("Missing gw_pwd")
         if self.debug:
@@ -331,7 +332,11 @@ class TEDAPI:
         url = f'https://{self.gw_ip}'
         self.din = None
         try:
-            _ = requests.get(url, verify=False, timeout=5)
+            resp = requests.get(url, verify=False, timeout=5)
+            if resp.status_code != 200:
+                # Connected but appears to be Powerwall 3
+                log.debug("Detected Powerwall 3 Gateway")
+                self.pw3 = True
             self.din = self.get_din() 
         except Exception as e:
             log.error(f"Unable to connect to Powerwall Gateway {self.gw_ip}")

--- a/pypowerwall/tedapi/__main__.py
+++ b/pypowerwall/tedapi/__main__.py
@@ -1,4 +1,4 @@
-# pyPowerWall - Tesla TEDAPI Class Main
+# pyPowerwall - Tesla TEDAPI Class Main
 # -*- coding: utf-8 -*-
 """
  Tesla TEADAPI Class - Command Line Test
@@ -6,60 +6,130 @@
  This script tests the TEDAPI class by connecting to a Tesla Powerwall Gateway
 """
 
-# Imports
-from pypowerwall.tedapi import TEDAPI, GW_IP
-import json
-import sys
+def run_tedapi_test(auto=False, debug=False):
+    # Print header
+    print("pyPowerwall - Powerwall Gateway TEDAPI Reader")
 
-# Print Header
-print("Tesla Powerwall Gateway TEDAPI Reader")
+    # Imports
+    from pypowerwall.tedapi import TEDAPI, GW_IP
+    from pypowerwall import __version__
+    import json
+    import sys
+    import argparse
+    import requests
+    import logging
 
-# Command line arguments
-if len(sys.argv) > 1:
-    gw_pwd = sys.argv[1]
-else:
-    # Get GW_PWD from User
-    gw_pwd = input("\nEnter Powerwall Gateway Password: ")
-print()
+    # Setup Logging
+    log = logging.getLogger(__name__)
 
-# Create TEDAPI Object and get Configuration and Status
-print(f"Connecting to Powerwall Gateway {GW_IP}")
-ted = TEDAPI(gw_pwd)
-config = ted.get_config()
-status = ted.get_status()
-print()
+    def set_debug(toggle=True, color=True):
+        """Enable verbose logging"""
+        if toggle:
+            if color:
+                logging.basicConfig(format='\x1b[31;1m%(levelname)s:%(message)s\x1b[0m', level=logging.DEBUG)
+            else:
+                logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
+            log.setLevel(logging.DEBUG)
+            log.debug('pyPowerwall TEDAPI version %s', __version__)
+            log.debug('Python %s on %s', sys.version, sys.platform)
+        else:
+            log.setLevel(logging.NOTSET)
 
-# Print Configuration
-print(" - Configuration:")
-site_info = config.get('site_info', {})
-site_name = site_info.get('site_name', 'Unknown')
-print(f"   - Site Name: {site_name}")
-battery_commission_date = site_info.get('battery_commission_date', 'Unknown')
-print(f"   - Battery Commission Date: {battery_commission_date}")
-vin = config.get('vin', 'Unknown')
-print(f"   - VIN: {vin}")
-number_of_powerwalls = len(config.get('battery_blocks', []))
-print(f"   - Number of Powerwalls: {number_of_powerwalls}")
-print()
+    # Load arguments if invoked from pypowerwall
+    if auto:
+        argv = ['pypowerwall']
+        if debug:
+            argv.append('--debug')
+        sys.argv = argv
 
-# Print power data
-print(" - Power Data:")
-nominalEnergyRemainingWh = status.get('control', {}).get('systemStatus', {}).get('nominalEnergyRemainingWh', 0)
-nominalFullPackEnergyWh = status.get('control', {}).get('systemStatus', {}).get('nominalFullPackEnergyWh', 0)
-soe = round(nominalEnergyRemainingWh / nominalFullPackEnergyWh * 100, 2)
-print(f"   - Battery Charge: {soe}% ({nominalEnergyRemainingWh}Wh of {nominalFullPackEnergyWh}Wh)")
-meterAggregates = status.get('control', {}).get('meterAggregates', [])
-for meter in meterAggregates:
-    location = meter.get('location', 'Unknown').title()
-    realPowerW = int(meter.get('realPowerW', 0))
-    print(f"   - {location}: {realPowerW}W")
-print()
+    # Check for arguments using argparse
+    parser = argparse.ArgumentParser(description='Tesla Powerwall Gateway TEDAPI Reader')
+    parser.add_argument('gw_pwd', nargs='?', help='Powerwall Gateway Password')
+    # Add debug
+    parser.add_argument('--debug', action='store_true', help='Enable Debug Output')
+    # Parse arguments
+    args = parser.parse_args()
+    if args.gw_pwd:
+        gw_pwd = args.gw_pwd
+    else:
+        gw_pwd = None
+    if args.debug:
+        set_debug(True)
 
-# Save Configuration and Status to JSON files
-with open('status.json', 'w') as f:
-    json.dump(status, f)
-with open('config.json', 'w') as f:
-    json.dump(config, f)
-print(" - Configuration and Status saved to config.json and status.json")
-print()
+    # Check that GW_IP is listening to port 443
+    url = f'https://{GW_IP}'
+    log.debug(f"Checking Powerwall Gateway at {url}")
+    print(f" - Connecting to {url}...", end="")
+    try:
+        resp = requests.get(url, verify=False, timeout=5)
+        log.debug(f"Connection to Powerwall Gateway successful, code {resp.status_code}.")
+        print(f" SUCCESS")
+    except Exception as e:
+        print(" FAILED")
+        print()
+        print(f"ERROR: Unable to connect to Powerwall Gateway {GW_IP} on port 443.")
+        print("Please verify your your host has a route to the Gateway.")
+        print(f"\nError details: {e}")
+        sys.exit(1)
 
+    # Get GW_PWD from User if not provided
+    if gw_pwd is None:
+        while not gw_pwd:
+            try:
+                gw_pwd = input("\nEnter Powerwall Gateway Password: ")
+            except KeyboardInterrupt:
+                print("")
+                sys.exit(1)
+            except Exception as e:
+                print(f"Error: {e}")
+                sys.exit(1)
+            if not gw_pwd:
+                print("Password Required")
+
+    # Create TEDAPI Object and get Configuration and Status
+    print()
+    print(f"Connecting to Powerwall Gateway {GW_IP}")
+    ted = TEDAPI(gw_pwd)
+    if ted.din is None:
+        print("\nERROR: Unable to connect to Powerwall Gateway. Check your password and try again")
+        sys.exit(1)
+    config = ted.get_config()
+    status = ted.get_status()
+    print()
+
+    # Print Configuration
+    print(" - Configuration:")
+    site_info = config.get('site_info', {})
+    site_name = site_info.get('site_name', 'Unknown')
+    print(f"   - Site Name: {site_name}")
+    battery_commission_date = site_info.get('battery_commission_date', 'Unknown')
+    print(f"   - Battery Commission Date: {battery_commission_date}")
+    vin = config.get('vin', 'Unknown')
+    print(f"   - VIN: {vin}")
+    number_of_powerwalls = len(config.get('battery_blocks', []))
+    print(f"   - Number of Powerwalls: {number_of_powerwalls}")
+    print()
+
+    # Print power data
+    print(" - Power Data:")
+    nominalEnergyRemainingWh = status.get('control', {}).get('systemStatus', {}).get('nominalEnergyRemainingWh', 0)
+    nominalFullPackEnergyWh = status.get('control', {}).get('systemStatus', {}).get('nominalFullPackEnergyWh', 0)
+    soe = round(nominalEnergyRemainingWh / nominalFullPackEnergyWh * 100, 2)
+    print(f"   - Battery Charge: {soe}% ({nominalEnergyRemainingWh}Wh of {nominalFullPackEnergyWh}Wh)")
+    meterAggregates = status.get('control', {}).get('meterAggregates', [])
+    for meter in meterAggregates:
+        location = meter.get('location', 'Unknown').title()
+        realPowerW = int(meter.get('realPowerW', 0))
+        print(f"   - {location}: {realPowerW}W")
+    print()
+
+    # Save Configuration and Status to JSON files
+    with open('status.json', 'w') as f:
+        json.dump(status, f)
+    with open('config.json', 'w') as f:
+        json.dump(config, f)
+    print(" - Configuration and Status saved to config.json and status.json")
+    print()
+
+if __name__ == "__main__":
+    run_tedapi_test()

--- a/pypowerwall/tedapi/__main__.py
+++ b/pypowerwall/tedapi/__main__.py
@@ -45,7 +45,7 @@ def run_tedapi_test(auto=False, debug=False):
     # Check for arguments using argparse
     parser = argparse.ArgumentParser(description='Tesla Powerwall Gateway TEDAPI Reader')
     parser.add_argument('gw_pwd', nargs='?', help='Powerwall Gateway Password')
-    # Add debug
+    parser.add_argument('--gw_ip', default=GW_IP, help='Powerwall Gateway IP Address')
     parser.add_argument('--debug', action='store_true', help='Enable Debug Output')
     # Parse arguments
     args = parser.parse_args()
@@ -55,6 +55,7 @@ def run_tedapi_test(auto=False, debug=False):
         gw_pwd = None
     if args.debug:
         set_debug(True)
+    GW_IP = args.gw_ip
 
     # Check that GW_IP is listening to port 443
     url = f'https://{GW_IP}'
@@ -89,7 +90,7 @@ def run_tedapi_test(auto=False, debug=False):
     # Create TEDAPI Object and get Configuration and Status
     print()
     print(f"Connecting to Powerwall Gateway {GW_IP}")
-    ted = TEDAPI(gw_pwd)
+    ted = TEDAPI(gw_pwd, host=GW_IP)
     if ted.din is None:
         print("\nERROR: Unable to connect to Powerwall Gateway. Check your password and try again")
         sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 #
 requests
-protobuf
+protobuf>=3.20.0
 teslapy

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'requests',      
-        'protobuf',        
+        'protobuf>=3.20.0',        
         'teslapy',     
     ],
     classifiers=[


### PR DESCRIPTION
## v0.10.3 - TEDAPI Connect Update

* Update `setup.py` to include dependencies on `protobuf>=3.20.0`.
* Add TEDAPI `connect()` logic to better validate Gateway endpoint access.
* Add documentation for TEDAPI setup.
* Update CLI to support TEDAPI calls.
* Proxy t60 - Fix edge case where `/csv` API will error due to NoneType inputs.
* Add TEDAPI argument to set custom GW IP address.

```bash
# Connect to TEDAPI and pull data
python3 -m pypowerwall tedapi

# Direct call to TEDAPI class test function (optional password)
python3 -m pypowerwall.tedapi GWPASSWORD
python3 -m pypowerwall.tedapi --debug
python3 -m pypowerwall.tedapi --gw_ip 192.168.91.1 --debug
```

Reference: #97 
