### PR TITLE
Fix errors with site references

### DIFF
--- a/pypowerwall/cloud/pypowerwall_cloud.py
+++ b/pypowerwall/cloud/pypowerwall_cloud.py
@@ -263,13 +263,14 @@ class PyPowerwallCloud(PyPowerwallBase):
             return False
         # Set siteindex - Find siteid in sites
         for idx, site in enumerate(sites):
-            if site['energy_site_id'] == siteid:
-                self.siteid = siteid
-                self.siteindex = idx
-                self.site = sites[self.siteindex]
-                site_name = sites[self.siteindex].get('site_name') or 'Unknown'
-                log.debug(f"Changed site to {self.siteid} ({site_name}) for {self.email}")
-                return True
+            if site.get('energy_site_id') != siteid:
+                continue
+            self.siteid = siteid
+            self.siteindex = idx
+            self.site = site
+            site_name = site.get('site_name', 'Unknown')
+            log.debug(f"Changed site to {self.siteid} ({site_name}) for {self.email}")
+            return True
         log.error("Site %d not found for %s" % (siteid, self.email))
         return False
 

--- a/pypowerwall/fleetapi/pypowerwall_fleetapi.py
+++ b/pypowerwall/fleetapi/pypowerwall_fleetapi.py
@@ -163,9 +163,11 @@ class PyPowerwallFleetAPI(PyPowerwallBase):
                 log.error("Site %r not found for %s" % (self.siteid, self.email))
                 return False
         # Set site
-        self.siteid = sites[self.siteindex].get('energy_site_id')
+        siteref = sites[self.siteindex]
+        self.siteid = siteref.get('energy_site_id')
+        site_name = siteref.get('site_name', 'Unknown')
         log.debug(f"Connected to Tesla FleetAPI - Site {self.siteid} "
-                  f"({sites[self.siteindex]['site_name']}) for {self.email}")
+                  f"({site_name}) for {self.email}")
         return True
 
     # Function to map Powerwall API to Tesla FleetAPI Data
@@ -242,12 +244,14 @@ class PyPowerwallFleetAPI(PyPowerwallBase):
             return False
         # Set siteindex - Find siteid in sites
         for idx, site in enumerate(sites):
-            if site['energy_site_id'] == siteid:
-                self.siteid = siteid
-                self.siteindex = idx
-                self.siteid = sites[self.siteindex]
-                log.debug(f"Changed site to {self.siteid} ({sites[self.siteindex]['site_name']}) for {self.email}")
-                return True
+            if site.get('energy_site_id') != siteid:
+                continue
+            self.siteid = siteid
+            self.siteindex = idx
+            self.site = site
+            site_name = site.get('site_name', 'Unknown')
+            log.debug(f"Changed site to {self.siteid} ({site_name}) for {self.email}")
+            return True
         log.error("Site %d not found for %s" % (siteid, self.email))
         return False
 


### PR DESCRIPTION
New Tesla user here, I have only Tesla solar inverters, and I was unable to access them with pypowerwall unless I applied this fix. Pypowerwall would crash when trying to find the site_name. The broken line was `self.siteid = sites[self.siteindex].get('energy_site_id')` in `pypowerwall_fleetapi.py`

Otherwise, make the change_site functions consistent and less error-prone! The change site function, especially the site name reference, can break users that only have Solar-Only Tesla inverters. Make the two change_site functions consistent and fix other issues where site_name is not provided by the Tesla API.