### PR TITLE
Add fan speeds to TEDAPI monitoring

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.12.9 - Fan Speeds
+
+* Add PVAC fan speeds to TEDAPI vitals monitoring (PVAC_Fan_Speed_Actual_RPM and PVAC_Fan_Speed_Target_RPM).
+
 ## v0.12.8 - TEDAPI Improvements
 
 * Avoid divide by zero when nominalFullPackEnergyWh is zero by @rlpm in https://github.com/jasonacox/pypowerwall/pull/150

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,2 +1,2 @@
-pypowerwall==0.12.7
+pypowerwall==0.12.9
 bs4==0.0.2

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -88,7 +88,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 12, 8)
+version_tuple = (0, 12, 9)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -51,7 +51,7 @@ import threading
 import time
 from functools import wraps
 from http import HTTPStatus
-from typing import List
+from typing import Dict, List
 
 import requests
 import urllib3
@@ -413,7 +413,7 @@ class TEDAPI:
             pb.message.payload.send.payload.value = 1
             pb.message.payload.send.payload.text = 'query DeviceControllerQuery($msaComp:ComponentFilter$msaSignals:[String!]){control{systemStatus{nominalFullPackEnergyWh nominalEnergyRemainingWh}islanding{customerIslandMode contactorClosed microGridOK gridOK disableReasons}meterAggregates{location realPowerW}alerts{active}siteShutdown{isShutDown reasons}batteryBlocks{din disableReasons}pvInverters{din disableReasons}}system{time supportMode{remoteService{isEnabled expiryTime sessionId}}sitemanagerStatus{isRunning}updateUrgencyCheck{urgency version{version gitHash}timestamp}}neurio{isDetectingWiredMeters readings{firmwareVersion serial dataRead{voltageV realPowerW reactivePowerVAR currentA}timestamp}pairings{serial shortId status errors macAddress hostname isWired modbusPort modbusId lastUpdateTimestamp}}teslaRemoteMeter{meters{din reading{timestamp firmwareVersion ctReadings{voltageV realPowerW reactivePowerVAR energyExportedWs energyImportedWs currentA}}firmwareUpdate{updating numSteps currentStep currentStepProgress progress}}detectedWired{din serialPort}}pw3Can{firmwareUpdate{isUpdating progress{updating numSteps currentStep currentStepProgress progress}}enumeration{inProgress}}esCan{bus{PVAC{packagePartNumber packageSerialNumber subPackagePartNumber subPackageSerialNumber PVAC_Status{isMIA PVAC_Pout PVAC_State PVAC_Vout PVAC_Fout}PVAC_InfoMsg{PVAC_appGitHash}PVAC_Logging{isMIA PVAC_PVCurrent_A PVAC_PVCurrent_B PVAC_PVCurrent_C PVAC_PVCurrent_D PVAC_PVMeasuredVoltage_A PVAC_PVMeasuredVoltage_B PVAC_PVMeasuredVoltage_C PVAC_PVMeasuredVoltage_D PVAC_VL1Ground PVAC_VL2Ground}alerts{isComplete isMIA active}}PINV{PINV_Status{isMIA PINV_Fout PINV_Pout PINV_Vout PINV_State PINV_GridState}PINV_AcMeasurements{isMIA PINV_VSplit1 PINV_VSplit2}PINV_PowerCapability{isComplete isMIA PINV_Pnom}alerts{isComplete isMIA active}}PVS{PVS_Status{isMIA PVS_State PVS_vLL PVS_StringA_Connected PVS_StringB_Connected PVS_StringC_Connected PVS_StringD_Connected PVS_SelfTestState}PVS_Logging{PVS_numStringsLockoutBits PVS_sbsComplete}alerts{isComplete isMIA active}}THC{packagePartNumber packageSerialNumber THC_InfoMsg{isComplete isMIA THC_appGitHash}THC_Logging{THC_LOG_PW_2_0_EnableLineState}}POD{POD_EnergyStatus{isMIA POD_nom_energy_remaining POD_nom_full_pack_energy}POD_InfoMsg{POD_appGitHash}}SYNC{packagePartNumber packageSerialNumber SYNC_InfoMsg{isMIA SYNC_appGitHash SYNC_assemblyId}METER_X_AcMeasurements{isMIA isComplete METER_X_CTA_InstRealPower METER_X_CTA_InstReactivePower METER_X_CTA_I METER_X_VL1N METER_X_CTB_InstRealPower METER_X_CTB_InstReactivePower METER_X_CTB_I METER_X_VL2N METER_X_CTC_InstRealPower METER_X_CTC_InstReactivePower METER_X_CTC_I METER_X_VL3N}METER_Y_AcMeasurements{isMIA isComplete METER_Y_CTA_InstRealPower METER_Y_CTA_InstReactivePower METER_Y_CTA_I METER_Y_VL1N METER_Y_CTB_InstRealPower METER_Y_CTB_InstReactivePower METER_Y_CTB_I METER_Y_VL2N METER_Y_CTC_InstRealPower METER_Y_CTC_InstReactivePower METER_Y_CTC_I METER_Y_VL3N}}ISLANDER{ISLAND_GridConnection{ISLAND_GridConnected isComplete}ISLAND_AcMeasurements{ISLAND_VL1N_Main ISLAND_FreqL1_Main ISLAND_VL2N_Main ISLAND_FreqL2_Main ISLAND_VL3N_Main ISLAND_FreqL3_Main ISLAND_VL1N_Load ISLAND_FreqL1_Load ISLAND_VL2N_Load ISLAND_FreqL2_Load ISLAND_VL3N_Load ISLAND_FreqL3_Load ISLAND_GridState isComplete isMIA}}}enumeration{inProgress numACPW numPVI}firmwareUpdate{isUpdating powerwalls{updating numSteps currentStep currentStepProgress progress}msa{updating numSteps currentStep currentStepProgress progress}msa1{updating numSteps currentStep currentStepProgress progress}sync{updating numSteps currentStep currentStepProgress progress}pvInverters{updating numSteps currentStep currentStepProgress progress}}phaseDetection{inProgress lastUpdateTimestamp powerwalls{din progress phase}}inverterSelfTests{isRunning isCanceled pinvSelfTestsResults{din overall{status test summary setMagnitude setTime tripMagnitude tripTime accuracyMagnitude accuracyTime currentMagnitude timestamp lastError}testResults{status test summary setMagnitude setTime tripMagnitude tripTime accuracyMagnitude accuracyTime currentMagnitude timestamp lastError}}}}components{msa:components(filter:$msaComp){partNumber serialNumber signals(names:$msaSignals){name value textValue boolValue timestamp}activeAlerts{name}}}ieee20305{longFormDeviceID polledResources{url name pollRateSeconds lastPolledTimestamp}controls{defaultControl{mRID setGradW opModEnergize opModMaxLimW opModImpLimW opModExpLimW opModGenLimW opModLoadLimW}activeControls{opModEnergize opModMaxLimW opModImpLimW opModExpLimW opModGenLimW opModLoadLimW}}registration{dateTimeRegistered pin}}}'
             pb.message.payload.send.code = b'0\x81\x87\x02B\x01A\x95\x12\xe3B\xd1\xca\x1a\xd3\x00\xf6}\x0bE@/\x9a\x9f\xc0\r\x06%\xac,\x0ej!)\nd\xef\xe67\x8b\xafb\xd7\xf8&\x0b.\xc1\xac\xd9!\x1f\xd6\x83\xffkIm\xf3\\J\xd8\xeeiTY\xde\x7f\xc5xR\x02A\x1dC\x03H\xfb8"\xb0\xe4\xd6\x18\xde\x11\xc45\xb2\xa9VB\xa6J\x8f\x08\x9d\xba\x86\xf1 W\xcdJ\x8c\x02*\x05\x12\xcb{<\x9b\xc8g\xc9\x9d9\x8bR\xb3\x89\xb8\xf1\xf1\x0f\x0e\x16E\xed\xd7\xbf\xd5&)\x92.\x12'
-            pb.message.payload.send.b.value = '{"msaComp":{"types" :["PVS","PVAC", "TESYNC", "TEPINV", "TETHC", "STSTSM",  "TEMSA", "TEPINV" ]},\n\t"msaSignals":[\n\t"MSA_pcbaId",\n\t"MSA_usageId",\n\t"MSA_appGitHash",\n\t"MSA_HeatingRateOccurred",\n\t"THC_AmbientTemp",\n\t"METER_Z_CTA_InstRealPower",\n\t"METER_Z_CTA_InstReactivePower",\n\t"METER_Z_CTA_I",\n\t"METER_Z_VL1G",\n\t"METER_Z_CTB_InstRealPower",\n\t"METER_Z_CTB_InstReactivePower",\n\t"METER_Z_CTB_I",\n\t"METER_Z_VL2G"]}'
+            pb.message.payload.send.b.value = '{"msaComp":{"types" :["PVS","PVAC", "TESYNC", "TEPINV", "TETHC", "STSTSM",  "TEMSA", "TEPINV" ]},\n\t"msaSignals":[\n\t"MSA_pcbaId",\n\t"MSA_usageId",\n\t"MSA_appGitHash",\n\t"PVAC_Fan_Speed_Actual_RPM",\n\t"PVAC_Fan_Speed_Target_RPM",\n\t"MSA_HeatingRateOccurred",\n\t"THC_AmbientTemp",\n\t"METER_Z_CTA_InstRealPower",\n\t"METER_Z_CTA_InstReactivePower",\n\t"METER_Z_CTA_I",\n\t"METER_Z_VL1G",\n\t"METER_Z_CTB_InstRealPower",\n\t"METER_Z_CTB_InstReactivePower",\n\t"METER_Z_CTB_I",\n\t"METER_Z_VL2G"]}'
             pb.tail.value = 1
             url = f'https://{self.gw_ip}/tedapi/v1'
             try:
@@ -932,6 +932,28 @@ class TEDAPI:
         return battery_level
 
 
+    def extract_fan_speeds(self, data) -> Dict[str, Dict[str, str]]:
+        fan_speed_signal_names = {"PVAC_Fan_Speed_Actual_RPM", "PVAC_Fan_Speed_Target_RPM"}
+
+        # List to store the valid fan speed values
+        result = {}
+
+        # Iterate over each component in the "msa" list
+        for component in data.get("components", {}).get("msa", []):
+            signals = component.get("signals", [])
+            fan_speeds = {
+                signal["name"]: signal["value"]
+                for signal in signals
+                if signal.get("name") in fan_speed_signal_names and signal.get("value") is not None
+            }
+            if not fan_speeds:
+                continue
+            componentPartNumber = component.get("partNumber")
+            componentSerialNumber = component.get("serialNumber")
+            result[f"PVAC--{componentPartNumber}--{componentSerialNumber}"] = fan_speeds
+        return result
+
+
     # Vitals API Mapping Function
     def vitals(self, force=False):
         """
@@ -1043,20 +1065,22 @@ class TEDAPI:
         if num != len(lookup(status, ['esCan', 'bus', 'PVS']) or {}):
             log.debug("PVAC and PVS device count mismatch in TEDAPI")
         # Loop through each device serial number
+        fan_speeds = self.extract_fan_speeds(status)
         for i, p in enumerate(lookup(status, ['esCan', 'bus', 'PVAC']) or {}):
             if not p['packageSerialNumber']:
                 continue
             packagePartNumber = p.get('packagePartNumber', str(i))
             packageSerialNumber = p.get('packageSerialNumber', str(i))
             pvac_name = f"PVAC--{packagePartNumber}--{packageSerialNumber}"
-            V_A = p['PVAC_Logging']['PVAC_PVMeasuredVoltage_A']
-            V_B = p['PVAC_Logging']['PVAC_PVMeasuredVoltage_B']
-            V_C = p['PVAC_Logging']['PVAC_PVMeasuredVoltage_C']
-            V_D = p['PVAC_Logging']['PVAC_PVMeasuredVoltage_D']
-            I_A = p['PVAC_Logging']['PVAC_PVCurrent_A']
-            I_B = p['PVAC_Logging']['PVAC_PVCurrent_B']
-            I_C = p['PVAC_Logging']['PVAC_PVCurrent_C']
-            I_D = p['PVAC_Logging']['PVAC_PVCurrent_D']
+            pvac_logging = p['PVAC_Logging']
+            V_A = pvac_logging['PVAC_PVMeasuredVoltage_A']
+            V_B = pvac_logging['PVAC_PVMeasuredVoltage_B']
+            V_C = pvac_logging['PVAC_PVMeasuredVoltage_C']
+            V_D = pvac_logging['PVAC_PVMeasuredVoltage_D']
+            I_A = pvac_logging['PVAC_PVCurrent_A']
+            I_B = pvac_logging['PVAC_PVCurrent_B']
+            I_C = pvac_logging['PVAC_PVCurrent_C']
+            I_D = pvac_logging['PVAC_PVCurrent_D']
             P_A = calculate_dc_power(V_A, I_A)
             P_B = calculate_dc_power(V_B, I_B)
             P_C = calculate_dc_power(V_C, I_C)
@@ -1102,6 +1126,13 @@ class TEDAPI:
                     "ecuType": 296
                 }
             }
+            pvac_fans = fan_speeds.get(pvac_name, {})
+            if pvac_fans:
+                pvac[pvac_name].update({
+                    "PVAC_Fan_Speed_Actual_RPM": pvac_fans["PVAC_Fan_Speed_Actual_RPM"],
+                    "PVAC_Fan_Speed_Target_RPM": pvac_fans["PVAC_Fan_Speed_Target_RPM"]
+                })
+
             pvs_name = f"PVS--{packagePartNumber}--{packageSerialNumber}"
             pvs_data = lookup(status, ['esCan', 'bus', 'PVS'])
             if i < len(pvs_data):

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -32,6 +32,7 @@
     get_battery_block(din) - Get the Powerwall 3 Battery Block Information
     get_pw3_vitals() - Get the Powerwall 3 Vitals Information
     get_device_controller() - Get the Powerwall Device Controller Status
+    get_fan_speed() - Get the fan speeds in RPM
 
  Note:
     This module requires access to the Powerwall Gateway. You can add a route to
@@ -932,6 +933,7 @@ class TEDAPI:
         return battery_level
 
 
+    # Helper Function
     def extract_fan_speeds(self, data) -> Dict[str, Dict[str, str]]:
         fan_speed_signal_names = {"PVAC_Fan_Speed_Actual_RPM", "PVAC_Fan_Speed_Target_RPM"}
 
@@ -953,7 +955,13 @@ class TEDAPI:
             result[f"PVAC--{componentPartNumber}--{componentSerialNumber}"] = fan_speeds
         return result
 
-
+    def get_fan_speeds(self, force=False):
+        """
+        Get the fan speeds for the Powerwall / Inverter
+        """
+        return self.extract_fan_speeds(self.get_device_controller(force=force))
+    
+    
     # Vitals API Mapping Function
     def vitals(self, force=False):
         """


### PR DESCRIPTION
# Summary
- Misc code cleanup in adjacent areas.
- Of note: No need to change the "code" parameter. The value field is apparently not validated against it.

# Testing
Works on my dual-inverter setup with 2x 7.6 kW Tesla inverters.
![image](https://github.com/user-attachments/assets/f177c16c-1321-4253-89a8-c30b554e3cb4)