### PR TITLE
Update proxy for v0.12.3 and add /csv/v2 API support

### DIFF
--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,14 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t68 (20 Jan 2025)
+
+* pyPowerwall v0.12.3 - Adds Custom GW IP for TEDAPI. 
+* Add new API /csv/v2 which extends /csv by adding grids status (1/0) and battery reserve (%)setting:
+
+```python
+# Grid,Home,Solar,Battery,Battery_Level,Grid_Status,Reserve
+```
+
 ### Proxy t67 (26 Dec 2024)
 
 * pyPowerwall v0.12.2 - Fix bug in cache timeout code that was not honoring pwcacheexpire setting. Raised by @erikgiesele in https://github.com/jasonacox/pypowerwall/issues/122 - PW_CACHE_EXPIRE=0 not possible? (Proxy)

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,2 +1,2 @@
-pypowerwall==0.12.2
+pypowerwall==0.12.3
 bs4==0.0.2


### PR DESCRIPTION
Minor update to bump library version and provide expanded data for simple clients via `/csv/v2` API endpoint. 

* pyPowerwall v0.12.3 - Adds Custom GW IP for TEDAPI. 
* Add new API /csv/v2 which extends /csv by adding grids status (1/0) and battery reserve (%)setting:

```python
# Grid,Home,Solar,Battery,Battery_Level,Grid_Status,Reserve
-76.00,1114.25,360.00,780.00,96.51,1,20
```