### PR TITLE
Alerts in extract_grid_status can be None. Block this edge case.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.12.7 - SystemConnectedToGrid Fix
+
+* Alerts in extract_grid_status can be None. Block this edge case. #145
+
 ## v0.12.6 - Aggregates Data
 
 * Updated aggregates call to include site current (METER_X) and external PV inverter data in solar (METER_Y). Reported in Issue #140.

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,2 +1,2 @@
-pypowerwall==0.12.6
+pypowerwall==0.12.7
 bs4==0.0.2

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -88,7 +88,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 12, 6)
+version_tuple = (0, 12, 7)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -224,7 +224,7 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
         return data
 
     def extract_grid_status(self, status) -> str:
-        alerts = lookup(status, ["control", "alerts", "active"])
+        alerts = lookup(status, ["control", "alerts", "active"]) or []
         if "SystemConnectedToGrid" in alerts:
             return "SystemGridConnected"
         grid_state = lookup(status, ["esCan", "bus", "ISLANDER", "ISLAND_GridConnection", "ISLAND_GridConnected"])


### PR DESCRIPTION
While doing some testing I saw this error:

```
    if "SystemConnectedToGrid" in alerts:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

I'm not sure what triggered it, but it's an edge case that needs to be fixed.