### PR TITLE
Add Grid Control Functions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ and call function to poll data.  Here is an example:
     set_mode(mode)            # Set Current Battery Operation Mode
     get_time_remaining()      # Get the backup time remaining on the battery
     set_operation(level, mode, json)  # Set Battery Reserve Percentage and/or Operation Mode
+    set_grid_charging(mode)   # Enable or disable grid charging (mode = True or False)
+    set_grid_export(mode)     # Set grid export mode (mode = battery_ok, pv_only, never)
+    get_grid_charging()       # Get the current grid charging mode
+    get_grid_export()         # Get the current grid export mode
 ```
 
 ## Tools
@@ -243,16 +247,18 @@ Options:
 
 Commands (run <command> -h to see usage information):
   {setup,scan,set,get,version}
-    setup               Setup Tesla Login for Cloud Mode access
-    scan                Scan local network for Powerwall gateway
-    set                 Set Powerwall Mode and Reserve Level
-    get                 Get Powerwall Settings and Power Levels
-    version             Print version information
+    setup                 Setup Tesla Login for Cloud Mode access
+    scan                  Scan local network for Powerwall gateway
+    set                   Set Powerwall Mode and Reserve Level
+    get                   Get Powerwall Settings and Power Levels
+    version               Print version information
 
    set options:
-      -mode MODE        Powerwall Mode: self_consumption, backup, or autonomous
-      -reserve RESERVE  Set Battery Reserve Level [Default=20]
-      -current          Set Battery Reserve Level to Current Charge
+      -mode MODE          Powerwall Mode: self_consumption, backup, or autonomous
+      -reserve RESERVE    Set Battery Reserve Level [Default=20]
+      -current            Set Battery Reserve Level to Current Charge
+      -gridcharging MODE  Set Grid Charging (allow) Mode ("on" or "off")
+      -gridexport MODE    Set Export to Grid Mode ("battery_ok", "pv_only", or "never")
 
    get options:
       -format FORMAT      Output format: text, json, csv

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,54 @@
 # RELEASE NOTES
 
+## v0.10.10 - Add Grid Control
+
+* Add a function and command line options to allow user to get and set grid charging and exporting modes (see https://github.com/jasonacox/pypowerwall/issues/108).
+* Supports FleetAPI and Cloud modes only (not Local mode)
+
+#### Command Line Examples
+
+```bash
+# Connect to Cloud
+python3 -m pypowerwall setup # or fleetapi
+
+# Get Current Settings
+python3 -m pypowerwall get
+
+# Turn on Grid charging
+python3 -m pypowerwall set -gridcharging on
+
+# Turn off Grid charging
+python3 -m pypowerwall  set -gridcharging off
+
+# Set Grid Export to Solar (PV) energy only
+python3 -m pypowerwall set -gridexport pv_only
+
+# Set Grid Export to Battery and Solar energy
+python3 -m pypowerwall set -gridexport battery_ok
+
+# Disable export of all energy to grid
+python3 -m pypowerwall set -gridexport never
+```
+
+#### Programming Examples
+
+```python
+import pypowerwall
+
+# FleetAPI Mode
+PW_HOST=""
+PW_EMAIL="my@example.com"
+pw = pypowerwall.Powerwall(host=PW_HOST, email=PW_EMAIL, fleetapi=True)
+
+# Get modes
+pw.get_grid_charging()
+pw.get_grid_export()
+
+# Set modes
+pw.set_grid_charging("on") # set grid charging mode (on or off)
+pw.set_grid_export("pv_only")   # set grid export mode (battery_ok, pv_only, or never)
+```
+
 ## v0.10.9 - TEDAPI Voltage & Current
 
 * Add computed voltage and current to `/api/meters/aggregates` from TEDAPI status data.

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -71,6 +71,10 @@
     set_mode(mode)            # Set Current Battery Operation Mode
     get_time_remaining()      # Get the backup time remaining on the battery
     set_operation(level, mode, json)        # Set Battery Reserve Percentage and/or Operation Mode
+    set_grid_charging(mode)   # Enable or disable grid charging (mode = True or False)
+    set_grid_export(mode)     # Set grid export mode (mode = battery_ok, pv_only, never)
+    get_grid_charging()       # Get the current grid charging mode
+    get_grid_export()         # Get the current grid export mode
 
  Requirements
     This module requires the following modules: requests, protobuf, teslapy
@@ -834,6 +838,51 @@ class Powerwall(object):
             The time remaining in hours
         """
         return self.client.get_time_remaining()
+
+    def set_grid_charging(self, mode) -> Optional[dict]:
+        """
+        Enable or disable grid charging
+
+        Args:
+            enabled:    Set to True to enable grid charging, False to disable it
+
+        Returns:
+            Dictionary with operation results.
+        """
+        return self.client.set_grid_charging(mode)
+
+    def get_grid_charging(self) -> Optional[bool]:
+        """
+        Get the current grid charging mode
+
+        Returns:
+            True if grid charging is enabled, False if it is disabled
+        """
+        return self.client.get_grid_charging()
+
+    def set_grid_export(self, mode: str) -> Optional[dict]:
+        """
+        Set grid export mode
+
+        Args:
+            mode:    Set grid export mode (battery_ok, pv_only, or never)
+
+        Returns:
+            Dictionary with operation results.
+        """
+        # Check for valid mode
+        if mode not in ['battery_ok', 'pv_only', 'never']:
+            raise ValueError(f"Invalid value for parameter 'mode': {mode}")
+        return self.client.set_grid_export(mode)
+
+    def get_grid_export(self) -> Optional[str]:
+        """
+        Get the current grid export mode
+
+        Returns:
+            The current grid export mode
+        """
+        return self.client.get_grid_export()
 
     def _validate_init_configuration(self):
 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -88,7 +88,7 @@ from json import JSONDecodeError
 from typing import Union, Optional
 import time
 
-version_tuple = (0, 10, 9)
+version_tuple = (0, 10, 10)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 
@@ -844,7 +844,7 @@ class Powerwall(object):
         Enable or disable grid charging
 
         Args:
-            enabled:    Set to True to enable grid charging, False to disable it
+            mode: Set to True to enable grid charging, False to disable it
 
         Returns:
             Dictionary with operation results.
@@ -865,7 +865,7 @@ class Powerwall(object):
         Set grid export mode
 
         Args:
-            mode:    Set grid export mode (battery_ok, pv_only, or never)
+            mode: Set grid export mode (battery_ok, pv_only, or never)
 
         Returns:
             Dictionary with operation results.

--- a/pypowerwall/fleetapi/pypowerwall_fleetapi.py
+++ b/pypowerwall/fleetapi/pypowerwall_fleetapi.py
@@ -777,6 +777,17 @@ class PyPowerwallFleetAPI(PyPowerwallBase):
             }
         return resp
 
+    def set_grid_charging(self, mode) -> bool:
+        return self.fleet.set_grid_charging(mode)
+
+    def set_grid_export(self, mode:str) -> bool:
+        return self.fleet.set_grid_export(mode)
+
+    def get_grid_export(self, force=False) -> str:
+        return self.fleet.get_grid_export(force=force)
+
+    def get_grid_charging(self, force=False) -> bool:
+        return self.fleet.get_grid_charging(force=force)
 
 if __name__ == "__main__":
     import sys

--- a/pypowerwall/local/pypowerwall_local.py
+++ b/pypowerwall/local/pypowerwall_local.py
@@ -452,3 +452,17 @@ class PyPowerwallLocal(PyPowerwallBase):
                 return d['nominal_energy_remaining'] / load
         # Default
         return None
+
+    # Functions not available in local mode
+
+    def set_grid_charging(self, mode: str) -> None:
+        log.error('Function set_grid_charging not available in local mode')
+
+    def set_grid_export(self, mode: str) -> None:
+        log.error('Function set_grid_export not available in local mode')
+
+    def get_grid_charging(self, force=False) -> None:
+        log.error('Function get_grid_charging not available in local mode')
+
+    def get_grid_export(self, force=False) -> None:
+        log.error('Function get_grid_export not available in local mode')


### PR DESCRIPTION
# Verison v0.10.10

* Add functions and command line options to allow user to get and set grid charging and exporting modes (see https://github.com/jasonacox/pypowerwall/issues/108).
* Supports FleetAPI and Cloud modes only (not Local mode)

#### Command Line Examples

```bash
# Connect to Cloud
python3 -m pypowerwall setup # or fleetapi

# Get Current Settings
python3 -m pypowerwall get

# Turn on Grid charging
python3 -m pypowerwall set -gridcharging on

# Turn off Grid charging
python3 -m pypowerwall  set -gridcharging off

# Set Grid Export to Solar (PV) energy only
python3 -m pypowerwall set -gridexport pv_only

# Set Grid Export to Battery and Solar energy
python3 -m pypowerwall set -gridexport battery_ok

# Disable export of all energy to grid
python3 -m pypowerwall set -gridexport never
```

#### Programming Examples

```python
import pypowerwall

# FleetAPI Mode
PW_HOST=""
PW_EMAIL="my@example.com"
pw = pypowerwall.Powerwall(host=PW_HOST, email=PW_EMAIL, fleetapi=True)

# Get modes
pw.get_grid_charging()
pw.get_grid_export()

# Set modes
pw.set_grid_charging("on") # set grid charging mode (on or off)
pw.set_grid_export("pv_only")   # set grid export mode (battery_ok, pv_only, or never)
```

Closes #108 
