### PR TITLE
Remove Negative Solar Values [Option]

### DIFF
--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,11 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t65 (22 Nov 2024)
+
+* Add `PW_NEG_SOLAR` config option and logic to remove negative solar values for /aggregates and /csv APIs
+* Update http://pypowerwall:8675/stats and http://pypowerwall:8675/help to show config data.
+* PR https://github.com/jasonacox/pypowerwall/pull/113
+
 ### Proxy t64 (1 Sep 2024)
 
 * Add PW3 features for pypowerwall v0.11.0


### PR DESCRIPTION
# Proxy t65 - Negative Solar Value [Option]

* Add PW_NEG_SOLAR config option and logic to remove negative solar values for `/aggregates` and `/csv` APIs
* Update http://pypowerwall:8675/stats and http://pypowerwall:8675/help to show config data

Reference: 

https://github.com/jasonacox/Powerwall-Dashboard/issues/543#issuecomment-2480684273