### PR TITLE
Improvements to grid status connected

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,8 @@
 # RELEASE NOTES
 
-## v0.12.4 - Normalize Alerts
+## v0.12.5 - Normalize Alerts
 
-* Fix an issue in TEDAPI where the grid status is not accurately reported in certain edge cases. Now, only the "SystemConnectedToGrid" alert will appear if it is present in alerts API. This update also eliminates the risk of duplicate alerts and normalizes this specific alert. PR https://github.com/jasonacox/pypowerwall/pull/139 by @Nexarian
+* Fix an issue in TEDAPI where the grid status is not accurately reported in certain edge cases. Now, only the "SystemConnectedToGrid" alert will appear if it is present in alerts API. This update also eliminates the risk of duplicate and redundant ("SystemGridConnected") alerts and normalizes this specific alert. PR https://github.com/jasonacox/pypowerwall/pull/139 by @Nexarian
 
 ## v0.12.3 - Custom GW IP
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.12.4 - Normalize Alerts
+
+* Fix an issue in TEDAPI where the grid status is not accurately reported in certain edge cases. Now, only the "SystemConnectedToGrid" alert will appear if it is present in alerts API. This update also eliminates the risk of duplicate alerts and normalizes this specific alert. PR https://github.com/jasonacox/pypowerwall/pull/139 by @Nexarian
+
 ## v0.12.3 - Custom GW IP
 
 * Fix TEDAPI URL from constant GW_IP to constructor selectable host gw_ip by @Nexarian in https://github.com/jasonacox/pypowerwall/pull/129 - The hard-coded 192.168.91.1 for the TEDAPI internal endpoint doesn't always work if you're using NAT. This change enables support for this use-case.

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -88,7 +88,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 12, 3)
+version_tuple = (0, 12, 4)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -614,10 +614,8 @@ class Powerwall(object):
             elif alert:
                 alerts.add(alert)
 
-        def normalize_alerts(s: str) -> str:
-            return s.replace("SystemGridConnected", "SystemConnectedToGrid")
-
-        normalized_alerts = {normalize_alerts(s) for s in alerts}
+        # In the future, if more replacements are needed, create a utility function here.
+        normalized_alerts = list({s.replace("SystemGridConnected", "SystemConnectedToGrid") for s in alerts})
 
         if jsonformat:
             return json.dumps(normalized_alerts, indent=4, sort_keys=True)

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -84,9 +84,9 @@ import json
 import logging
 import os.path
 import sys
-from json import JSONDecodeError
-from typing import Union, Optional
 import time
+from json import JSONDecodeError
+from typing import Optional, Union
 
 version_tuple = (0, 12, 3)
 version = __version__ = '%d.%d.%d' % version_tuple
@@ -95,15 +95,15 @@ __author__ = 'jasonacox'
 # noinspection PyPackageRequirements
 import urllib3
 
-from pypowerwall.regex import HOST_REGEX, IPV4_6_REGEX, EMAIL_REGEX
-from pypowerwall.exceptions import PyPowerwallInvalidConfigurationParameter, InvalidBatteryReserveLevelException
-from pypowerwall.cloud.pypowerwall_cloud import PyPowerwallCloud
-from pypowerwall.local.pypowerwall_local import PyPowerwallLocal
-from pypowerwall.fleetapi.pypowerwall_fleetapi import PyPowerwallFleetAPI
-from pypowerwall.pypowerwall_base import parse_version, PyPowerwallBase
-from pypowerwall.tedapi.pypowerwall_tedapi import PyPowerwallTEDAPI
+from pypowerwall.cloud.pypowerwall_cloud import AUTHFILE, PyPowerwallCloud
+from pypowerwall.exceptions import (InvalidBatteryReserveLevelException,
+                                    PyPowerwallInvalidConfigurationParameter)
 from pypowerwall.fleetapi.fleetapi import CONFIGFILE
-from pypowerwall.cloud.pypowerwall_cloud import AUTHFILE
+from pypowerwall.fleetapi.pypowerwall_fleetapi import PyPowerwallFleetAPI
+from pypowerwall.local.pypowerwall_local import PyPowerwallLocal
+from pypowerwall.pypowerwall_base import PyPowerwallBase, parse_version
+from pypowerwall.regex import EMAIL_REGEX, HOST_REGEX, IPV4_6_REGEX
+from pypowerwall.tedapi.pypowerwall_tedapi import PyPowerwallTEDAPI
 
 urllib3.disable_warnings()  # Disable SSL warnings
 
@@ -581,17 +581,17 @@ class Powerwall(object):
           jsonformat = If True, return JSON format otherwise return Python Dictionary
           alertonly  = If True, return only alerts without device name
         """
-        alerts = []
+        alerts = set()
         devices: dict = self.vitals() or {}
         if devices:
             for device in devices:
-                if 'alerts' in devices[device]:
-                    for i in devices[device]['alerts']:
-                        if alertsonly:
-                            alerts.append(i)
-                        else:
-                            item = {device: i}
-                            alerts.append(item)
+                if not 'alerts' in devices[device]:
+                    continue
+                for i in devices[device]['alerts']:
+                    if alertsonly:
+                        alerts.add(i)
+                        continue
+                    alerts.add({device: i})
         elif not devices and alertsonly is True:
             # Vitals API is not present in firmware versions > 23.44 for local mode.
             # This is a workaround to get alerts from the /api/solar_powerwall endpoint
@@ -599,27 +599,29 @@ class Powerwall(object):
             pvac_alerts = data.get('pvac_alerts') or {}
             for alert, value in pvac_alerts.items():
                 if value is True:
-                    alerts.append(alert)
+                    alerts.add(alert)
             pvs_alerts = data.get('pvs_alerts') or {}
             for alert, value in pvs_alerts.items():
                 if value is True:
-                    alerts.append(alert)
+                    alerts.add(alert)
 
         # Augment with inferred alerts from the grid_status
         grid_status = self.poll('/api/system_status/grid_status')
         if grid_status:
             alert = grid_status.get('grid_status')
-            if alert == 'SystemGridConnected' and 'SystemConnectedToGrid' not in alerts:
-                alerts.append('SystemConnectedToGrid')
-            elif alert:
-                alerts.append(alert)
             if grid_status.get('grid_services_active'):
-                alerts.append('GridServicesActive')
+                alerts.add('GridServicesActive')
+            elif alert:
+                alerts.add(alert)
+
+        def normalize_alerts(s: str) -> str:
+            return s.replace("SystemGridConnected", "SystemConnectedToGrid")
+
+        normalized_alerts = {normalize_alerts(s) for s in alerts}
 
         if jsonformat:
-            return json.dumps(alerts, indent=4, sort_keys=True)
-        else:
-            return alerts
+            return json.dumps(normalized_alerts, indent=4, sort_keys=True)
+        return normalized_alerts
 
     def get_reserve(self, scale=True, force=False) -> Optional[float]:
         """

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -88,7 +88,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 12, 4)
+version_tuple = (0, 12, 5)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -2,14 +2,14 @@
 # -*- coding: utf-8 -*-
 """
  Tesla TEADAPI Class
- 
- This module allows you to access the Tesla Powerwall Gateway 
+
+ This module allows you to access the Tesla Powerwall Gateway
  TEDAPI on 192.168.91.1 as used by the Tesla One app.
 
  Class:
     TEDAPI(gw_pwd: str, debug: bool = False, pwcacheexpire: int = 5, timeout: int = 5,
               pwconfigexpire: int = 5, host: str = GW_IP) - Initialize TEDAPI
-    
+
  Parameters:
     gw_pwd - Powerwall Gateway Password
     debug - Enable Debug Output
@@ -156,7 +156,7 @@ class TEDAPI:
     def get_config(self,force=False):
         """
         Get the Powerwall Gateway Configuration
-        
+
         Payload:
         {
             "auto_meter_update": true,
@@ -663,7 +663,7 @@ class TEDAPI:
                 "POD_nom_full_pack_energy": 0.0,
                 "POD_nom_energy_to_be_charged": 0.0,
             }
-        }   
+        }
         """
         # Check Connection
         if not self.din:
@@ -845,7 +845,7 @@ class TEDAPI:
         pb.message.payload.send.payload.text = " query ComponentsQuery (\n  $pchComponentsFilter: ComponentFilter,\n  $pchSignalNames: [String!],\n  $pwsComponentsFilter: ComponentFilter,\n  $pwsSignalNames: [String!],\n  $bmsComponentsFilter: ComponentFilter,\n  $bmsSignalNames: [String!],\n  $hvpComponentsFilter: ComponentFilter,\n  $hvpSignalNames: [String!],\n  $baggrComponentsFilter: ComponentFilter,\n  $baggrSignalNames: [String!],\n  ) {\n  # TODO STST-57686: Introduce GraphQL fragments to shorten\n  pw3Can {\n    firmwareUpdate {\n      isUpdating\n      progress {\n         updating\n         numSteps\n         currentStep\n         currentStepProgress\n         progress\n      }\n    }\n  }\n  components {\n    pws: components(filter: $pwsComponentsFilter) {\n      signals(names: $pwsSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    pch: components(filter: $pchComponentsFilter) {\n      signals(names: $pchSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    bms: components(filter: $bmsComponentsFilter) {\n      signals(names: $bmsSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    hvp: components(filter: $hvpComponentsFilter) {\n      partNumber\n      serialNumber\n      signals(names: $hvpSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    baggr: components(filter: $baggrComponentsFilter) {\n      signals(names: $baggrSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n  }\n}\n"
         pb.message.payload.send.code = b'0\201\210\002B\000\270q\354>\243m\325p\371S\253\231\346~:\032\216~\242\263\207\017L\273O\203u\241\270\333w\233\354\276\246h\262\243\255\261\007\202D\277\353x\023O\022\303\216\264\010-\'i6\360>B\237\236\304\244m\002B\001\023Pk\033)\277\236\342R\264\247g\260u\036\023\3662\354\242\353\035\221\234\027\245\321J\342\345\037q\262O\3446-\353\315m1\237zai0\341\207C4\307\300Z\177@h\335\327\0239\252f\n\206W'
         pb.message.payload.send.b.value = "{\"pwsComponentsFilter\":{\"types\":[\"PW3SAF\"]},\"pwsSignalNames\":[\"PWS_SelfTest\",\"PWS_PeImpTestState\",\"PWS_PvIsoTestState\",\"PWS_RelaySelfTest_State\",\"PWS_MciTestState\",\"PWS_appGitHash\",\"PWS_ProdSwitch_State\"],\"pchComponentsFilter\":{\"types\":[\"PCH\"]},\"pchSignalNames\":[\"PCH_State\",\"PCH_PvState_A\",\"PCH_PvState_B\",\"PCH_PvState_C\",\"PCH_PvState_D\",\"PCH_PvState_E\",\"PCH_PvState_F\",\"PCH_AcFrequency\",\"PCH_AcVoltageAB\",\"PCH_AcVoltageAN\",\"PCH_AcVoltageBN\",\"PCH_packagePartNumber_1_7\",\"PCH_packagePartNumber_8_14\",\"PCH_packagePartNumber_15_20\",\"PCH_packageSerialNumber_1_7\",\"PCH_packageSerialNumber_8_14\",\"PCH_PvVoltageA\",\"PCH_PvVoltageB\",\"PCH_PvVoltageC\",\"PCH_PvVoltageD\",\"PCH_PvVoltageE\",\"PCH_PvVoltageF\",\"PCH_PvCurrentA\",\"PCH_PvCurrentB\",\"PCH_PvCurrentC\",\"PCH_PvCurrentD\",\"PCH_PvCurrentE\",\"PCH_PvCurrentF\",\"PCH_BatteryPower\",\"PCH_AcRealPowerAB\",\"PCH_SlowPvPowerSum\",\"PCH_AcMode\",\"PCH_AcFrequency\",\"PCH_DcdcState_A\",\"PCH_DcdcState_B\",\"PCH_appGitHash\"],\"bmsComponentsFilter\":{\"types\":[\"PW3BMS\"]},\"bmsSignalNames\":[\"BMS_nominalEnergyRemaining\",\"BMS_nominalFullPackEnergy\",\"BMS_appGitHash\"],\"hvpComponentsFilter\":{\"types\":[\"PW3HVP\"]},\"hvpSignalNames\":[\"HVP_State\",\"HVP_appGitHash\"],\"baggrComponentsFilter\":{\"types\":[\"BAGGR\"]},\"baggrSignalNames\":[\"BAGGR_State\",\"BAGGR_OperationRequest\",\"BAGGR_NumBatteriesConnected\",\"BAGGR_NumBatteriesPresent\",\"BAGGR_NumBatteriesExpected\",\"BAGGR_LOG_BattConnectionStatus0\",\"BAGGR_LOG_BattConnectionStatus1\",\"BAGGR_LOG_BattConnectionStatus2\",\"BAGGR_LOG_BattConnectionStatus3\"]}"
-        pb.tail.value = 2   
+        pb.tail.value = 2
         url = f'https://{self.gw_ip}/tedapi/device/{din}/v1'
         try:
             # Set lock
@@ -913,7 +913,7 @@ class TEDAPI:
 
     def current_power(self, location=None, force=False):
         """
-        Get the current power in watts for a location: 
+        Get the current power in watts for a location:
             BATTERY, SITE, LOAD, SOLAR, SOLAR_RGM, GENERATOR, CONDUCTOR
         """
         status = self.get_status(force)
@@ -962,7 +962,7 @@ class TEDAPI:
 
     def vitals(self, force=False):
         """
-        Use tedapi data to create a vitals API dictionary 
+        Use tedapi data to create a vitals API dictionary
         """
         def calculate_ac_power(Vpeak, Ipeak):
             Vrms = Vpeak / math.sqrt(2)

--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -1,15 +1,15 @@
 import json
 import logging
-from typing import Optional, Union
 import math
+from typing import Optional, Union
 
-from pypowerwall.tedapi import TEDAPI, GW_IP, lookup
+from pypowerwall import __version__
+from pypowerwall.pypowerwall_base import PyPowerwallBase
+from pypowerwall.tedapi import GW_IP, TEDAPI, lookup
 from pypowerwall.tedapi.decorators import not_implemented_mock_data
-from pypowerwall.tedapi.exceptions import * # pylint: disable=unused-wildcard-import
+from pypowerwall.tedapi.exceptions import *  # pylint: disable=unused-wildcard-import
 from pypowerwall.tedapi.mock_data import *  # pylint: disable=unused-wildcard-import
 from pypowerwall.tedapi.stubs import *
-from pypowerwall.pypowerwall_base import PyPowerwallBase
-from pypowerwall import __version__
 
 log = logging.getLogger(__name__)
 
@@ -215,7 +215,7 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
                 "version": firmware_version,
                 "git_hash": None,
                 "commission_count": 0,
-                "device_type": None, 
+                "device_type": None,
                 "teg_type": "unknown",
                 "sync_type": "unknown",
                 "cellular_disabled": False,
@@ -223,18 +223,22 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
             }
         return data
 
-    def get_api_system_status_grid_status(self, **kwargs) -> Optional[Union[dict, list, str, bytes]]:
-        force = kwargs.get('force', False)
-        status = self.tedapi.get_status(force=force)
+    def extract_grid_status(self, status) -> str:
+        alerts = lookup(status, ["control", "alerts", "active"])
+        if "SystemConnectedToGrid" in alerts:
+            return "SystemGridConnected"
         grid_state = lookup(status, ["esCan", "bus", "ISLANDER", "ISLAND_GridConnection", "ISLAND_GridConnected"])
         if not grid_state:
             return None
         if grid_state == "ISLAND_GridConnected_Connected":
-            grid_status = "SystemGridConnected"
-        else:
-            grid_status = "SystemIslandedActive"
+            return "SystemGridConnected"
+        return "SystemIslandedActive"
+
+    def get_api_system_status_grid_status(self, **kwargs) -> Optional[Union[dict, list, str, bytes]]:
+        force = kwargs.get('force', False)
+        status = self.tedapi.get_status(force=force)
         data = {
-            "grid_status": grid_status,
+            "grid_status": self.extract_grid_status(status),
             "grid_services_active": None, # TODO
         }
         return data
@@ -409,13 +413,7 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
         if not isinstance(status, dict) or not isinstance(config, dict):
             return None
         status = self.tedapi.get_status(force=force)
-        grid_state = lookup(status, ["esCan", "bus", "ISLANDER", "ISLAND_GridConnection", "ISLAND_GridConnected"])
-        if not grid_state:
-            grid_status = None
-        elif grid_state == "ISLAND_GridConnected_Connected":
-            grid_status = "SystemGridConnected"
-        else:
-            grid_status = "SystemIslandedActive"
+        grid_status = self.extract_grid_status(status)
         total_pack_energy = lookup(status, ["control", "systemStatus", "nominalFullPackEnergyWh"]) or 0
         energy_left = lookup(status, ["control", "systemStatus", "nominalEnergyRemainingWh"]) or 0
         batteryBlocks = lookup(config, ["control", "batteryBlocks"]) or []
@@ -558,6 +556,7 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
 
 if __name__ == "__main__":
     import sys
+
     # Command Line Debugging Mode
     print(f"pyPowerwall - Powerwall Gateway TEDAPI Test [v{__version__}]")
     set_debug(quiet=False, debug=True, color=True)


### PR DESCRIPTION
In certain TEDAPI edge cases the grid status was not correct. This fixes it so that "SystemConnectedToGrid" is the only alert that appears if the Tesla alerts API contains such a thing. It also removes risk of duplicates and normalizes this particular alert.