### PR TITLE
Avoid divide by zero when nominalFullPackEnergyWh is zero

### DIFF
--- a/pypowerwall/tedapi/__main__.py
+++ b/pypowerwall/tedapi/__main__.py
@@ -115,8 +115,11 @@ def run_tedapi_test(auto=False, debug=False):
     print(" - Power Data:")
     nominalEnergyRemainingWh = status.get('control', {}).get('systemStatus', {}).get('nominalEnergyRemainingWh', 0)
     nominalFullPackEnergyWh = status.get('control', {}).get('systemStatus', {}).get('nominalFullPackEnergyWh', 0)
-    soe = round(nominalEnergyRemainingWh / nominalFullPackEnergyWh * 100, 2)
-    print(f"   - Battery Charge: {soe}% ({nominalEnergyRemainingWh}Wh of {nominalFullPackEnergyWh}Wh)")
+    if nominalFullPackEnergyWh is 0:
+        print(f"   - Battery Charge Unknown, possibly disconnected from AC? ({nominalEnergyRemainingWh}Wh of {nominalFullPackEnergyWh}Wh)")
+    else:
+        soe = round(nominalEnergyRemainingWh / nominalFullPackEnergyWh * 100, 2)
+        print(f"   - Battery Charge: {soe}% ({nominalEnergyRemainingWh}Wh of {nominalFullPackEnergyWh}Wh)")
     meterAggregates = status.get('control', {}).get('meterAggregates', [])
     for meter in meterAggregates:
         location = meter.get('location', 'Unknown').title()


### PR DESCRIPTION
e.g. due to AC being disconnected

My PW3 was recently installed, but has not yet been granted PTO. So I have to keep it disconnected from AC.
In this state, nominalFullPackEnergyWh is zero, so `pypowerwall tedapi` fails with a divide by zero error.