### PR TITLE
Add thread locking to TEDAPI

### DIFF
--- a/pypowerwall/api_lock.py
+++ b/pypowerwall/api_lock.py
@@ -1,0 +1,82 @@
+import logging
+import random
+import threading
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from typing import DefaultDict
+
+log = logging.getLogger(__name__)
+
+
+class ApiLockPool:
+    def __init__(self):
+        self._locks: DefaultDict[str, threading.Lock] = defaultdict(threading.Lock)
+        self._pool_lock = threading.Lock()
+
+    def get_lock(self, key: str) -> threading.Lock:
+        with self._pool_lock:
+            return self._locks[key]
+
+    def __getitem__(self, key: str) -> threading.Lock:
+        return self.get_lock(key)
+
+
+def acquire_with_exponential_backoff(
+    lock: threading.Lock,
+    timeout: float,
+    initial_delay: float = 0.1,
+    factor: int = 2,
+    max_delay: int = 2,
+    jitter: float = 0.1
+) -> bool:
+    """
+    Attempts to acquire a lock using exponential backoff with jitter.
+
+    This function repeatedly attempts to acquire the given lock without blocking.
+    If the lock is not immediately available, it waits for a delay period that increases
+    exponentially with each attempt, plus a random jitter to reduce contention. The process
+    continues until the lock is acquired or the total elapsed time exceeds the specified timeout.
+
+    Args:
+        lock (threading.Lock): The lock instance to acquire.
+        timeout (float): The total time (in seconds) to keep trying to acquire the lock.
+        initial_delay (float, optional): The initial delay (in seconds) before retrying after a failed attempt. Defaults to 0.1.
+        factor (int, optional): The multiplier for the delay after each failed attempt. Defaults to 2.
+        max_delay (int, optional): The maximum delay (in seconds) between retries. Defaults to 2.
+        jitter (float, optional): The maximum additional random delay (in seconds) added to each sleep interval. Defaults to 0.1.
+
+    Returns:
+        bool: True if the lock was acquired within the timeout period, otherwise False.
+    """
+    start_time = time.perf_counter()
+    delay = initial_delay
+
+    # Continue trying until the elapsed time exceeds the timeout
+    elapsed = time.perf_counter() - start_time
+    while elapsed < timeout:
+        if lock.acquire(blocking=False):
+            return True
+        remaining_time = timeout - elapsed
+        # Ensure we don't sleep past the timeout and add a bit of random jitter
+        sleep_time = min(delay, remaining_time) + random.uniform(0, jitter)
+        time.sleep(sleep_time)
+        delay = min(delay * factor, max_delay)
+        log.info(f"Timeout for {lock}")
+        elapsed = time.perf_counter() - start_time
+
+    return False
+
+
+@contextmanager
+def acquire_lock_with_backoff(lock, timeout, **backoff_kwargs):
+    """
+    Context manager for acquiring a lock using exponential backoff with jitter.
+    Raises TimeoutError if the lock is not acquired in the given timeout.
+    """
+    if not acquire_with_exponential_backoff(lock, timeout, **backoff_kwargs):
+        raise TimeoutError("Unable to acquire lock within the specified timeout.")
+    try:
+        yield
+    finally:
+        lock.release()

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -44,23 +44,30 @@
 """
 
 # Imports
-
+import json
 import logging
 import math
 import sys
 import time
-import json
+from http import HTTPStatus
+from typing import List
+
 import requests
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
+
 from pypowerwall import __version__
+from pypowerwall.api_lock import ApiLockPool, acquire_lock_with_backoff
+
 from . import tedapi_pb2
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+urllib3.disable_warnings(InsecureRequestWarning)
 
 # TEDAPI Fixed Gateway IP Address
 GW_IP = "192.168.91.1"
 
 # Rate Limit Codes
-BUSY_CODES = [429, 503]
+BUSY_CODES: List[HTTPStatus] = [HTTPStatus.TOO_MANY_REQUESTS, HTTPStatus.SERVICE_UNAVAILABLE]
 
 # Setup Logging
 log = logging.getLogger(__name__)
@@ -95,7 +102,7 @@ class TEDAPI:
         self.gw_ip = host
         self.din = None
         self.pw3 = False # Powerwall 3 Gateway only supports TEDAPI
-        self.apilock = {} # holds the api lock status
+        self.apilock = ApiLockPool()
         if not gw_pwd:
             raise ValueError("Missing gw_pwd")
         if self.debug:
@@ -141,10 +148,10 @@ class TEDAPI:
             self.pwcooldown = time.perf_counter() + 300
             log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
             return None
-        if r.status_code == 403:
+        if r.status_code == HTTPStatus.FORBIDDEN:
             log.error("Access Denied: Check your Gateway Password")
             return None
-        if r.status_code != 200:
+        if r.status_code != HTTPStatus.OK:
             log.error(f"Error fetching DIN: {r.status_code}")
             return None
         din = r.text
@@ -185,73 +192,61 @@ class TEDAPI:
         }
         """
         # Check for lock and wait if api request already sent
-        if 'config' in self.apilock:
-            locktime = time.perf_counter()
-            while self.apilock['config']:
-                time.sleep(0.2)
-                if time.perf_counter() >= locktime + self.timeout:
-                    log.debug(" -- tedapi: Timeout waiting for config (unable to acquire lock)")
+        data = None
+        with acquire_lock_with_backoff(self.apilock['config'], self.timeout):
+            # Check Cache
+            if not force and "config" in self.pwcachetime:
+                if time.time() - self.pwcachetime["config"] < self.pwconfigexpire:
+                    log.debug("Using Cached Payload")
+                    return self.pwcache["config"]
+            if not force and self.pwcooldown > time.perf_counter():
+                # Rate limited - return None
+                log.debug('Rate limit cooldown period - Pausing API calls')
+                return None
+            # Check Connection
+            if not self.din:
+                if not self.connect():
+                    log.error("Not Connected - Unable to get configuration")
                     return None
-        # Check Cache
-        if not force and "config" in self.pwcachetime:
-            if time.time() - self.pwcachetime["config"] < self.pwconfigexpire:
-                log.debug("Using Cached Payload")
-                return self.pwcache["config"]
-        if not force and self.pwcooldown > time.perf_counter():
-            # Rate limited - return None
-            log.debug('Rate limit cooldown period - Pausing API calls')
-            return None
-        # Check Connection
-        if not self.din:
-            if not self.connect():
-                log.error("Not Connected - Unable to get configuration")
-                return None
-        # Fetch Configuration from Powerwall
-        log.debug("Get Configuration from Powerwall")
-        # Build Protobuf to fetch config
-        pb = tedapi_pb2.Message()
-        pb.message.deliveryChannel = 1
-        pb.message.sender.local = 1
-        pb.message.recipient.din = self.din  # DIN of Powerwall
-        pb.message.config.send.num = 1
-        pb.message.config.send.file = "config.json"
-        pb.tail.value = 1
-        url = f'https://{self.gw_ip}/tedapi/v1'
-        try:
-            # Set lock
-            self.apilock['config'] = True
-            r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
-                                          headers={'Content-type': 'application/octet-string'},
-                                          data=pb.SerializeToString(), timeout=self.timeout)
-            log.debug(f"Response Code: {r.status_code}")
-            if r.status_code in BUSY_CODES:
-                # Rate limited - Switch to cooldown mode for 5 minutes
-                self.pwcooldown = time.perf_counter() + 300
-                log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
-                self.apilock['config'] = False
-                return None
-            if r.status_code != 200:
-                log.error(f"Error fetching config: {r.status_code}")
-                self.apilock['config'] = False
-                return None
-            # Decode response
-            tedapi = tedapi_pb2.Message()
-            tedapi.ParseFromString(r.content)
-            payload = tedapi.message.config.recv.file.text
+            # Fetch Configuration from Powerwall
+            log.debug("Get Configuration from Powerwall")
+            # Build Protobuf to fetch config
+            pb = tedapi_pb2.Message()
+            pb.message.deliveryChannel = 1
+            pb.message.sender.local = 1
+            pb.message.recipient.din = self.din  # DIN of Powerwall
+            pb.message.config.send.num = 1
+            pb.message.config.send.file = "config.json"
+            pb.tail.value = 1
+            url = f'https://{self.gw_ip}/tedapi/v1'
             try:
-                data = json.loads(payload)
-            except json.JSONDecodeError as e:
-                log.error(f"Error Decoding JSON: {e}")
-                data = {}
-            log.debug(f"Configuration: {data}")
-            self.pwcachetime["config"] = time.time()
-            self.pwcache["config"] = data
-        except Exception as e:
-            log.error(f"Error fetching config: {e}")
-            data = None
-        finally:
-            # Release lock
-            self.apilock['config'] = False
+                r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
+                                            headers={'Content-type': 'application/octet-string'},
+                                            data=pb.SerializeToString(), timeout=self.timeout)
+                log.debug(f"Response Code: {r.status_code}")
+                if r.status_code in BUSY_CODES:
+                    # Rate limited - Switch to cooldown mode for 5 minutes
+                    self.pwcooldown = time.perf_counter() + 300
+                    log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
+                    return None
+                if r.status_code != HTTPStatus.OK:
+                    log.error(f"Error fetching config: {r.status_code}")
+                    return None
+                # Decode response
+                tedapi = tedapi_pb2.Message()
+                tedapi.ParseFromString(r.content)
+                payload = tedapi.message.config.recv.file.text
+                try:
+                    data = json.loads(payload)
+                except json.JSONDecodeError as e:
+                    log.error(f"Error Decoding JSON: {e}")
+                    data = {}
+                log.debug(f"Configuration: {data}")
+                self.pwcachetime["config"] = time.time()
+                self.pwcache["config"] = data
+            except Exception as e:
+                log.error(f"Error fetching config: {e}")
+                data = None
         return data
 
     def get_status(self, force=False):
@@ -293,79 +288,67 @@ class TEDAPI:
             "pw3Can": {},
             "system": {}
         }
-
         """
         # Check for lock and wait if api request already sent
-        if 'status' in self.apilock:
-            locktime = time.perf_counter()
-            while self.apilock['status']:
-                time.sleep(0.2)
-                if time.perf_counter() >= locktime + self.timeout:
-                    log.debug(" -- tedapi: Timeout waiting for status (unable to acquire lock)")
+        data = None
+        with acquire_lock_with_backoff(self.apilock['status'], self.timeout):
+            # Check Cache
+            if not force and "status" in self.pwcachetime:
+                if time.time() - self.pwcachetime["status"] < self.pwcacheexpire:
+                    log.debug("Using Cached Payload")
+                    return self.pwcache["status"]
+            if not force and self.pwcooldown > time.perf_counter():
+                # Rate limited - return None
+                log.debug('Rate limit cooldown period - Pausing API calls')
+                return None
+            # Check Connection
+            if not self.din:
+                if not self.connect():
+                    log.error("Not Connected - Unable to get status")
                     return None
-        # Check Cache
-        if not force and "status" in self.pwcachetime:
-            if time.time() - self.pwcachetime["status"] < self.pwcacheexpire:
-                log.debug("Using Cached Payload")
-                return self.pwcache["status"]
-        if not force and self.pwcooldown > time.perf_counter():
-            # Rate limited - return None
-            log.debug('Rate limit cooldown period - Pausing API calls')
-            return None
-        # Check Connection
-        if not self.din:
-            if not self.connect():
-                log.error("Not Connected - Unable to get status")
-                return None
-        # Fetch Current Status from Powerwall
-        log.debug("Get Status from Powerwall")
-        # Build Protobuf to fetch status
-        pb = tedapi_pb2.Message()
-        pb.message.deliveryChannel = 1
-        pb.message.sender.local = 1
-        pb.message.recipient.din = self.din  # DIN of Powerwall
-        pb.message.payload.send.num = 2
-        pb.message.payload.send.payload.value = 1
-        pb.message.payload.send.payload.text = " query DeviceControllerQuery {\n  control {\n    systemStatus {\n        nominalFullPackEnergyWh\n        nominalEnergyRemainingWh\n    }\n    islanding {\n        customerIslandMode\n        contactorClosed\n        microGridOK\n        gridOK\n    }\n    meterAggregates {\n      location\n      realPowerW\n    }\n    alerts {\n      active\n    },\n    siteShutdown {\n      isShutDown\n      reasons\n    }\n    batteryBlocks {\n      din\n      disableReasons\n    }\n    pvInverters {\n      din\n      disableReasons\n    }\n  }\n  system {\n    time\n    sitemanagerStatus {\n      isRunning\n    }\n    updateUrgencyCheck  {\n      urgency\n      version {\n        version\n        gitHash\n      }\n      timestamp\n    }\n  }\n  neurio {\n    isDetectingWiredMeters\n    readings {\n      serial\n      dataRead {\n        voltageV\n        realPowerW\n        reactivePowerVAR\n        currentA\n      }\n      timestamp\n    }\n    pairings {\n      serial\n      shortId\n      status\n      errors\n      macAddress\n      isWired\n      modbusPort\n      modbusId\n      lastUpdateTimestamp\n    }\n  }\n  pw3Can {\n    firmwareUpdate {\n      isUpdating\n      progress {\n         updating\n         numSteps\n         currentStep\n         currentStepProgress\n         progress\n      }\n    }\n  }\n  esCan {\n    bus {\n      PVAC {\n        packagePartNumber\n        packageSerialNumber\n        subPackagePartNumber\n        subPackageSerialNumber\n        PVAC_Status {\n          isMIA\n          PVAC_Pout\n          PVAC_State\n          PVAC_Vout\n          PVAC_Fout\n        }\n        PVAC_InfoMsg {\n          PVAC_appGitHash\n        }\n        PVAC_Logging {\n          isMIA\n          PVAC_PVCurrent_A\n          PVAC_PVCurrent_B\n          PVAC_PVCurrent_C\n          PVAC_PVCurrent_D\n          PVAC_PVMeasuredVoltage_A\n          PVAC_PVMeasuredVoltage_B\n          PVAC_PVMeasuredVoltage_C\n          PVAC_PVMeasuredVoltage_D\n          PVAC_VL1Ground\n          PVAC_VL2Ground\n        }\n        alerts {\n          isComplete\n          isMIA\n          active\n        }\n      }\n      PINV {\n        PINV_Status {\n          isMIA\n          PINV_Fout\n          PINV_Pout\n          PINV_Vout\n          PINV_State\n          PINV_GridState\n        }\n        PINV_AcMeasurements {\n          isMIA\n          PINV_VSplit1\n          PINV_VSplit2\n        }\n        PINV_PowerCapability {\n          isComplete\n          isMIA\n          PINV_Pnom\n        }\n        alerts {\n          isComplete\n          isMIA\n          active\n        }\n      }\n      PVS {\n        PVS_Status {\n          isMIA\n          PVS_State\n          PVS_vLL\n          PVS_StringA_Connected\n          PVS_StringB_Connected\n          PVS_StringC_Connected\n          PVS_StringD_Connected\n          PVS_SelfTestState\n        }\n        alerts {\n          isComplete\n          isMIA\n          active\n        }\n      }\n      THC {\n        packagePartNumber\n        packageSerialNumber\n        THC_InfoMsg {\n          isComplete\n          isMIA\n          THC_appGitHash\n        }\n        THC_Logging {\n          THC_LOG_PW_2_0_EnableLineState\n        }\n      }\n      POD {\n        POD_EnergyStatus {\n          isMIA\n          POD_nom_energy_remaining\n          POD_nom_full_pack_energy\n        }\n        POD_InfoMsg {\n            POD_appGitHash\n        }\n      }\n      MSA {\n        packagePartNumber\n        packageSerialNumber\n        MSA_InfoMsg {\n          isMIA\n          MSA_appGitHash\n          MSA_assemblyId\n        }\n        METER_Z_AcMeasurements {\n          isMIA\n          lastRxTime\n          METER_Z_CTA_InstRealPower\n          METER_Z_CTA_InstReactivePower\n          METER_Z_CTA_I\n          METER_Z_VL1G\n          METER_Z_CTB_InstRealPower\n          METER_Z_CTB_InstReactivePower\n          METER_Z_CTB_I\n          METER_Z_VL2G\n        }\n        MSA_Status {\n          lastRxTime\n        }\n      }\n      SYNC {\n        packagePartNumber\n        packageSerialNumber\n        SYNC_InfoMsg {\n          isMIA\n          SYNC_appGitHash\n        }\n        METER_X_AcMeasurements {\n          isMIA\n          isComplete\n          lastRxTime\n          METER_X_CTA_InstRealPower\n          METER_X_CTA_InstReactivePower\n          METER_X_CTA_I\n          METER_X_VL1N\n          METER_X_CTB_InstRealPower\n          METER_X_CTB_InstReactivePower\n          METER_X_CTB_I\n          METER_X_VL2N\n          METER_X_CTC_InstRealPower\n          METER_X_CTC_InstReactivePower\n          METER_X_CTC_I\n          METER_X_VL3N\n        }\n        METER_Y_AcMeasurements {\n          isMIA\n          isComplete\n          lastRxTime\n          METER_Y_CTA_InstRealPower\n          METER_Y_CTA_InstReactivePower\n          METER_Y_CTA_I\n          METER_Y_VL1N\n          METER_Y_CTB_InstRealPower\n          METER_Y_CTB_InstReactivePower\n          METER_Y_CTB_I\n          METER_Y_VL2N\n          METER_Y_CTC_InstRealPower\n          METER_Y_CTC_InstReactivePower\n          METER_Y_CTC_I\n          METER_Y_VL3N\n        }\n        SYNC_Status {\n          lastRxTime\n        }\n      }\n      ISLANDER {\n        ISLAND_GridConnection {\n          ISLAND_GridConnected\n          isComplete\n        }\n        ISLAND_AcMeasurements {\n          ISLAND_VL1N_Main\n          ISLAND_FreqL1_Main\n          ISLAND_VL2N_Main\n          ISLAND_FreqL2_Main\n          ISLAND_VL3N_Main\n          ISLAND_FreqL3_Main\n          ISLAND_VL1N_Load\n          ISLAND_FreqL1_Load\n          ISLAND_VL2N_Load\n          ISLAND_FreqL2_Load\n          ISLAND_VL3N_Load\n          ISLAND_FreqL3_Load\n          ISLAND_GridState\n          lastRxTime\n          isComplete\n          isMIA\n        }\n      }\n    }\n    enumeration {\n      inProgress\n      numACPW\n      numPVI\n    }\n    firmwareUpdate {\n      isUpdating\n      powerwalls {\n        updating\n        numSteps\n        currentStep\n        currentStepProgress\n        progress\n      }\n      msa {\n        updating\n        numSteps\n        currentStep\n        currentStepProgress\n        progress\n      }\n      sync {\n        updating\n        numSteps\n        currentStep\n        currentStepProgress\n        progress\n      }\n      pvInverters {\n        updating\n        numSteps\n        currentStep\n        currentStepProgress\n        progress\n      }\n    }\n    phaseDetection {\n      inProgress\n      lastUpdateTimestamp\n      powerwalls {\n        din\n        progress\n        phase\n      }\n    }\n    inverterSelfTests {\n      isRunning\n      isCanceled\n      pinvSelfTestsResults {\n        din\n        overall {\n          status\n          test\n          summary\n          setMagnitude\n          setTime\n          tripMagnitude\n          tripTime\n          accuracyMagnitude\n          accuracyTime\n          currentMagnitude\n          timestamp\n          lastError\n        }\n        testResults {\n          status\n          test\n          summary\n          setMagnitude\n          setTime\n          tripMagnitude\n          tripTime\n          accuracyMagnitude\n          accuracyTime\n          currentMagnitude\n          timestamp\n          lastError\n        }\n      }\n    }\n  }\n}\n"
-        pb.message.payload.send.code = b'0\201\206\002A\024\261\227\245\177\255\265\272\321r\032\250\275j\305\030\2300\266\022B\242\264pO\262\024vd\267\316\032\f\376\322V\001\f\177*\366\345\333g_/`\v\026\225_qc\023$\323\216y\276~\335A1\022x\002Ap\a_\264\037]\304>\362\356\005\245V\301\177*\b\307\016\246]\037\202\242\353I~\332\317\021\336\006\033q\317\311\264\315\374\036\365s\272\225\215#o!\315z\353\345z\226\365\341\f\265\256r\373\313/\027\037'
-        pb.message.payload.send.b.value = "{}"
-        pb.tail.value = 1
-        url = f'https://{self.gw_ip}/tedapi/v1'
-        try:
-            # Set lock
-            self.apilock['status'] = True
-            r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
-                                          headers={'Content-type': 'application/octet-string'},
-                                          data=pb.SerializeToString(), timeout=self.timeout)
-            log.debug(f"Response Code: {r.status_code}")
-            if r.status_code in BUSY_CODES:
-                # Rate limited - Switch to cooldown mode for 5 minutes
-                self.pwcooldown = time.perf_counter() + 300
-                log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
-                self.apilock['status'] = False
-                return None
-            if r.status_code != 200:
-                log.error(f"Error fetching status: {r.status_code}")
-                self.apilock['status'] = False
-                return None
-            # Decode response
-            tedapi = tedapi_pb2.Message()
-            tedapi.ParseFromString(r.content)
-            payload = tedapi.message.payload.recv.text
+            # Fetch Current Status from Powerwall
+            log.debug("Get Status from Powerwall")
+            # Build Protobuf to fetch status
+            pb = tedapi_pb2.Message()
+            pb.message.deliveryChannel = 1
+            pb.message.sender.local = 1
+            pb.message.recipient.din = self.din  # DIN of Powerwall
+            pb.message.payload.send.num = 2
+            pb.message.payload.send.payload.value = 1
+            pb.message.payload.send.payload.text = " query DeviceControllerQuery {\n  control {\n    systemStatus {\n        nominalFullPackEnergyWh\n        nominalEnergyRemainingWh\n    }\n    islanding {\n        customerIslandMode\n        contactorClosed\n        microGridOK\n        gridOK\n    }\n    meterAggregates {\n      location\n      realPowerW\n    }\n    alerts {\n      active\n    },\n    siteShutdown {\n      isShutDown\n      reasons\n    }\n    batteryBlocks {\n      din\n      disableReasons\n    }\n    pvInverters {\n      din\n      disableReasons\n    }\n  }\n  system {\n    time\n    sitemanagerStatus {\n      isRunning\n    }\n    updateUrgencyCheck  {\n      urgency\n      version {\n        version\n        gitHash\n      }\n      timestamp\n    }\n  }\n  neurio {\n    isDetectingWiredMeters\n    readings {\n      serial\n      dataRead {\n        voltageV\n        realPowerW\n        reactivePowerVAR\n        currentA\n      }\n      timestamp\n    }\n    pairings {\n      serial\n      shortId\n      status\n      errors\n      macAddress\n      isWired\n      modbusPort\n      modbusId\n      lastUpdateTimestamp\n    }\n  }\n  pw3Can {\n    firmwareUpdate {\n      isUpdating\n      progress {\n         updating\n         numSteps\n         currentStep\n         currentStepProgress\n         progress\n      }\n    }\n  }\n  esCan {\n    bus {\n      PVAC {\n        packagePartNumber\n        packageSerialNumber\n        subPackagePartNumber\n        subPackageSerialNumber\n        PVAC_Status {\n          isMIA\n          PVAC_Pout\n          PVAC_State\n          PVAC_Vout\n          PVAC_Fout\n        }\n        PVAC_InfoMsg {\n          PVAC_appGitHash\n        }\n        PVAC_Logging {\n          isMIA\n          PVAC_PVCurrent_A\n          PVAC_PVCurrent_B\n          PVAC_PVCurrent_C\n          PVAC_PVCurrent_D\n          PVAC_PVMeasuredVoltage_A\n          PVAC_PVMeasuredVoltage_B\n          PVAC_PVMeasuredVoltage_C\n          PVAC_PVMeasuredVoltage_D\n          PVAC_VL1Ground\n          PVAC_VL2Ground\n        }\n        alerts {\n          isComplete\n          isMIA\n          active\n        }\n      }\n      PINV {\n        PINV_Status {\n          isMIA\n          PINV_Fout\n          PINV_Pout\n          PINV_Vout\n          PINV_State\n          PINV_GridState\n        }\n        PINV_AcMeasurements {\n          isMIA\n          PINV_VSplit1\n          PINV_VSplit2\n        }\n        PINV_PowerCapability {\n          isComplete\n          isMIA\n          PINV_Pnom\n        }\n        alerts {\n          isComplete\n          isMIA\n          active\n        }\n      }\n      PVS {\n        PVS_Status {\n          isMIA\n          PVS_State\n          PVS_vLL\n          PVS_StringA_Connected\n          PVS_StringB_Connected\n          PVS_StringC_Connected\n          PVS_StringD_Connected\n          PVS_SelfTestState\n        }\n        alerts {\n          isComplete\n          isMIA\n          active\n        }\n      }\n      THC {\n        packagePartNumber\n        packageSerialNumber\n        THC_InfoMsg {\n          isComplete\n          isMIA\n          THC_appGitHash\n        }\n        THC_Logging {\n          THC_LOG_PW_2_0_EnableLineState\n        }\n      }\n      POD {\n        POD_EnergyStatus {\n          isMIA\n          POD_nom_energy_remaining\n          POD_nom_full_pack_energy\n        }\n        POD_InfoMsg {\n            POD_appGitHash\n        }\n      }\n      MSA {\n        packagePartNumber\n        packageSerialNumber\n        MSA_InfoMsg {\n          isMIA\n          MSA_appGitHash\n          MSA_assemblyId\n        }\n        METER_Z_AcMeasurements {\n          isMIA\n          lastRxTime\n          METER_Z_CTA_InstRealPower\n          METER_Z_CTA_InstReactivePower\n          METER_Z_CTA_I\n          METER_Z_VL1G\n          METER_Z_CTB_InstRealPower\n          METER_Z_CTB_InstReactivePower\n          METER_Z_CTB_I\n          METER_Z_VL2G\n        }\n        MSA_Status {\n          lastRxTime\n        }\n      }\n      SYNC {\n        packagePartNumber\n        packageSerialNumber\n        SYNC_InfoMsg {\n          isMIA\n          SYNC_appGitHash\n        }\n        METER_X_AcMeasurements {\n          isMIA\n          isComplete\n          lastRxTime\n          METER_X_CTA_InstRealPower\n          METER_X_CTA_InstReactivePower\n          METER_X_CTA_I\n          METER_X_VL1N\n          METER_X_CTB_InstRealPower\n          METER_X_CTB_InstReactivePower\n          METER_X_CTB_I\n          METER_X_VL2N\n          METER_X_CTC_InstRealPower\n          METER_X_CTC_InstReactivePower\n          METER_X_CTC_I\n          METER_X_VL3N\n        }\n        METER_Y_AcMeasurements {\n          isMIA\n          isComplete\n          lastRxTime\n          METER_Y_CTA_InstRealPower\n          METER_Y_CTA_InstReactivePower\n          METER_Y_CTA_I\n          METER_Y_VL1N\n          METER_Y_CTB_InstRealPower\n          METER_Y_CTB_InstReactivePower\n          METER_Y_CTB_I\n          METER_Y_VL2N\n          METER_Y_CTC_InstRealPower\n          METER_Y_CTC_InstReactivePower\n          METER_Y_CTC_I\n          METER_Y_VL3N\n        }\n        SYNC_Status {\n          lastRxTime\n        }\n      }\n      ISLANDER {\n        ISLAND_GridConnection {\n          ISLAND_GridConnected\n          isComplete\n        }\n        ISLAND_AcMeasurements {\n          ISLAND_VL1N_Main\n          ISLAND_FreqL1_Main\n          ISLAND_VL2N_Main\n          ISLAND_FreqL2_Main\n          ISLAND_VL3N_Main\n          ISLAND_FreqL3_Main\n          ISLAND_VL1N_Load\n          ISLAND_FreqL1_Load\n          ISLAND_VL2N_Load\n          ISLAND_FreqL2_Load\n          ISLAND_VL3N_Load\n          ISLAND_FreqL3_Load\n          ISLAND_GridState\n          lastRxTime\n          isComplete\n          isMIA\n        }\n      }\n    }\n    enumeration {\n      inProgress\n      numACPW\n      numPVI\n    }\n    firmwareUpdate {\n      isUpdating\n      powerwalls {\n        updating\n        numSteps\n        currentStep\n        currentStepProgress\n        progress\n      }\n      msa {\n        updating\n        numSteps\n        currentStep\n        currentStepProgress\n        progress\n      }\n      sync {\n        updating\n        numSteps\n        currentStep\n        currentStepProgress\n        progress\n      }\n      pvInverters {\n        updating\n        numSteps\n        currentStep\n        currentStepProgress\n        progress\n      }\n    }\n    phaseDetection {\n      inProgress\n      lastUpdateTimestamp\n      powerwalls {\n        din\n        progress\n        phase\n      }\n    }\n    inverterSelfTests {\n      isRunning\n      isCanceled\n      pinvSelfTestsResults {\n        din\n        overall {\n          status\n          test\n          summary\n          setMagnitude\n          setTime\n          tripMagnitude\n          tripTime\n          accuracyMagnitude\n          accuracyTime\n          currentMagnitude\n          timestamp\n          lastError\n        }\n        testResults {\n          status\n          test\n          summary\n          setMagnitude\n          setTime\n          tripMagnitude\n          tripTime\n          accuracyMagnitude\n          accuracyTime\n          currentMagnitude\n          timestamp\n          lastError\n        }\n      }\n    }\n  }\n}\n"
+            pb.message.payload.send.code = b'0\201\206\002A\024\261\227\245\177\255\265\272\321r\032\250\275j\305\030\2300\266\022B\242\264pO\262\024vd\267\316\032\f\376\322V\001\f\177*\366\345\333g_/`\v\026\225_qc\023$\323\216y\276~\335A1\022x\002Ap\a_\264\037]\304>\362\356\005\245V\301\177*\b\307\016\246]\037\202\242\353I~\332\317\021\336\006\033q\317\311\264\315\374\036\365s\272\225\215#o!\315z\353\345z\226\365\341\f\265\256r\373\313/\027\037'
+            pb.message.payload.send.b.value = "{}"
+            pb.tail.value = 1
+            url = f'https://{self.gw_ip}/tedapi/v1'
             try:
-                data = json.loads(payload)
-            except json.JSONDecodeError as e:
-                log.error(f"Error Decoding JSON: {e}")
-                data = {}
-            log.debug(f"Status: {data}")
-            self.pwcachetime["status"] = time.time()
-            self.pwcache["status"] = data
-        except Exception as e:
-            log.error(f"Error fetching status: {e}")
-            data = None
-        finally:
-            # Release lock
-            self.apilock['status'] = False
+                # Set lock
+                r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
+                                            headers={'Content-type': 'application/octet-string'},
+                                            data=pb.SerializeToString(), timeout=self.timeout)
+                log.debug(f"Response Code: {r.status_code}")
+                if r.status_code in BUSY_CODES:
+                    # Rate limited - Switch to cooldown mode for 5 minutes
+                    self.pwcooldown = time.perf_counter() + 300
+                    log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
+                    return None
+                if r.status_code != HTTPStatus.OK:
+                    log.error(f"Error fetching status: {r.status_code}")
+                    return None
+                # Decode response
+                tedapi = tedapi_pb2.Message()
+                tedapi.ParseFromString(r.content)
+                payload = tedapi.message.payload.recv.text
+                try:
+                    data = json.loads(payload)
+                except json.JSONDecodeError as e:
+                    log.error(f"Error Decoding JSON: {e}")
+                    data = {}
+                log.debug(f"Status: {data}")
+                self.pwcachetime["status"] = time.time()
+                self.pwcache["status"] = data
+            except Exception as e:
+                log.error(f"Error fetching status: {e}")
+                data = None
         return data
 
     def get_device_controller(self, force=False):
@@ -387,77 +370,66 @@ class TEDAPI:
         TODO: Refactor to combine tedapi queries
         """
         # Check for lock and wait if api request already sent
-        if 'controller' in self.apilock:
-            locktime = time.perf_counter()
-            while self.apilock['controller']:
-                time.sleep(0.2)
-                if time.perf_counter() >= locktime + self.timeout:
-                    log.debug(" -- tedapi: Timeout waiting for controller data (unable to acquire lock)")
+        data = None
+        with acquire_lock_with_backoff(self.apilock['controller'], self.timeout):
+            # Check Cache
+            if not force and "controller" in self.pwcachetime:
+                if time.time() - self.pwcachetime["controller"] < self.pwcacheexpire:
+                    log.debug("Using Cached Payload")
+                    return self.pwcache["controller"]
+            if not force and self.pwcooldown > time.perf_counter():
+                # Rate limited - return None
+                log.debug('Rate limit cooldown period - Pausing API calls')
+                return None
+            # Check Connection
+            if not self.din:
+                if not self.connect():
+                    log.error("Not Connected - Unable to get controller data")
                     return None
-        # Check Cache
-        if not force and "controller" in self.pwcachetime:
-            if time.time() - self.pwcachetime["controller"] < self.pwcacheexpire:
-                log.debug("Using Cached Payload")
-                return self.pwcache["controller"]
-        if not force and self.pwcooldown > time.perf_counter():
-            # Rate limited - return None
-            log.debug('Rate limit cooldown period - Pausing API calls')
-            return None
-        # Check Connection
-        if not self.din:
-            if not self.connect():
-                log.error("Not Connected - Unable to get controller data")
-                return None
-        # Fetch Current Status from Powerwall
-        log.debug("Get controller data from Powerwall")
-        # Build Protobuf to fetch controller data
-        pb = tedapi_pb2.Message()
-        pb.message.deliveryChannel = 1
-        pb.message.sender.local = 1
-        pb.message.recipient.din = self.din  # DIN of Powerwall
-        pb.message.payload.send.num = 2
-        pb.message.payload.send.payload.value = 1
-        pb.message.payload.send.payload.text = 'query DeviceControllerQuery($msaComp:ComponentFilter$msaSignals:[String!]){control{systemStatus{nominalFullPackEnergyWh nominalEnergyRemainingWh}islanding{customerIslandMode contactorClosed microGridOK gridOK disableReasons}meterAggregates{location realPowerW}alerts{active}siteShutdown{isShutDown reasons}batteryBlocks{din disableReasons}pvInverters{din disableReasons}}system{time supportMode{remoteService{isEnabled expiryTime sessionId}}sitemanagerStatus{isRunning}updateUrgencyCheck{urgency version{version gitHash}timestamp}}neurio{isDetectingWiredMeters readings{firmwareVersion serial dataRead{voltageV realPowerW reactivePowerVAR currentA}timestamp}pairings{serial shortId status errors macAddress hostname isWired modbusPort modbusId lastUpdateTimestamp}}teslaRemoteMeter{meters{din reading{timestamp firmwareVersion ctReadings{voltageV realPowerW reactivePowerVAR energyExportedWs energyImportedWs currentA}}firmwareUpdate{updating numSteps currentStep currentStepProgress progress}}detectedWired{din serialPort}}pw3Can{firmwareUpdate{isUpdating progress{updating numSteps currentStep currentStepProgress progress}}enumeration{inProgress}}esCan{bus{PVAC{packagePartNumber packageSerialNumber subPackagePartNumber subPackageSerialNumber PVAC_Status{isMIA PVAC_Pout PVAC_State PVAC_Vout PVAC_Fout}PVAC_InfoMsg{PVAC_appGitHash}PVAC_Logging{isMIA PVAC_PVCurrent_A PVAC_PVCurrent_B PVAC_PVCurrent_C PVAC_PVCurrent_D PVAC_PVMeasuredVoltage_A PVAC_PVMeasuredVoltage_B PVAC_PVMeasuredVoltage_C PVAC_PVMeasuredVoltage_D PVAC_VL1Ground PVAC_VL2Ground}alerts{isComplete isMIA active}}PINV{PINV_Status{isMIA PINV_Fout PINV_Pout PINV_Vout PINV_State PINV_GridState}PINV_AcMeasurements{isMIA PINV_VSplit1 PINV_VSplit2}PINV_PowerCapability{isComplete isMIA PINV_Pnom}alerts{isComplete isMIA active}}PVS{PVS_Status{isMIA PVS_State PVS_vLL PVS_StringA_Connected PVS_StringB_Connected PVS_StringC_Connected PVS_StringD_Connected PVS_SelfTestState}PVS_Logging{PVS_numStringsLockoutBits PVS_sbsComplete}alerts{isComplete isMIA active}}THC{packagePartNumber packageSerialNumber THC_InfoMsg{isComplete isMIA THC_appGitHash}THC_Logging{THC_LOG_PW_2_0_EnableLineState}}POD{POD_EnergyStatus{isMIA POD_nom_energy_remaining POD_nom_full_pack_energy}POD_InfoMsg{POD_appGitHash}}SYNC{packagePartNumber packageSerialNumber SYNC_InfoMsg{isMIA SYNC_appGitHash SYNC_assemblyId}METER_X_AcMeasurements{isMIA isComplete METER_X_CTA_InstRealPower METER_X_CTA_InstReactivePower METER_X_CTA_I METER_X_VL1N METER_X_CTB_InstRealPower METER_X_CTB_InstReactivePower METER_X_CTB_I METER_X_VL2N METER_X_CTC_InstRealPower METER_X_CTC_InstReactivePower METER_X_CTC_I METER_X_VL3N}METER_Y_AcMeasurements{isMIA isComplete METER_Y_CTA_InstRealPower METER_Y_CTA_InstReactivePower METER_Y_CTA_I METER_Y_VL1N METER_Y_CTB_InstRealPower METER_Y_CTB_InstReactivePower METER_Y_CTB_I METER_Y_VL2N METER_Y_CTC_InstRealPower METER_Y_CTC_InstReactivePower METER_Y_CTC_I METER_Y_VL3N}}ISLANDER{ISLAND_GridConnection{ISLAND_GridConnected isComplete}ISLAND_AcMeasurements{ISLAND_VL1N_Main ISLAND_FreqL1_Main ISLAND_VL2N_Main ISLAND_FreqL2_Main ISLAND_VL3N_Main ISLAND_FreqL3_Main ISLAND_VL1N_Load ISLAND_FreqL1_Load ISLAND_VL2N_Load ISLAND_FreqL2_Load ISLAND_VL3N_Load ISLAND_FreqL3_Load ISLAND_GridState isComplete isMIA}}}enumeration{inProgress numACPW numPVI}firmwareUpdate{isUpdating powerwalls{updating numSteps currentStep currentStepProgress progress}msa{updating numSteps currentStep currentStepProgress progress}msa1{updating numSteps currentStep currentStepProgress progress}sync{updating numSteps currentStep currentStepProgress progress}pvInverters{updating numSteps currentStep currentStepProgress progress}}phaseDetection{inProgress lastUpdateTimestamp powerwalls{din progress phase}}inverterSelfTests{isRunning isCanceled pinvSelfTestsResults{din overall{status test summary setMagnitude setTime tripMagnitude tripTime accuracyMagnitude accuracyTime currentMagnitude timestamp lastError}testResults{status test summary setMagnitude setTime tripMagnitude tripTime accuracyMagnitude accuracyTime currentMagnitude timestamp lastError}}}}components{msa:components(filter:$msaComp){partNumber serialNumber signals(names:$msaSignals){name value textValue boolValue timestamp}activeAlerts{name}}}ieee20305{longFormDeviceID polledResources{url name pollRateSeconds lastPolledTimestamp}controls{defaultControl{mRID setGradW opModEnergize opModMaxLimW opModImpLimW opModExpLimW opModGenLimW opModLoadLimW}activeControls{opModEnergize opModMaxLimW opModImpLimW opModExpLimW opModGenLimW opModLoadLimW}}registration{dateTimeRegistered pin}}}'
-        pb.message.payload.send.code = b'0\x81\x87\x02B\x01A\x95\x12\xe3B\xd1\xca\x1a\xd3\x00\xf6}\x0bE@/\x9a\x9f\xc0\r\x06%\xac,\x0ej!)\nd\xef\xe67\x8b\xafb\xd7\xf8&\x0b.\xc1\xac\xd9!\x1f\xd6\x83\xffkIm\xf3\\J\xd8\xeeiTY\xde\x7f\xc5xR\x02A\x1dC\x03H\xfb8"\xb0\xe4\xd6\x18\xde\x11\xc45\xb2\xa9VB\xa6J\x8f\x08\x9d\xba\x86\xf1 W\xcdJ\x8c\x02*\x05\x12\xcb{<\x9b\xc8g\xc9\x9d9\x8bR\xb3\x89\xb8\xf1\xf1\x0f\x0e\x16E\xed\xd7\xbf\xd5&)\x92.\x12'
-        pb.message.payload.send.b.value = '{"msaComp":{"types" :["PVS","PVAC", "TESYNC", "TEPINV", "TETHC", "STSTSM",  "TEMSA", "TEPINV" ]},\n\t"msaSignals":[\n\t"MSA_pcbaId",\n\t"MSA_usageId",\n\t"MSA_appGitHash",\n\t"MSA_HeatingRateOccurred",\n\t"THC_AmbientTemp",\n\t"METER_Z_CTA_InstRealPower",\n\t"METER_Z_CTA_InstReactivePower",\n\t"METER_Z_CTA_I",\n\t"METER_Z_VL1G",\n\t"METER_Z_CTB_InstRealPower",\n\t"METER_Z_CTB_InstReactivePower",\n\t"METER_Z_CTB_I",\n\t"METER_Z_VL2G"]}'
-        pb.tail.value = 1
-        url = f'https://{self.gw_ip}/tedapi/v1'
-        try:
-            # Set lock
-            self.apilock['controller'] = True
-            r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
-                                          headers={'Content-type': 'application/octet-string'},
-                                          data=pb.SerializeToString(), timeout=self.timeout)
-            log.debug(f"Response Code: {r.status_code}")
-            if r.status_code in BUSY_CODES:
-                # Rate limited - Switch to cooldown mode for 5 minutes
-                self.pwcooldown = time.perf_counter() + 300
-                log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
-                self.apilock['controller'] = False
-                return None
-            if r.status_code != 200:
-                log.error(f"Error fetching controller data: {r.status_code}")
-                self.apilock['controller'] = False
-                return None
-            # Decode response
-            tedapi = tedapi_pb2.Message()
-            tedapi.ParseFromString(r.content)
-            payload = tedapi.message.payload.recv.text
-            log.debug(f"Payload: {payload}")
+            # Fetch Current Status from Powerwall
+            log.debug("Get controller data from Powerwall")
+            # Build Protobuf to fetch controller data
+            pb = tedapi_pb2.Message()
+            pb.message.deliveryChannel = 1
+            pb.message.sender.local = 1
+            pb.message.recipient.din = self.din  # DIN of Powerwall
+            pb.message.payload.send.num = 2
+            pb.message.payload.send.payload.value = 1
+            pb.message.payload.send.payload.text = 'query DeviceControllerQuery($msaComp:ComponentFilter$msaSignals:[String!]){control{systemStatus{nominalFullPackEnergyWh nominalEnergyRemainingWh}islanding{customerIslandMode contactorClosed microGridOK gridOK disableReasons}meterAggregates{location realPowerW}alerts{active}siteShutdown{isShutDown reasons}batteryBlocks{din disableReasons}pvInverters{din disableReasons}}system{time supportMode{remoteService{isEnabled expiryTime sessionId}}sitemanagerStatus{isRunning}updateUrgencyCheck{urgency version{version gitHash}timestamp}}neurio{isDetectingWiredMeters readings{firmwareVersion serial dataRead{voltageV realPowerW reactivePowerVAR currentA}timestamp}pairings{serial shortId status errors macAddress hostname isWired modbusPort modbusId lastUpdateTimestamp}}teslaRemoteMeter{meters{din reading{timestamp firmwareVersion ctReadings{voltageV realPowerW reactivePowerVAR energyExportedWs energyImportedWs currentA}}firmwareUpdate{updating numSteps currentStep currentStepProgress progress}}detectedWired{din serialPort}}pw3Can{firmwareUpdate{isUpdating progress{updating numSteps currentStep currentStepProgress progress}}enumeration{inProgress}}esCan{bus{PVAC{packagePartNumber packageSerialNumber subPackagePartNumber subPackageSerialNumber PVAC_Status{isMIA PVAC_Pout PVAC_State PVAC_Vout PVAC_Fout}PVAC_InfoMsg{PVAC_appGitHash}PVAC_Logging{isMIA PVAC_PVCurrent_A PVAC_PVCurrent_B PVAC_PVCurrent_C PVAC_PVCurrent_D PVAC_PVMeasuredVoltage_A PVAC_PVMeasuredVoltage_B PVAC_PVMeasuredVoltage_C PVAC_PVMeasuredVoltage_D PVAC_VL1Ground PVAC_VL2Ground}alerts{isComplete isMIA active}}PINV{PINV_Status{isMIA PINV_Fout PINV_Pout PINV_Vout PINV_State PINV_GridState}PINV_AcMeasurements{isMIA PINV_VSplit1 PINV_VSplit2}PINV_PowerCapability{isComplete isMIA PINV_Pnom}alerts{isComplete isMIA active}}PVS{PVS_Status{isMIA PVS_State PVS_vLL PVS_StringA_Connected PVS_StringB_Connected PVS_StringC_Connected PVS_StringD_Connected PVS_SelfTestState}PVS_Logging{PVS_numStringsLockoutBits PVS_sbsComplete}alerts{isComplete isMIA active}}THC{packagePartNumber packageSerialNumber THC_InfoMsg{isComplete isMIA THC_appGitHash}THC_Logging{THC_LOG_PW_2_0_EnableLineState}}POD{POD_EnergyStatus{isMIA POD_nom_energy_remaining POD_nom_full_pack_energy}POD_InfoMsg{POD_appGitHash}}SYNC{packagePartNumber packageSerialNumber SYNC_InfoMsg{isMIA SYNC_appGitHash SYNC_assemblyId}METER_X_AcMeasurements{isMIA isComplete METER_X_CTA_InstRealPower METER_X_CTA_InstReactivePower METER_X_CTA_I METER_X_VL1N METER_X_CTB_InstRealPower METER_X_CTB_InstReactivePower METER_X_CTB_I METER_X_VL2N METER_X_CTC_InstRealPower METER_X_CTC_InstReactivePower METER_X_CTC_I METER_X_VL3N}METER_Y_AcMeasurements{isMIA isComplete METER_Y_CTA_InstRealPower METER_Y_CTA_InstReactivePower METER_Y_CTA_I METER_Y_VL1N METER_Y_CTB_InstRealPower METER_Y_CTB_InstReactivePower METER_Y_CTB_I METER_Y_VL2N METER_Y_CTC_InstRealPower METER_Y_CTC_InstReactivePower METER_Y_CTC_I METER_Y_VL3N}}ISLANDER{ISLAND_GridConnection{ISLAND_GridConnected isComplete}ISLAND_AcMeasurements{ISLAND_VL1N_Main ISLAND_FreqL1_Main ISLAND_VL2N_Main ISLAND_FreqL2_Main ISLAND_VL3N_Main ISLAND_FreqL3_Main ISLAND_VL1N_Load ISLAND_FreqL1_Load ISLAND_VL2N_Load ISLAND_FreqL2_Load ISLAND_VL3N_Load ISLAND_FreqL3_Load ISLAND_GridState isComplete isMIA}}}enumeration{inProgress numACPW numPVI}firmwareUpdate{isUpdating powerwalls{updating numSteps currentStep currentStepProgress progress}msa{updating numSteps currentStep currentStepProgress progress}msa1{updating numSteps currentStep currentStepProgress progress}sync{updating numSteps currentStep currentStepProgress progress}pvInverters{updating numSteps currentStep currentStepProgress progress}}phaseDetection{inProgress lastUpdateTimestamp powerwalls{din progress phase}}inverterSelfTests{isRunning isCanceled pinvSelfTestsResults{din overall{status test summary setMagnitude setTime tripMagnitude tripTime accuracyMagnitude accuracyTime currentMagnitude timestamp lastError}testResults{status test summary setMagnitude setTime tripMagnitude tripTime accuracyMagnitude accuracyTime currentMagnitude timestamp lastError}}}}components{msa:components(filter:$msaComp){partNumber serialNumber signals(names:$msaSignals){name value textValue boolValue timestamp}activeAlerts{name}}}ieee20305{longFormDeviceID polledResources{url name pollRateSeconds lastPolledTimestamp}controls{defaultControl{mRID setGradW opModEnergize opModMaxLimW opModImpLimW opModExpLimW opModGenLimW opModLoadLimW}activeControls{opModEnergize opModMaxLimW opModImpLimW opModExpLimW opModGenLimW opModLoadLimW}}registration{dateTimeRegistered pin}}}'
+            pb.message.payload.send.code = b'0\x81\x87\x02B\x01A\x95\x12\xe3B\xd1\xca\x1a\xd3\x00\xf6}\x0bE@/\x9a\x9f\xc0\r\x06%\xac,\x0ej!)\nd\xef\xe67\x8b\xafb\xd7\xf8&\x0b.\xc1\xac\xd9!\x1f\xd6\x83\xffkIm\xf3\\J\xd8\xeeiTY\xde\x7f\xc5xR\x02A\x1dC\x03H\xfb8"\xb0\xe4\xd6\x18\xde\x11\xc45\xb2\xa9VB\xa6J\x8f\x08\x9d\xba\x86\xf1 W\xcdJ\x8c\x02*\x05\x12\xcb{<\x9b\xc8g\xc9\x9d9\x8bR\xb3\x89\xb8\xf1\xf1\x0f\x0e\x16E\xed\xd7\xbf\xd5&)\x92.\x12'
+            pb.message.payload.send.b.value = '{"msaComp":{"types" :["PVS","PVAC", "TESYNC", "TEPINV", "TETHC", "STSTSM",  "TEMSA", "TEPINV" ]},\n\t"msaSignals":[\n\t"MSA_pcbaId",\n\t"MSA_usageId",\n\t"MSA_appGitHash",\n\t"MSA_HeatingRateOccurred",\n\t"THC_AmbientTemp",\n\t"METER_Z_CTA_InstRealPower",\n\t"METER_Z_CTA_InstReactivePower",\n\t"METER_Z_CTA_I",\n\t"METER_Z_VL1G",\n\t"METER_Z_CTB_InstRealPower",\n\t"METER_Z_CTB_InstReactivePower",\n\t"METER_Z_CTB_I",\n\t"METER_Z_VL2G"]}'
+            pb.tail.value = 1
+            url = f'https://{self.gw_ip}/tedapi/v1'
             try:
-                data = json.loads(payload)
-            except json.JSONDecodeError as e:
-                log.error(f"Error Decoding JSON: {e}")
-                data = {}
-            log.debug(f"Status: {data}")
-            self.pwcachetime["controller"] = time.time()
-            self.pwcache["controller"] = data
-        except Exception as e:
-            log.error(f"Error fetching controller data: {e}")
-            data = None
-        finally:
-            # Release lock
-            self.apilock['controller'] = False
+                # Set lock
+                r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
+                                            headers={'Content-type': 'application/octet-string'},
+                                            data=pb.SerializeToString(), timeout=self.timeout)
+                log.debug(f"Response Code: {r.status_code}")
+                if r.status_code in BUSY_CODES:
+                    # Rate limited - Switch to cooldown mode for 5 minutes
+                    self.pwcooldown = time.perf_counter() + 300
+                    log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
+                    return None
+                if r.status_code != HTTPStatus.OK:
+                    log.error(f"Error fetching controller data: {r.status_code}")
+                    return None
+                # Decode response
+                tedapi = tedapi_pb2.Message()
+                tedapi.ParseFromString(r.content)
+                payload = tedapi.message.payload.recv.text
+                log.debug(f"Payload: {payload}")
+                try:
+                    data = json.loads(payload)
+                except json.JSONDecodeError as e:
+                    log.error(f"Error Decoding JSON: {e}")
+                    data = {}
+                log.debug(f"Status: {data}")
+                self.pwcachetime["controller"] = time.time()
+                self.pwcache["controller"] = data
+            except Exception as e:
+                log.error(f"Error fetching controller data: {e}")
+                data = None
         return data
 
     def get_firmware_version(self, force=False, details=False):
@@ -470,92 +442,86 @@ class TEDAPI:
                             gateway part number, serial number, and wireless devices
         """
         payload = None
-        # Check Connection
-        if not self.din:
-            if not self.connect():
-                log.error("Not Connected - Unable to get firmware version")
+        with acquire_lock_with_backoff(self.apilock['firmware'], self.timeout):
+            # Check Connection
+            if not self.din:
+                if not self.connect():
+                    log.error("Not Connected - Unable to get firmware version")
+                    return None
+            # Check Cache
+            if not force and "firmware" in self.pwcachetime:
+                if time.time() - self.pwcachetime["firmware"] < self.pwcacheexpire:
+                    log.debug("Using Cached Firmware")
+                    return self.pwcache["firmware"]
+            if not force and self.pwcooldown > time.perf_counter():
+                # Rate limited - return None
+                log.debug('Rate limit cooldown period - Pausing API calls')
                 return None
-        # Check Cache
-        if not force and "firmware" in self.pwcachetime:
-            if time.time() - self.pwcachetime["firmware"] < self.pwcacheexpire:
-                log.debug("Using Cached Firmware")
-                return self.pwcache["firmware"]
-        if not force and self.pwcooldown > time.perf_counter():
-            # Rate limited - return None
-            log.debug('Rate limit cooldown period - Pausing API calls')
-            return None
-        # Fetch Current Status from Powerwall
-        log.debug("Get Firmware Version from Powerwall")
-        # Build Protobuf to fetch status
-        pb = tedapi_pb2.Message()
-        pb.message.deliveryChannel = 1
-        pb.message.sender.local = 1
-        pb.message.recipient.din = self.din  # DIN of Powerwall
-        pb.message.firmware.request = ""
-        pb.tail.value = 1
-        url = f'https://{self.gw_ip}/tedapi/v1'
-        try:
-            # Set lock
-            self.apilock['firmware'] = True
-            r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
-                                          headers={'Content-type': 'application/octet-string'},
-                                          data=pb.SerializeToString(), timeout=self.timeout)
-            log.debug(f"Response Code: {r.status_code}")
-            if r.status_code in BUSY_CODES:
-                # Rate limited - Switch to cooldown mode for 5 minutes
-                self.pwcooldown = time.perf_counter() + 300
-                log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
-                self.apilock['firmware'] = False
-                return None
-            if r.status_code != 200:
-                log.error(f"Error fetching firmware version: {r.status_code}")
-                self.apilock['firmware'] = False
-                return None
-            # Decode response
-            tedapi = tedapi_pb2.Message()
-            tedapi.ParseFromString(r.content)
-            firmware_version = tedapi.message.firmware.system.version.text
-            if details:
-                payload = {
-                    "system": {
-                        "gateway": {
-                            "partNumber": tedapi.message.firmware.system.gateway.partNumber,
-                            "serialNumber": tedapi.message.firmware.system.gateway.serialNumber
-                        },
-                        "din": tedapi.message.firmware.system.din,
-                        "version": {
-                            "text": tedapi.message.firmware.system.version.text,
-                            "githash": tedapi.message.firmware.system.version.githash
-                        },
-                        "five": tedapi.message.firmware.system.five,
-                        "six": tedapi.message.firmware.system.six,
-                        "wireless": {
-                            "device": []
+            # Fetch Current Status from Powerwall
+            log.debug("Get Firmware Version from Powerwall")
+            # Build Protobuf to fetch status
+            pb = tedapi_pb2.Message()
+            pb.message.deliveryChannel = 1
+            pb.message.sender.local = 1
+            pb.message.recipient.din = self.din  # DIN of Powerwall
+            pb.message.firmware.request = ""
+            pb.tail.value = 1
+            url = f'https://{self.gw_ip}/tedapi/v1'
+            try:
+                r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
+                                            headers={'Content-type': 'application/octet-string'},
+                                            data=pb.SerializeToString(), timeout=self.timeout)
+                log.debug(f"Response Code: {r.status_code}")
+                if r.status_code in BUSY_CODES:
+                    # Rate limited - Switch to cooldown mode for 5 minutes
+                    self.pwcooldown = time.perf_counter() + 300
+                    log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
+                    return None
+                if r.status_code != HTTPStatus.OK:
+                    log.error(f"Error fetching firmware version: {r.status_code}")
+                    return None
+                # Decode response
+                tedapi = tedapi_pb2.Message()
+                tedapi.ParseFromString(r.content)
+                firmware_version = tedapi.message.firmware.system.version.text
+                if details:
+                    payload = {
+                        "system": {
+                            "gateway": {
+                                "partNumber": tedapi.message.firmware.system.gateway.partNumber,
+                                "serialNumber": tedapi.message.firmware.system.gateway.serialNumber
+                            },
+                            "din": tedapi.message.firmware.system.din,
+                            "version": {
+                                "text": tedapi.message.firmware.system.version.text,
+                                "githash": tedapi.message.firmware.system.version.githash
+                            },
+                            "five": tedapi.message.firmware.system.five,
+                            "six": tedapi.message.firmware.system.six,
+                            "wireless": {
+                                "device": []
+                            }
                         }
                     }
-                }
-                try:
-                    for device in tedapi.message.firmware.system.wireless.device:
-                        payload["system"]["wireless"]["device"].append({
-                            "company": device.company.value,
-                            "model": device.model.value,
-                            "fcc_id": device.fcc_id.value,
-                            "ic": device.ic.value
-                        })
-                except Exception as e:
-                    log.debug(f"Error parsing wireless devices: {e}")
-                log.debug(f"Firmware Version: {payload}")
-            else:
-                payload = firmware_version
-            log.debug(f"Firmware Version: {firmware_version}")
-            self.pwcachetime["firmware"] = time.time()
-            self.pwcache["firmware"] = firmware_version
-        except Exception as e:
-            log.error(f"Error fetching firmware version: {e}")
-            payload = None
-        finally:
-            # Release lock
-            self.apilock['firmware'] = False
+                    try:
+                        for device in tedapi.message.firmware.system.wireless.device:
+                            payload["system"]["wireless"]["device"].append({
+                                "company": device.company.value,
+                                "model": device.model.value,
+                                "fcc_id": device.fcc_id.value,
+                                "ic": device.ic.value
+                            })
+                    except Exception as e:
+                        log.debug(f"Error parsing wireless devices: {e}")
+                    log.debug(f"Firmware Version: {payload}")
+                else:
+                    payload = firmware_version
+                log.debug(f"Firmware Version: {firmware_version}")
+                self.pwcachetime["firmware"] = time.time()
+                self.pwcache["firmware"] = firmware_version
+            except Exception as e:
+                log.error(f"Error fetching firmware version: {e}")
+                payload = None
         return payload
 
     def get_components(self, force=False):
@@ -565,67 +531,61 @@ class TEDAPI:
         Note: Provides empty response for previous Powerwall versions
         """
         components = None
-        # Check Connection
-        if not self.din:
-            if not self.connect():
-                log.error("Not Connected - Unable to get configuration")
+        with acquire_lock_with_backoff(self.apilock['components'], self.timeout):
+            # Check Connection
+            if not self.din:
+                if not self.connect():
+                    log.error("Not Connected - Unable to get configuration")
+                    return None
+            # Check Cache
+            if not force and "components" in self.pwcachetime:
+                if time.time() - self.pwcachetime["components"] < self.pwconfigexpire:
+                    log.debug("Using Cached Components")
+                    return self.pwcache["components"]
+            if not force and self.pwcooldown > time.perf_counter():
+                # Rate limited - return None
+                log.debug('Rate limit cooldown period - Pausing API calls')
                 return None
-        # Check Cache
-        if not force and "components" in self.pwcachetime:
-            if time.time() - self.pwcachetime["components"] < self.pwconfigexpire:
-                log.debug("Using Cached Components")
-                return self.pwcache["components"]
-        if not force and self.pwcooldown > time.perf_counter():
-            # Rate limited - return None
-            log.debug('Rate limit cooldown period - Pausing API calls')
-            return None
-        # Fetch Configuration from Powerwall
-        log.debug("Get PW3 Components from Powerwall")
-        # Build Protobuf to fetch config
-        pb = tedapi_pb2.Message()
-        pb.message.deliveryChannel = 1
-        pb.message.sender.local = 1
-        pb.message.recipient.din = self.din  # DIN of Powerwall
-        pb.message.payload.send.num = 2
-        pb.message.payload.send.payload.value = 1
-        pb.message.payload.send.payload.text = " query ComponentsQuery (\n  $pchComponentsFilter: ComponentFilter,\n  $pchSignalNames: [String!],\n  $pwsComponentsFilter: ComponentFilter,\n  $pwsSignalNames: [String!],\n  $bmsComponentsFilter: ComponentFilter,\n  $bmsSignalNames: [String!],\n  $hvpComponentsFilter: ComponentFilter,\n  $hvpSignalNames: [String!],\n  $baggrComponentsFilter: ComponentFilter,\n  $baggrSignalNames: [String!],\n  ) {\n  # TODO STST-57686: Introduce GraphQL fragments to shorten\n  pw3Can {\n    firmwareUpdate {\n      isUpdating\n      progress {\n         updating\n         numSteps\n         currentStep\n         currentStepProgress\n         progress\n      }\n    }\n  }\n  components {\n    pws: components(filter: $pwsComponentsFilter) {\n      signals(names: $pwsSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    pch: components(filter: $pchComponentsFilter) {\n      signals(names: $pchSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    bms: components(filter: $bmsComponentsFilter) {\n      signals(names: $bmsSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    hvp: components(filter: $hvpComponentsFilter) {\n      partNumber\n      serialNumber\n      signals(names: $hvpSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    baggr: components(filter: $baggrComponentsFilter) {\n      signals(names: $baggrSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n  }\n}\n"
-        pb.message.payload.send.code = b'0\201\210\002B\000\270q\354>\243m\325p\371S\253\231\346~:\032\216~\242\263\207\017L\273O\203u\241\270\333w\233\354\276\246h\262\243\255\261\007\202D\277\353x\023O\022\303\216\264\010-\'i6\360>B\237\236\304\244m\002B\001\023Pk\033)\277\236\342R\264\247g\260u\036\023\3662\354\242\353\035\221\234\027\245\321J\342\345\037q\262O\3446-\353\315m1\237zai0\341\207C4\307\300Z\177@h\335\327\0239\252f\n\206W'
-        pb.message.payload.send.b.value = "{\"pwsComponentsFilter\":{\"types\":[\"PW3SAF\"]},\"pwsSignalNames\":[\"PWS_SelfTest\",\"PWS_PeImpTestState\",\"PWS_PvIsoTestState\",\"PWS_RelaySelfTest_State\",\"PWS_MciTestState\",\"PWS_appGitHash\",\"PWS_ProdSwitch_State\"],\"pchComponentsFilter\":{\"types\":[\"PCH\"]},\"pchSignalNames\":[\"PCH_State\",\"PCH_PvState_A\",\"PCH_PvState_B\",\"PCH_PvState_C\",\"PCH_PvState_D\",\"PCH_PvState_E\",\"PCH_PvState_F\",\"PCH_AcFrequency\",\"PCH_AcVoltageAB\",\"PCH_AcVoltageAN\",\"PCH_AcVoltageBN\",\"PCH_packagePartNumber_1_7\",\"PCH_packagePartNumber_8_14\",\"PCH_packagePartNumber_15_20\",\"PCH_packageSerialNumber_1_7\",\"PCH_packageSerialNumber_8_14\",\"PCH_PvVoltageA\",\"PCH_PvVoltageB\",\"PCH_PvVoltageC\",\"PCH_PvVoltageD\",\"PCH_PvVoltageE\",\"PCH_PvVoltageF\",\"PCH_PvCurrentA\",\"PCH_PvCurrentB\",\"PCH_PvCurrentC\",\"PCH_PvCurrentD\",\"PCH_PvCurrentE\",\"PCH_PvCurrentF\",\"PCH_BatteryPower\",\"PCH_AcRealPowerAB\",\"PCH_SlowPvPowerSum\",\"PCH_AcMode\",\"PCH_AcFrequency\",\"PCH_DcdcState_A\",\"PCH_DcdcState_B\",\"PCH_appGitHash\"],\"bmsComponentsFilter\":{\"types\":[\"PW3BMS\"]},\"bmsSignalNames\":[\"BMS_nominalEnergyRemaining\",\"BMS_nominalFullPackEnergy\",\"BMS_appGitHash\"],\"hvpComponentsFilter\":{\"types\":[\"PW3HVP\"]},\"hvpSignalNames\":[\"HVP_State\",\"HVP_appGitHash\"],\"baggrComponentsFilter\":{\"types\":[\"BAGGR\"]},\"baggrSignalNames\":[\"BAGGR_State\",\"BAGGR_OperationRequest\",\"BAGGR_NumBatteriesConnected\",\"BAGGR_NumBatteriesPresent\",\"BAGGR_NumBatteriesExpected\",\"BAGGR_LOG_BattConnectionStatus0\",\"BAGGR_LOG_BattConnectionStatus1\",\"BAGGR_LOG_BattConnectionStatus2\",\"BAGGR_LOG_BattConnectionStatus3\"]}"
-        pb.tail.value = 1
-        url = f'https://{self.gw_ip}/tedapi/v1'
-        try:
-            # Set lock
-            self.apilock['components'] = True
-            r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
-                                          headers={'Content-type': 'application/octet-string'},
-                                          data=pb.SerializeToString(), timeout=self.timeout)
-            log.debug(f"Response Code: {r.status_code}")
-            if r.status_code in BUSY_CODES:
-                # Rate limited - Switch to cooldown mode for 5 minutes
-                self.pwcooldown = time.perf_counter() + 300
-                log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
-                self.apilock['components'] = False
-                return None
-            if r.status_code != 200:
-                log.error(f"Error fetching components: {r.status_code}")
-                self.apilock['components'] = False
-                return None
-            # Decode response
-            tedapi = tedapi_pb2.Message()
-            tedapi.ParseFromString(r.content)
-            payload = tedapi.message.payload.recv.text
-            log.debug(f"Payload (len={len(payload)}): {payload}")
-            # Append payload to components
-            components = json.loads(payload)
-            log.debug(f"Components: {components}")
-            self.pwcachetime["components"] = time.time()
-            self.pwcache["components"] = components
-        except Exception as e:
-            log.error(f"Error fetching components: {e}")
-            components = None
-        finally:
-            # Release lock
-            self.apilock['components'] = False
+            # Fetch Configuration from Powerwall
+            log.debug("Get PW3 Components from Powerwall")
+            # Build Protobuf to fetch config
+            pb = tedapi_pb2.Message()
+            pb.message.deliveryChannel = 1
+            pb.message.sender.local = 1
+            pb.message.recipient.din = self.din  # DIN of Powerwall
+            pb.message.payload.send.num = 2
+            pb.message.payload.send.payload.value = 1
+            pb.message.payload.send.payload.text = " query ComponentsQuery (\n  $pchComponentsFilter: ComponentFilter,\n  $pchSignalNames: [String!],\n  $pwsComponentsFilter: ComponentFilter,\n  $pwsSignalNames: [String!],\n  $bmsComponentsFilter: ComponentFilter,\n  $bmsSignalNames: [String!],\n  $hvpComponentsFilter: ComponentFilter,\n  $hvpSignalNames: [String!],\n  $baggrComponentsFilter: ComponentFilter,\n  $baggrSignalNames: [String!],\n  ) {\n  # TODO STST-57686: Introduce GraphQL fragments to shorten\n  pw3Can {\n    firmwareUpdate {\n      isUpdating\n      progress {\n         updating\n         numSteps\n         currentStep\n         currentStepProgress\n         progress\n      }\n    }\n  }\n  components {\n    pws: components(filter: $pwsComponentsFilter) {\n      signals(names: $pwsSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    pch: components(filter: $pchComponentsFilter) {\n      signals(names: $pchSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    bms: components(filter: $bmsComponentsFilter) {\n      signals(names: $bmsSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    hvp: components(filter: $hvpComponentsFilter) {\n      partNumber\n      serialNumber\n      signals(names: $hvpSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    baggr: components(filter: $baggrComponentsFilter) {\n      signals(names: $baggrSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n  }\n}\n"
+            pb.message.payload.send.code = b'0\201\210\002B\000\270q\354>\243m\325p\371S\253\231\346~:\032\216~\242\263\207\017L\273O\203u\241\270\333w\233\354\276\246h\262\243\255\261\007\202D\277\353x\023O\022\303\216\264\010-\'i6\360>B\237\236\304\244m\002B\001\023Pk\033)\277\236\342R\264\247g\260u\036\023\3662\354\242\353\035\221\234\027\245\321J\342\345\037q\262O\3446-\353\315m1\237zai0\341\207C4\307\300Z\177@h\335\327\0239\252f\n\206W'
+            pb.message.payload.send.b.value = "{\"pwsComponentsFilter\":{\"types\":[\"PW3SAF\"]},\"pwsSignalNames\":[\"PWS_SelfTest\",\"PWS_PeImpTestState\",\"PWS_PvIsoTestState\",\"PWS_RelaySelfTest_State\",\"PWS_MciTestState\",\"PWS_appGitHash\",\"PWS_ProdSwitch_State\"],\"pchComponentsFilter\":{\"types\":[\"PCH\"]},\"pchSignalNames\":[\"PCH_State\",\"PCH_PvState_A\",\"PCH_PvState_B\",\"PCH_PvState_C\",\"PCH_PvState_D\",\"PCH_PvState_E\",\"PCH_PvState_F\",\"PCH_AcFrequency\",\"PCH_AcVoltageAB\",\"PCH_AcVoltageAN\",\"PCH_AcVoltageBN\",\"PCH_packagePartNumber_1_7\",\"PCH_packagePartNumber_8_14\",\"PCH_packagePartNumber_15_20\",\"PCH_packageSerialNumber_1_7\",\"PCH_packageSerialNumber_8_14\",\"PCH_PvVoltageA\",\"PCH_PvVoltageB\",\"PCH_PvVoltageC\",\"PCH_PvVoltageD\",\"PCH_PvVoltageE\",\"PCH_PvVoltageF\",\"PCH_PvCurrentA\",\"PCH_PvCurrentB\",\"PCH_PvCurrentC\",\"PCH_PvCurrentD\",\"PCH_PvCurrentE\",\"PCH_PvCurrentF\",\"PCH_BatteryPower\",\"PCH_AcRealPowerAB\",\"PCH_SlowPvPowerSum\",\"PCH_AcMode\",\"PCH_AcFrequency\",\"PCH_DcdcState_A\",\"PCH_DcdcState_B\",\"PCH_appGitHash\"],\"bmsComponentsFilter\":{\"types\":[\"PW3BMS\"]},\"bmsSignalNames\":[\"BMS_nominalEnergyRemaining\",\"BMS_nominalFullPackEnergy\",\"BMS_appGitHash\"],\"hvpComponentsFilter\":{\"types\":[\"PW3HVP\"]},\"hvpSignalNames\":[\"HVP_State\",\"HVP_appGitHash\"],\"baggrComponentsFilter\":{\"types\":[\"BAGGR\"]},\"baggrSignalNames\":[\"BAGGR_State\",\"BAGGR_OperationRequest\",\"BAGGR_NumBatteriesConnected\",\"BAGGR_NumBatteriesPresent\",\"BAGGR_NumBatteriesExpected\",\"BAGGR_LOG_BattConnectionStatus0\",\"BAGGR_LOG_BattConnectionStatus1\",\"BAGGR_LOG_BattConnectionStatus2\",\"BAGGR_LOG_BattConnectionStatus3\"]}"
+            pb.tail.value = 1
+            url = f'https://{self.gw_ip}/tedapi/v1'
+            try:
+                r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
+                                            headers={'Content-type': 'application/octet-string'},
+                                            data=pb.SerializeToString(), timeout=self.timeout)
+                log.debug(f"Response Code: {r.status_code}")
+                if r.status_code in BUSY_CODES:
+                    # Rate limited - Switch to cooldown mode for 5 minutes
+                    self.pwcooldown = time.perf_counter() + 300
+                    log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
+                    return None
+                if r.status_code != HTTPStatus.OK:
+                    log.error(f"Error fetching components: {r.status_code}")
+                    return None
+                # Decode response
+                tedapi = tedapi_pb2.Message()
+                tedapi.ParseFromString(r.content)
+                payload = tedapi.message.payload.recv.text
+                log.debug(f"Payload (len={len(payload)}): {payload}")
+                # Append payload to components
+                components = json.loads(payload)
+                log.debug(f"Components: {components}")
+                self.pwcachetime["components"] = time.time()
+                self.pwcache["components"] = components
+            except Exception as e:
+                log.error(f"Error fetching components: {e}")
+                components = None
         return components
 
 
@@ -712,7 +672,7 @@ class TEDAPI:
             r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
                             headers={'Content-type': 'application/octet-string'},
                             data=pb.SerializeToString(), timeout=self.timeout)
-            if r.status_code == 200:
+            if r.status_code == HTTPStatus.OK:
                 # Decode response
                 tedapi = tedapi_pb2.Message()
                 tedapi.ParseFromString(r.content)
@@ -818,74 +778,67 @@ class TEDAPI:
 
         Note: Provides 404 response for previous Powerwall versions
         """
-        data = None
         # Make sure we have a DIN
         if not din:
             log.error("No DIN specified - Unable to get battery block")
             return None
-        # Check Cache
-        if not force and din in self.pwcachetime:
-            if time.time() - self.pwcachetime[din] < self.pwcacheexpire:
-                log.debug("Using Cached Battery Block")
-                return self.pwcache[din]
-        if not force and self.pwcooldown > time.perf_counter():
-            # Rate limited - return None
-            log.debug('Rate limit cooldown period - Pausing API calls')
-            return None
-        # Fetch Battery Block from Powerwall
-        log.debug(f"Get Battery Block from Powerwall ({din})")
-        # Build Protobuf to fetch config
-        pb = tedapi_pb2.Message()
-        pb.message.deliveryChannel = 1
-        pb.message.sender.local = 1
-        pb.message.sender.din = self.din  # DIN of Primary Powerwall 3 / System
-        pb.message.recipient.din = din  # DIN of Powerwall of Interest
-        pb.message.payload.send.num = 2
-        pb.message.payload.send.payload.value = 1
-        pb.message.payload.send.payload.text = " query ComponentsQuery (\n  $pchComponentsFilter: ComponentFilter,\n  $pchSignalNames: [String!],\n  $pwsComponentsFilter: ComponentFilter,\n  $pwsSignalNames: [String!],\n  $bmsComponentsFilter: ComponentFilter,\n  $bmsSignalNames: [String!],\n  $hvpComponentsFilter: ComponentFilter,\n  $hvpSignalNames: [String!],\n  $baggrComponentsFilter: ComponentFilter,\n  $baggrSignalNames: [String!],\n  ) {\n  # TODO STST-57686: Introduce GraphQL fragments to shorten\n  pw3Can {\n    firmwareUpdate {\n      isUpdating\n      progress {\n         updating\n         numSteps\n         currentStep\n         currentStepProgress\n         progress\n      }\n    }\n  }\n  components {\n    pws: components(filter: $pwsComponentsFilter) {\n      signals(names: $pwsSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    pch: components(filter: $pchComponentsFilter) {\n      signals(names: $pchSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    bms: components(filter: $bmsComponentsFilter) {\n      signals(names: $bmsSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    hvp: components(filter: $hvpComponentsFilter) {\n      partNumber\n      serialNumber\n      signals(names: $hvpSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    baggr: components(filter: $baggrComponentsFilter) {\n      signals(names: $baggrSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n  }\n}\n"
-        pb.message.payload.send.code = b'0\201\210\002B\000\270q\354>\243m\325p\371S\253\231\346~:\032\216~\242\263\207\017L\273O\203u\241\270\333w\233\354\276\246h\262\243\255\261\007\202D\277\353x\023O\022\303\216\264\010-\'i6\360>B\237\236\304\244m\002B\001\023Pk\033)\277\236\342R\264\247g\260u\036\023\3662\354\242\353\035\221\234\027\245\321J\342\345\037q\262O\3446-\353\315m1\237zai0\341\207C4\307\300Z\177@h\335\327\0239\252f\n\206W'
-        pb.message.payload.send.b.value = "{\"pwsComponentsFilter\":{\"types\":[\"PW3SAF\"]},\"pwsSignalNames\":[\"PWS_SelfTest\",\"PWS_PeImpTestState\",\"PWS_PvIsoTestState\",\"PWS_RelaySelfTest_State\",\"PWS_MciTestState\",\"PWS_appGitHash\",\"PWS_ProdSwitch_State\"],\"pchComponentsFilter\":{\"types\":[\"PCH\"]},\"pchSignalNames\":[\"PCH_State\",\"PCH_PvState_A\",\"PCH_PvState_B\",\"PCH_PvState_C\",\"PCH_PvState_D\",\"PCH_PvState_E\",\"PCH_PvState_F\",\"PCH_AcFrequency\",\"PCH_AcVoltageAB\",\"PCH_AcVoltageAN\",\"PCH_AcVoltageBN\",\"PCH_packagePartNumber_1_7\",\"PCH_packagePartNumber_8_14\",\"PCH_packagePartNumber_15_20\",\"PCH_packageSerialNumber_1_7\",\"PCH_packageSerialNumber_8_14\",\"PCH_PvVoltageA\",\"PCH_PvVoltageB\",\"PCH_PvVoltageC\",\"PCH_PvVoltageD\",\"PCH_PvVoltageE\",\"PCH_PvVoltageF\",\"PCH_PvCurrentA\",\"PCH_PvCurrentB\",\"PCH_PvCurrentC\",\"PCH_PvCurrentD\",\"PCH_PvCurrentE\",\"PCH_PvCurrentF\",\"PCH_BatteryPower\",\"PCH_AcRealPowerAB\",\"PCH_SlowPvPowerSum\",\"PCH_AcMode\",\"PCH_AcFrequency\",\"PCH_DcdcState_A\",\"PCH_DcdcState_B\",\"PCH_appGitHash\"],\"bmsComponentsFilter\":{\"types\":[\"PW3BMS\"]},\"bmsSignalNames\":[\"BMS_nominalEnergyRemaining\",\"BMS_nominalFullPackEnergy\",\"BMS_appGitHash\"],\"hvpComponentsFilter\":{\"types\":[\"PW3HVP\"]},\"hvpSignalNames\":[\"HVP_State\",\"HVP_appGitHash\"],\"baggrComponentsFilter\":{\"types\":[\"BAGGR\"]},\"baggrSignalNames\":[\"BAGGR_State\",\"BAGGR_OperationRequest\",\"BAGGR_NumBatteriesConnected\",\"BAGGR_NumBatteriesPresent\",\"BAGGR_NumBatteriesExpected\",\"BAGGR_LOG_BattConnectionStatus0\",\"BAGGR_LOG_BattConnectionStatus1\",\"BAGGR_LOG_BattConnectionStatus2\",\"BAGGR_LOG_BattConnectionStatus3\"]}"
-        pb.tail.value = 2
-        url = f'https://{self.gw_ip}/tedapi/device/{din}/v1'
-        try:
-            # Set lock
-            self.apilock[din] = True
-            r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
-                                        headers={'Content-type': 'application/octet-string'},
-                                        data=pb.SerializeToString(), timeout=self.timeout)
-            log.debug(f"Response Code: {r.status_code}")
-            if r.status_code in BUSY_CODES:
-                # Rate limited - Switch to cooldown mode for 5 minutes
-                self.pwcooldown = time.perf_counter() + 300
-                log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
-                self.apilock[din] = False
+        data = None
+        with acquire_lock_with_backoff(self.apilock[din], self.timeout):
+            # Check Cache
+            if not force and din in self.pwcachetime:
+                if time.time() - self.pwcachetime[din] < self.pwcacheexpire:
+                    log.debug("Using Cached Battery Block")
+                    return self.pwcache[din]
+            if not force and self.pwcooldown > time.perf_counter():
+                # Rate limited - return None
+                log.debug('Rate limit cooldown period - Pausing API calls')
                 return None
-            if r.status_code == 404:
-                log.debug(f"Device not found: {din}")
-                self.apilock[din] = False
-                return None
-            if r.status_code != 200:
-                log.error(f"Error fetching config: {r.status_code}")
-                self.apilock[din] = False
-                return None
-            # Decode response
-            tedapi = tedapi_pb2.Message()
-            tedapi.ParseFromString(r.content)
-            payload = tedapi.message.config.recv.file.text
+            # Fetch Battery Block from Powerwall
+            log.debug(f"Get Battery Block from Powerwall ({din})")
+            # Build Protobuf to fetch config
+            pb = tedapi_pb2.Message()
+            pb.message.deliveryChannel = 1
+            pb.message.sender.local = 1
+            pb.message.sender.din = self.din  # DIN of Primary Powerwall 3 / System
+            pb.message.recipient.din = din  # DIN of Powerwall of Interest
+            pb.message.payload.send.num = 2
+            pb.message.payload.send.payload.value = 1
+            pb.message.payload.send.payload.text = " query ComponentsQuery (\n  $pchComponentsFilter: ComponentFilter,\n  $pchSignalNames: [String!],\n  $pwsComponentsFilter: ComponentFilter,\n  $pwsSignalNames: [String!],\n  $bmsComponentsFilter: ComponentFilter,\n  $bmsSignalNames: [String!],\n  $hvpComponentsFilter: ComponentFilter,\n  $hvpSignalNames: [String!],\n  $baggrComponentsFilter: ComponentFilter,\n  $baggrSignalNames: [String!],\n  ) {\n  # TODO STST-57686: Introduce GraphQL fragments to shorten\n  pw3Can {\n    firmwareUpdate {\n      isUpdating\n      progress {\n         updating\n         numSteps\n         currentStep\n         currentStepProgress\n         progress\n      }\n    }\n  }\n  components {\n    pws: components(filter: $pwsComponentsFilter) {\n      signals(names: $pwsSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    pch: components(filter: $pchComponentsFilter) {\n      signals(names: $pchSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    bms: components(filter: $bmsComponentsFilter) {\n      signals(names: $bmsSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    hvp: components(filter: $hvpComponentsFilter) {\n      partNumber\n      serialNumber\n      signals(names: $hvpSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n    baggr: components(filter: $baggrComponentsFilter) {\n      signals(names: $baggrSignalNames) {\n        name\n        value\n        textValue\n        boolValue\n        timestamp\n      }\n      activeAlerts {\n        name\n      }\n    }\n  }\n}\n"
+            pb.message.payload.send.code = b'0\201\210\002B\000\270q\354>\243m\325p\371S\253\231\346~:\032\216~\242\263\207\017L\273O\203u\241\270\333w\233\354\276\246h\262\243\255\261\007\202D\277\353x\023O\022\303\216\264\010-\'i6\360>B\237\236\304\244m\002B\001\023Pk\033)\277\236\342R\264\247g\260u\036\023\3662\354\242\353\035\221\234\027\245\321J\342\345\037q\262O\3446-\353\315m1\237zai0\341\207C4\307\300Z\177@h\335\327\0239\252f\n\206W'
+            pb.message.payload.send.b.value = "{\"pwsComponentsFilter\":{\"types\":[\"PW3SAF\"]},\"pwsSignalNames\":[\"PWS_SelfTest\",\"PWS_PeImpTestState\",\"PWS_PvIsoTestState\",\"PWS_RelaySelfTest_State\",\"PWS_MciTestState\",\"PWS_appGitHash\",\"PWS_ProdSwitch_State\"],\"pchComponentsFilter\":{\"types\":[\"PCH\"]},\"pchSignalNames\":[\"PCH_State\",\"PCH_PvState_A\",\"PCH_PvState_B\",\"PCH_PvState_C\",\"PCH_PvState_D\",\"PCH_PvState_E\",\"PCH_PvState_F\",\"PCH_AcFrequency\",\"PCH_AcVoltageAB\",\"PCH_AcVoltageAN\",\"PCH_AcVoltageBN\",\"PCH_packagePartNumber_1_7\",\"PCH_packagePartNumber_8_14\",\"PCH_packagePartNumber_15_20\",\"PCH_packageSerialNumber_1_7\",\"PCH_packageSerialNumber_8_14\",\"PCH_PvVoltageA\",\"PCH_PvVoltageB\",\"PCH_PvVoltageC\",\"PCH_PvVoltageD\",\"PCH_PvVoltageE\",\"PCH_PvVoltageF\",\"PCH_PvCurrentA\",\"PCH_PvCurrentB\",\"PCH_PvCurrentC\",\"PCH_PvCurrentD\",\"PCH_PvCurrentE\",\"PCH_PvCurrentF\",\"PCH_BatteryPower\",\"PCH_AcRealPowerAB\",\"PCH_SlowPvPowerSum\",\"PCH_AcMode\",\"PCH_AcFrequency\",\"PCH_DcdcState_A\",\"PCH_DcdcState_B\",\"PCH_appGitHash\"],\"bmsComponentsFilter\":{\"types\":[\"PW3BMS\"]},\"bmsSignalNames\":[\"BMS_nominalEnergyRemaining\",\"BMS_nominalFullPackEnergy\",\"BMS_appGitHash\"],\"hvpComponentsFilter\":{\"types\":[\"PW3HVP\"]},\"hvpSignalNames\":[\"HVP_State\",\"HVP_appGitHash\"],\"baggrComponentsFilter\":{\"types\":[\"BAGGR\"]},\"baggrSignalNames\":[\"BAGGR_State\",\"BAGGR_OperationRequest\",\"BAGGR_NumBatteriesConnected\",\"BAGGR_NumBatteriesPresent\",\"BAGGR_NumBatteriesExpected\",\"BAGGR_LOG_BattConnectionStatus0\",\"BAGGR_LOG_BattConnectionStatus1\",\"BAGGR_LOG_BattConnectionStatus2\",\"BAGGR_LOG_BattConnectionStatus3\"]}"
+            pb.tail.value = 2
+            url = f'https://{self.gw_ip}/tedapi/device/{din}/v1'
             try:
-                data = json.loads(payload)
-            except json.JSONDecodeError as e:
-                log.error(f"Error Decoding JSON: {e}")
-                data = {}
-            log.debug(f"Configuration: {data}")
-            self.pwcachetime[din] = time.time()
-            self.pwcache[din] = data
-        except Exception as e:
-            log.error(f"Error fetching device: {e}")
-            data = None
-        finally:
-            # Release lock
-            self.apilock[din] = False
+                r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
+                                            headers={'Content-type': 'application/octet-string'},
+                                            data=pb.SerializeToString(), timeout=self.timeout)
+                log.debug(f"Response Code: {r.status_code}")
+                if r.status_code in BUSY_CODES:
+                    # Rate limited - Switch to cooldown mode for 5 minutes
+                    self.pwcooldown = time.perf_counter() + 300
+                    log.error('Possible Rate limited by Powerwall at - Activating 5 minute cooldown')
+                    return None
+                if r.status_code == 404:
+                    log.debug(f"Device not found: {din}")
+                    return None
+                if r.status_code != 200:
+                    log.error(f"Error fetching config: {r.status_code}")
+                    return None
+                # Decode response
+                tedapi = tedapi_pb2.Message()
+                tedapi.ParseFromString(r.content)
+                payload = tedapi.message.config.recv.file.text
+                try:
+                    data = json.loads(payload)
+                except json.JSONDecodeError as e:
+                    log.error(f"Error Decoding JSON: {e}")
+                    data = {}
+                log.debug(f"Configuration: {data}")
+                self.pwcachetime[din] = time.time()
+                self.pwcache[din] = data
+            except Exception as e:
+                log.error(f"Error fetching device: {e}")
+                data = None
         return data
 
     def connect(self):
@@ -898,7 +851,7 @@ class TEDAPI:
         self.din = None
         try:
             resp = requests.get(url, verify=False, timeout=5)
-            if resp.status_code != 200:
+            if resp.status_code != HTTPStatus.OK:
                 # Connected but appears to be Powerwall 3
                 log.debug("Detected Powerwall 3 Gateway")
                 self.pw3 = True
@@ -1031,15 +984,13 @@ class TEDAPI:
             # Loop through each CT on the Neurio device
             sn = n.get('serial', str(c))
             cts = {}
-            i = 0
             c = c + 1
-            for ct in n['dataRead'] or {}:
+            for i, ct in enumerate(n['dataRead'] or {}):
                 # Only show if we have a meter configuration and cts[i] is true
                 cts_bool = lookup(meter_config, [sn, 'cts'])
                 if isinstance(cts_bool, list) and i < len(cts_bool):
                     if not cts_bool[i]:
                         # Skip this CT
-                        i = i + 1
                         continue
                 factor = lookup(meter_config, [sn, 'real_power_scale_factor']) or 1
                 device = f"NEURIO_CT{i}_"
@@ -1049,7 +1000,6 @@ class TEDAPI:
                 cts[device + "InstCurrent"] = lookup(ct, ['currentA'])
                 location = lookup(meter_config, [sn, 'location'])
                 cts[device + "Location"] = location[i] if len(location) > i else None
-                i = i + 1
             meter_manufacturer = None
             if lookup(meter_config, [sn, 'type']) == "neurio_w2_tcp":
                 meter_manufacturer = "NEURIO"
@@ -1069,12 +1019,11 @@ class TEDAPI:
         pvac = {}
         pvs = {}
         tesla = {}
-        i = 0
         num = len(lookup(status, ['esCan', 'bus', 'PVAC']) or {})
         if num != len(lookup(status, ['esCan', 'bus', 'PVS']) or {}):
             log.debug("PVAC and PVS device count mismatch in TEDAPI")
         # Loop through each device serial number
-        for p in lookup(status, ['esCan', 'bus', 'PVAC']) or {}:
+        for i, p in enumerate(lookup(status, ['esCan', 'bus', 'PVAC']) or {}):
             if not p['packageSerialNumber']:
                 continue
             packagePartNumber = p.get('packagePartNumber', str(i))
@@ -1184,7 +1133,6 @@ class TEDAPI:
                 },
                 "serialNumber": f"{packagePartNumber}--{packageSerialNumber}",
             }
-            i = i + 1
 
         # Create STSTSM block
         name = f"STSTSM--{lookup(config, ['vin'])}"
@@ -1214,9 +1162,8 @@ class TEDAPI:
         tethc = {} # parent
         tepinv = {}
         tepod = {}
-        i = 0
         # Loop through each THC device serial number
-        for p in lookup(status, ['esCan', 'bus', 'THC']) or {}:
+        for i, p in enumerate(lookup(status, ['esCan', 'bus', 'THC']) or {}):
             if not p['packageSerialNumber']:
                 continue
             packagePartNumber = p.get('packagePartNumber', str(i))
@@ -1303,7 +1250,6 @@ class TEDAPI:
                     "ecuType": 253
                 }
             }
-            i = i + 1
 
         # Create TESYNC block
         tesync = {}
@@ -1423,9 +1369,8 @@ class TEDAPI:
         if not isinstance(status, dict) or not isinstance(config, dict):
             return None
         block = {}
-        i = 0
         # Loop through each THC device serial number
-        for p in lookup(status, ['esCan', 'bus', 'THC']) or {}:
+        for i, p in enumerate(lookup(status, ['esCan', 'bus', 'THC']) or {}):
             if not p['packageSerialNumber']:
                 continue
             packagePartNumber = p.get('packagePartNumber', str(i))
@@ -1473,7 +1418,6 @@ class TEDAPI:
                 "p_out": lookup(pinv, ['PINV_Status', 'PINV_Pout']),
                 "v_out": lookup(pinv, ['PINV_Status', 'PINV_Vout']),
             })
-            i = i + 1
         return block
 
     # End of TEDAPI Class

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -90,12 +90,14 @@ def lookup(data, keylist):
     return data
 
 def uses_api_lock(func):
+    # If the attribute doesn't exist or isn't a valid threading.Lock, overwrite it.
+    if not hasattr(func, 'api_lock') or not isinstance(func.api_lock, type(threading.Lock)):
+        func.api_lock = threading.Lock()
     @wraps(func)
     def wrapper(*args, **kwargs):
         # Inject the function object itself into kwargs.
         kwargs['self_function'] = func
         return func(*args, **kwargs)
-    func.api_lock = threading.Lock()
     return wrapper
 
 # TEDAPI Class


### PR DESCRIPTION
# Summary
- Using a dictionary with an api lock is not thread safe. Given that this is frequently called from the proxy, a more thread safe option is appropriate, especially because I am in the process of modifying the proxy to call multiple gateways.
- A large amount of the "changes" are simply indenting existing lines for the "with" statement that the api lock uses.
- Update some typing
- Switch to enumerate instead of manually incrementing indicies.

# Testing
- Using my Raspberry PI. This has been working well for about a week.