### PR TITLE
v0.12.2 - TEDAPI Cache Expiration Fix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
 
 * Fix bug in cache expiration timeout code that was not honring pwcacheexpire setting. Raised by @erikgiesele in https://github.com/jasonacox/pypowerwall/issues/122 - PW_CACHE_EXPIRE=0 not possible? (Proxy)
 * Add WARNING log in proxy for settings below 5s.
+* Change TEDAPI config default timeout from 300s to 5s and link to pwcacheexpire setting.
 
 ## v0.12.1 - Scanner Update
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.12.2 - Cache Expiration Fix
+
+* Fix bug in cache expiration timeout code that was not honring pwcacheexpire setting. Raised by @erikgiesele in https://github.com/jasonacox/pypowerwall/issues/122 - PW_CACHE_EXPIRE=0 not possible? (Proxy)
+* Add WARNING log in proxy for settings below 5s.
 
 ## v0.12.1 - Scanner Update
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## v0.12.2 - Cache Expiration Fix
 
-* Fix bug in cache expiration timeout code that was not honring pwcacheexpire setting. Raised by @erikgiesele in https://github.com/jasonacox/pypowerwall/issues/122 - PW_CACHE_EXPIRE=0 not possible? (Proxy)
+* Fix bug in cache expiration timeout code that was not honoring pwcacheexpire setting. Raised by @erikgiesele in https://github.com/jasonacox/pypowerwall/issues/122 - PW_CACHE_EXPIRE=0 not possible? (Proxy)
 * Add WARNING log in proxy for settings below 5s.
 * Change TEDAPI config default timeout from 300s to 5s and link to pwcacheexpire setting.
 

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,14 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t67 (26 Dec 2024)
+
+* pyPowerwall v0.12.2 - Fix bug in cache timeout code that was not honring pwcacheexpire setting. Raised by @erikgiesele in https://github.com/jasonacox/pypowerwall/issues/122 - PW_CACHE_EXPIRE=0 not possible? (Proxy)
+* Add WARNING log in proxy for settings below 5s.
+
+### Proxy t66
+
+* pyPowerwall v0.12.0
+
 ### Proxy t65 (22 Nov 2024)
 
 * Add `PW_NEG_SOLAR` config option and logic to remove negative solar values for /aggregates and /csv APIs

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -2,7 +2,7 @@
 
 ### Proxy t67 (26 Dec 2024)
 
-* pyPowerwall v0.12.2 - Fix bug in cache timeout code that was not honring pwcacheexpire setting. Raised by @erikgiesele in https://github.com/jasonacox/pypowerwall/issues/122 - PW_CACHE_EXPIRE=0 not possible? (Proxy)
+* pyPowerwall v0.12.2 - Fix bug in cache timeout code that was not honoring pwcacheexpire setting. Raised by @erikgiesele in https://github.com/jasonacox/pypowerwall/issues/122 - PW_CACHE_EXPIRE=0 not possible? (Proxy)
 * Add WARNING log in proxy for settings below 5s.
 
 ### Proxy t66

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,2 +1,2 @@
-pypowerwall==0.12.1
+pypowerwall==0.12.2
 bs4==0.0.2

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -54,7 +54,7 @@ from transform import get_static, inject_js
 import pypowerwall
 from pypowerwall import parse_version
 
-BUILD = "t66"
+BUILD = "t67"
 ALLOWLIST = [
     '/api/status', '/api/site_info/site_name', '/api/meters/site',
     '/api/meters/solar', '/api/sitemaster', '/api/powerwalls',
@@ -171,13 +171,16 @@ else:
              (pypowerwall.version, BUILD, httptype, port))
 log.info("pyPowerwall Proxy Started")
 
+# Check for cache expire time limit below 5s
+if cache_expire < 5:
+    log.warning("Cache expiration set below 5s (PW_CACHE_EXPIRE=%d)" % cache_expire)
 
 # Signal handler - Exit on SIGTERM
 # noinspection PyUnusedLocal
 def sig_term_handle(signum, frame):
     raise SystemExit
 
-
+# Register signal handler
 signal.signal(signal.SIGTERM, sig_term_handle)
 
 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -244,6 +244,7 @@ class Powerwall(object):
                         log.debug("TEDAPI ** full **")
                         self.tedapi_mode = "full"
                         self.client = PyPowerwallTEDAPI(self.gw_pwd, pwcacheexpire=self.pwcacheexpire,
+                                                        pwconfigexpire=self.pwcacheexpire,
                                                         timeout=self.timeout, host=self.host)
                     else:
                         self.tedapi_mode = "hybrid"

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -88,7 +88,7 @@ from json import JSONDecodeError
 from typing import Union, Optional
 import time
 
-version_tuple = (0, 12, 1)
+version_tuple = (0, 12, 2)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -8,7 +8,7 @@
 
  Class:
     TEDAPI(gw_pwd: str, debug: bool = False, pwcacheexpire: int = 5, timeout: int = 5,
-              pwconfigexpire: int = 300, host: str = GW_IP) - Initialize TEDAPI
+              pwconfigexpire: int = 5, host: str = GW_IP) - Initialize TEDAPI
     
  Parameters:
     gw_pwd - Powerwall Gateway Password
@@ -84,7 +84,7 @@ def lookup(data, keylist):
 # TEDAPI Class
 class TEDAPI:
     def __init__(self, gw_pwd: str, debug: bool = False, pwcacheexpire: int = 5, timeout: int = 5,
-                 pwconfigexpire: int = 300, host: str = GW_IP) -> None:
+                 pwconfigexpire: int = 5, host: str = GW_IP) -> None:
         self.debug = debug
         self.pwcachetime = {}  # holds the cached data timestamps for api
         self.pwcacheexpire = pwcacheexpire  # seconds to expire status cache

--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -61,7 +61,8 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
         self.auth = {'AuthCookie': 'local', 'UserRecord': 'local'}  # Bogus local auth record
 
         # Initialize TEDAPI
-        self.tedapi = TEDAPI(self.gw_pwd, debug=self.debug, host=self.host, timeout=self.timeout)
+        self.tedapi = TEDAPI(self.gw_pwd, debug=self.debug, host=self.host, timeout=self.timeout,
+                             pwcacheexpire=self.pwcacheexpire, pwconfigexpire=self.pwconfigexpire)
         log.debug(f" -- tedapi: Attempting to connect to {self.host}...")
         if not self.tedapi.connect():
             raise ConnectionError(f"Unable to connect to Tesla TEDAPI at {self.host}")

--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -46,7 +46,7 @@ def compute_LL_voltage(v1n, v2n, v3n=None):
 # noinspection PyMethodMayBeStatic
 class PyPowerwallTEDAPI(PyPowerwallBase):
     def __init__(self, gw_pwd: str, debug: bool = False, pwcacheexpire: int = 5, timeout: int = 5,
-                 pwconfigexpire: int = 300, host: str = GW_IP) -> None:
+                 pwconfigexpire: int = 5, host: str = GW_IP) -> None:
         super().__init__("nobody@nowhere.com")
         self.tedapi = None
         self.timeout = timeout


### PR DESCRIPTION
## v0.12.2 - Cache Expiration Fix

* Fix bug in cache expiration timeout code that was not honring pwcacheexpire setting. Raised by @erikgiesele in https://github.com/jasonacox/pypowerwall/issues/122 - PW_CACHE_EXPIRE=0 not possible? (Proxy)
* Add WARNING log in proxy for settings below 5s.
* Change TEDAPI config default timeout from 300s to 5s and link to pwcacheexpire setting.

Closes #122 
