### PR TITLE
v0.10.5 - Minor Fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
 
 * Fix for TEDAPI "full" (e.g. Powerwall 3) mode, including `grid_status` bug resulting in false reports of grid status, `level()` bug where data gap resulted in 0% state of charge and `alerts()` where data gap from tedapi resulted in a `null` alert.
 * Add TEDAPI API call locking to limit load caused by concurrent polling.
+* Proxy - Add battery full_pack and remaining energy data to `/pod` API call for all cases.
 
 ## v0.10.4 - Powerwall 3 Local API Support
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.10.5 - Minor Fixes
+
+* Placeholder
+
 ## v0.10.4 - Powerwall 3 Local API Support
 
 * Add local support for Powerwall 3 using TEDAPI. 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,8 @@
 
 ## v0.10.5 - Minor Fixes
 
-* Placeholder
+* Fix for TEDAPI "full" (e.g. Powerwall 3) mode, including `grid_status` bug resulting in false reports of grid status, `level()` bug where data gap resulted in 0% state of charge and `alerts()` where data gap from tedapi resulted in a `null` alert.
+* Add TEDAPI API call locking to limit load caused by concurrent polling.
 
 ## v0.10.4 - Powerwall 3 Local API Support
 

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,9 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t62 (13 Jun 2024)
+
+* Add battery full_pack and remaining energy data to `/pod` API call for all cases.
+
 ### Proxy t61 (9 Jun 2024)
 
 * Fix 404 bug that would throw error when user requested non-supported URI.

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,2 +1,2 @@
-pypowerwall==0.10.4
+pypowerwall==0.10.5
 bs4==0.0.2

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -55,7 +55,7 @@ from pypowerwall.fleetapi.fleetapi import CONFIGFILE
 from transform import get_static, inject_js
 from urllib.parse import urlparse, parse_qs
 
-BUILD = "t61"
+BUILD = "t62"
 ALLOWLIST = [
     '/api/status', '/api/site_info/site_name', '/api/meters/site',
     '/api/meters/solar', '/api/sitemaster', '/api/powerwalls',
@@ -497,10 +497,8 @@ class Handler(BaseHTTPRequestHandler):
                     pod["PW%d_POD_nom_full_pack_energy" % idx] = get_value(v, 'POD_nom_full_pack_energy')
                     idx = idx + 1
             # Aggregate data
-            if pod:
-                # Only poll if we have battery data
-                pod["nominal_full_pack_energy"] = get_value(d, 'nominal_full_pack_energy')
-                pod["nominal_energy_remaining"] = get_value(d, 'nominal_energy_remaining')
+            pod["nominal_full_pack_energy"] = get_value(d, 'nominal_full_pack_energy')
+            pod["nominal_energy_remaining"] = get_value(d, 'nominal_energy_remaining')
             pod["time_remaining_hours"] = pw.get_time_remaining()
             pod["backup_reserve_percent"] = pw.get_reserve()
             message: str = json.dumps(pod)

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -606,7 +606,7 @@ class Powerwall(object):
             alert = grid_status.get('grid_status')
             if alert == 'SystemGridConnected' and 'SystemConnectedToGrid' not in alerts:
                 alerts.append('SystemConnectedToGrid')
-            else:
+            elif alert:
                 alerts.append(alert)
             if grid_status.get('grid_services_active'):
                 alerts.append('GridServicesActive')

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -84,7 +84,7 @@ from json import JSONDecodeError
 from typing import Union, Optional
 import time
 
-version_tuple = (0, 10, 4)
+version_tuple = (0, 10, 5)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -172,7 +172,9 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
 
     def get_api_system_status_soe(self, **kwargs) -> Optional[Union[dict, list, str, bytes]]:
         force = kwargs.get('force', False)
-        percentage_charged = self.tedapi.battery_level(force=force) or 0
+        percentage_charged = self.tedapi.battery_level(force=force)
+        if not percentage_charged:
+            return None
         data = {
             "percentage": percentage_charged
         }
@@ -203,8 +205,10 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
     def get_api_system_status_grid_status(self, **kwargs) -> Optional[Union[dict, list, str, bytes]]:
         force = kwargs.get('force', False)
         status = self.tedapi.get_status(force=force)
-        alerts = lookup(status, ["control", "alerts", "active"]) or []
-        if "SystemConnectedToGrid" in alerts:
+        grid_state = lookup(status, ["esCan", "bus", "ISLANDER", "ISLAND_GridConnection", "ISLAND_GridConnected"])
+        if not grid_state:
+            return None
+        if grid_state == "ISLAND_GridConnected_Connected":
             grid_status = "SystemGridConnected"
         else:
             grid_status = "SystemIslandedActive"
@@ -347,8 +351,10 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
         if not isinstance(status, dict) or not isinstance(config, dict):
             return None
         status = self.tedapi.get_status(force=force)
-        alerts = lookup(status, ["control", "alerts", "active"]) or []
-        if "SystemConnectedToGrid" in alerts:
+        grid_state = lookup(status, ["esCan", "bus", "ISLANDER", "ISLAND_GridConnection", "ISLAND_GridConnected"])
+        if not grid_state:
+            grid_status = None
+        elif grid_state == "ISLAND_GridConnected_Connected":
             grid_status = "SystemGridConnected"
         else:
             grid_status = "SystemIslandedActive"

--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -347,7 +347,7 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
         if not isinstance(status, dict) or not isinstance(config, dict):
             return None
         status = self.tedapi.get_status(force=force)
-        alerts = lookup(status, ["control", "alerts", "active"])
+        alerts = lookup(status, ["control", "alerts", "active"]) or []
         if "SystemConnectedToGrid" in alerts:
             grid_status = "SystemGridConnected"
         else:


### PR DESCRIPTION
* Fix for TEDAPI "full" (e.g. Powerwall 3) mode, including `grid_status` bug resulting in false reports of grid status, `level()` bug where data gap resulted in 0% state of charge and `alerts()` where data gap from tedapi resulted in a `null` alert.
* Add TEDAPI API call locking to limit load caused by concurrent polling.
* Proxy - Add battery full_pack and remaining energy data to `/pod` API call for all cases.
