### PR TITLE
Add option to get CSV headers

### DIFF
--- a/proxy/HELP.md
+++ b/proxy/HELP.md
@@ -11,6 +11,7 @@ There are several shortcut API URLs that aggregate or otherwise process Powerwal
 * /temps/pw - Powerwall Temperatures with Simplified Key (PWx_temp)
 * /csv - Key power data in CSV format: (grid, home, solar, battery, batterylevel)
 * /csv/v2 - CSV format: (grid, home, solar, battery, batterylevel, grid_up, reserve)
+*           Optional: Use /csv?headers or /csv/v2?headers to add field headers.
 * /vitals - Powerwall Device Vitals 
 * /strings - Powerwall Inverter String Data
 * /soe - Powerwall Battery Level

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,15 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t69 (15 Mar 2025)
+
+* pyPowerwall v0.12.7 - Added new data features (Neurio Vitals, Aggregates Data) and fixed a critical issue (SystemConnectedToGrid Fix) while normalizing Alerts.
+* Add option to get CSV headers by @mccahan in https://github.com/jasonacox/pypowerwall/pull/149
+
+```bash
+curl http://localhost:8675/csv/v2?headers
+curl http://localhost:8675/csv?headers
+```
+
 ### Proxy t68 (20 Jan 2025)
 
 * pyPowerwall v0.12.3 - Adds Custom GW IP for TEDAPI. 

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -54,7 +54,7 @@ from transform import get_static, inject_js
 import pypowerwall
 from pypowerwall import parse_version
 
-BUILD = "t68"
+BUILD = "t69"
 ALLOWLIST = [
     '/api/status', '/api/site_info/site_name', '/api/meters/site',
     '/api/meters/solar', '/api/sitemaster', '/api/powerwalls',

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -369,7 +369,7 @@ class Handler(BaseHTTPRequestHandler):
         elif self.path == '/api/system_status/grid_status':
             # Grid Status - JSON
             message: str = pw.poll('/api/system_status/grid_status', jsonformat=True)
-        elif self.path == '/csv' or self.path == '/csv/v2':
+        elif self.path.startswith('/csv') or self.path.startswith('/csv/v2'):
             # CSV Output - Grid,Home,Solar,Battery,Level
             # CSV2 Output - Grid,Home,Solar,Battery,Level,GridStatus,Reserve
             contenttype = 'text/plain; charset=utf-8'
@@ -382,15 +382,21 @@ class Handler(BaseHTTPRequestHandler):
                 solar = 0
                 # Shift energy from solar to load
                 home -= solar
-            if self.path == '/csv':
-                message = "%0.2f,%0.2f,%0.2f,%0.2f,%0.2f\n" \
-                    % (grid, home, solar, battery, batterylevel)
-            else:
+            if self.path.startswith('/csv/v2'):
                 gridstatus = 1 if pw.grid_status() == 'UP' else 0
                 reserve = pw.get_reserve() or 0
-                message = "%0.2f,%0.2f,%0.2f,%0.2f,%0.2f,%d,%d\n" \
+                message = ""
+                if "headers" in self.path:
+                    message += "Grid,Home,Solar,Battery,BatteryLevel,GridStatus,Reserve\n"
+                message += "%0.2f,%0.2f,%0.2f,%0.2f,%0.2f,%d,%d\n" \
                     % (grid, home, solar, battery, batterylevel, 
                         gridstatus, reserve)
+            else:
+                message = ""
+                if "headers" in self.path:
+                    message += "Grid,Home,Solar,Battery,BatteryLevel\n"
+                message += "%0.2f,%0.2f,%0.2f,%0.2f,%0.2f\n" \
+                    % (grid, home, solar, battery, batterylevel)
         elif self.path == '/vitals':
             # Vitals Data - JSON
             message: str = pw.vitals(jsonformat=True) or json.dumps({})

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -372,6 +372,7 @@ class Handler(BaseHTTPRequestHandler):
         elif self.path.startswith('/csv') or self.path.startswith('/csv/v2'):
             # CSV Output - Grid,Home,Solar,Battery,Level
             # CSV2 Output - Grid,Home,Solar,Battery,Level,GridStatus,Reserve
+            # Add ?headers to include CSV headers, e.g. http://localhost:8675/csv?headers
             contenttype = 'text/plain; charset=utf-8'
             batterylevel = pw.level() or 0
             grid = pw.grid() or 0


### PR DESCRIPTION
Playing around with some widget stuff, the CSV endpoints are very convenient but it's helpful to be able to get them with headers. I put it in as a query string and made sure it won't affect any existing URL calls. I switched the order around starting on line ~386 because otherwise `self.path.startswith('/csv')` would match `/csv/v2` as well

http://localhost:8675/csv/v2?headers
http://localhost:8675/csv?headers