### PR TITLE
Add computed voltage and current to aggregates from TEDAPI status data

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,9 @@
 # RELEASE NOTES
 
-## v0.10.8 - TEDAPI Voltage & Current
+## v0.10.9 - TEDAPI Voltage & Current
 
-* Add computed voltage and current to `/api/meters/aggregates` from TEDAPI status data. 
+* Add computed voltage and current to `/api/meters/aggregates` from TEDAPI status data.
+* Fix error in `num_meters_aggregated` calculation in aggregates.
 
 ## v0.10.8 - TEDAPI Firmware Version
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.10.8 - TEDAPI Voltage & Current
+
+* Add computed voltage and current to `/api/meters/aggregates` from TEDAPI status data. 
+
 ## v0.10.8 - TEDAPI Firmware Version
 
 * Add TEDAPI `get_firmware_version()` to poll Powerwall for firmware version. Discovered by @geptto in https://github.com/jasonacox/pypowerwall/issues/97. This function has been integrated into pypowerwall existing APIs (e.g. `pw.version()`)

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -84,7 +84,7 @@ from json import JSONDecodeError
 from typing import Union, Optional
 import time
 
-version_tuple = (0, 10, 8)
+version_tuple = (0, 10, 9)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/tedapi/stubs.py
+++ b/pypowerwall/tedapi/stubs.py
@@ -37,7 +37,7 @@ API_METERS_AGGREGATES_STUB = {
         "last_phase_energy_communication_time": "0001-01-01T00:00:00Z",
         "timeout": 1500000000,
         "num_meters_aggregated": None,
-        "instant_total_current": 0
+        "instant_total_current": None
     },
     "load": {
         "last_communication_time": None,
@@ -56,7 +56,7 @@ API_METERS_AGGREGATES_STUB = {
         "last_phase_power_communication_time": "0001-01-01T00:00:00Z",
         "last_phase_energy_communication_time": "0001-01-01T00:00:00Z",
         "timeout": 1500000000,
-        "instant_total_current": 0
+        "instant_total_current": None
     },
     "solar": {
         "last_communication_time": None,
@@ -76,7 +76,7 @@ API_METERS_AGGREGATES_STUB = {
         "last_phase_energy_communication_time": "0001-01-01T00:00:00Z",
         "timeout": 1000000000,
         "num_meters_aggregated": None,
-        "instant_total_current": 0
+        "instant_total_current": None
     }
 }
 


### PR DESCRIPTION
## v0.10.9- TEDAPI Voltage & Current

* Add computed voltage and current to `/api/meters/aggregates` using system data from TEDAPI status payload. 
