### PR TITLE
Add power history retrieval to FleetAPI

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,17 @@
 # RELEASE NOTES
 
+## v0.10.7 - Energy History
+
+* FleetAPI - Add `get_history()` and `get_calendar_history()` to return energy, power, soe, and other history data.
+
+```python
+import pypowerwall
+
+pw = pypowerwall.Powerwall(host=PW_HOST, email=PW_EMAIL, fleetapi=True)
+pw.client.fleet.get_calendar_history(kind="soe")
+pw.client.fleet.get_history(kind="power")
+```
+
 ## v0.10.6 - pyLint Cleanup
 
 * Minor Bug Fixes - TEDAPI get_reserve() fix to address unscaled results.

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -84,7 +84,7 @@ from json import JSONDecodeError
 from typing import Union, Optional
 import time
 
-version_tuple = (0, 10, 6)
+version_tuple = (0, 10, 7)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/fleetapi/fleetapi.py
+++ b/pypowerwall/fleetapi/fleetapi.py
@@ -19,6 +19,8 @@
     get_site_info() - get site info
     get_battery_reserve() - get battery reserve level
     get_operating_mode() - get operating mode
+    get_history() - get energy history
+    get_calendar_history() - get calendar history
     solar_power() - get solar power
     grid_power() - get grid power
     battery_power() - get battery power
@@ -461,6 +463,38 @@ class FleetAPI:
         payload = self.poll("api/1/products", force=force)
         log.debug(f"get_products: {payload}")
         return self.keyval(payload, "response")
+
+    def get_calendar_history(self, kind=None, duration=None, time_zone=None, 
+                             start=None, end=None):
+        """ Get energy history 
+        kind: power, soe, energy, backup, self_consumption, 
+              time_of_use_energy, savings
+        duration: day, week, month, year, lifetime
+        time_zone: America/Los_Angeles
+        start: 2024-05-01T00:00:00-07:00 (RFC3339 format)
+        end: 2024-05-01T23:59:59-07:00
+        """
+        return self.get_history(kind, duration, time_zone, 
+                                start, end, "calendar_history")
+    
+    def get_history(self, kind=None, duration=None, time_zone=None, 
+                    start=None, end=None, history="history"):
+        """ Get energy history 
+        kind: power, energy, backup, self_consumption
+        duration: day, week, month, year, lifetime
+        time_zone: America/Los_Angeles
+        start: 2024-05-01T00:00:00-07:00 (RFC3339 format)
+        end: 2024-05-01T23:59:59-07:00
+        """
+        if not self.site_id:
+            return None
+        arg_kind = f"kind={kind}&" if kind else ""
+        arg_duration = f"period={duration}&" if duration else ""
+        arg_time_zone = f"time_zone={time_zone}" if time_zone else ""
+        arg_start = f"start={start}&" if start else ""
+        arg_end = f"end={end}&" if end else ""
+        h = self.poll(f"api/1/energy_sites/{self.site_id}/{history}?{arg_kind}{arg_duration}{arg_time_zone}{arg_start}{arg_end}")
+        return self.keyval(h, "response")
 
     def set_battery_reserve(self, reserve: int):
         if reserve < 0 or reserve > 100:


### PR DESCRIPTION

## v0.10.7 - Energy History

* FleetAPI - Add `get_history()` and `get_calendar_history()` to return energy, power, soe, and other history data.

```python
import pypowerwall

pw = pypowerwall.Powerwall(host=PW_HOST, email=PW_EMAIL, fleetapi=True)
pw.client.fleet.get_calendar_history(kind="soe")
pw.client.fleet.get_history(kind="power")
```