### PR TITLE
Use Neurio for TEDAPI data when Tesla Remote Meter is not present

### DIFF
--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -351,7 +351,8 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
                 status_data=status,
                 meter_config_data=self.tedapi.derive_meter_config(config)
             )
-            for i, data in enumerate(neurio_data[1].values()):
+            i = 1
+            for data in neurio_data[1].values():
                 if data["Location"] != "site":
                     continue
                 current = math.copysign(data.get("InstCurrent", 0), data.get("InstRealPower", 0))
@@ -365,6 +366,7 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
                 elif i == 3:
                     i3 = current
                     v3n = voltage
+                i += 1
             nonzero = [x for x in (i1, i2, i3) if x != 0]
             i_site = sum(nonzero) / len(nonzero) if nonzero else 0
             vll_site = compute_LL_voltage(

--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -335,11 +335,44 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
         v2n = v_site.get("ISLAND_VL2N_Main", 0)
         v3n = v_site.get("ISLAND_VL3N_Main", 0)
         vll_site = compute_LL_voltage(v1n, v2n, v3n)
+
         meter_x = lookup(status, ("esCan","bus","SYNC","METER_X_AcMeasurements")) or {}
-        i1 = meter_x.get("METER_X_CTA_I", 0)
-        i2 = meter_x.get("METER_X_CTB_I", 0)
-        i3 = meter_x.get("METER_X_CTC_I", 0)
-        i_site = i1 + i2 + i3
+        i_site = i1 = i2 = i3 = 0
+        neurio_readings = lookup(status, ("neurio", "readings"))
+        if meter_x and not meter_x["isMIA"]:
+            i1 = meter_x.get("METER_X_CTA_I", 0)
+            i2 = meter_x.get("METER_X_CTB_I", 0)
+            i3 = meter_x.get("METER_X_CTC_I", 0)
+            i_site = i1 + i2 + i3
+        elif neurio_readings and len(neurio_readings) > 0:
+            vll_site = v1n = v2n = v3n = 0
+            neurio_data = self.tedapi.aggregate_neurio_data(
+                config_data=config,
+                status_data=status,
+                meter_config_data=self.tedapi.derive_meter_config(config)
+            )
+            for i, data in enumerate(neurio_data[1].values()):
+                if data["Location"] != "site":
+                    continue
+                current = math.copysign(data.get("InstCurrent", 0), data.get("InstRealPower", 0))
+                voltage = data.get("InstVoltage", 0)
+                if i == 1:
+                    i1 = current
+                    v1n = voltage
+                elif i == 2:
+                    i2 = current
+                    v2n = voltage
+                elif i == 3:
+                    i3 = current
+                    v3n = voltage
+            nonzero = [x for x in (i1, i2, i3) if x != 0]
+            i_site = sum(nonzero) / len(nonzero) if nonzero else 0
+            vll_site = compute_LL_voltage(
+                v1n = v1n,
+                v2n = v2n,
+                v3n = v3n if i == 3 else None
+            )
+
         # Compute solar (pv) voltages and current
         v_solar = lookup(status, ("esCan","bus","PVS")) or []
         sum_vll_solar = 0

--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -343,7 +343,7 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
             i1 = meter_x.get("METER_X_CTA_I", 0)
             i2 = meter_x.get("METER_X_CTB_I", 0)
             i3 = meter_x.get("METER_X_CTC_I", 0)
-            i_site = i1 + i2 + i3
+            i_site = sum(x for x in (i1, i2, i3) if x is not None)
         elif neurio_readings and len(neurio_readings) > 0:
             vll_site = v1n = v2n = v3n = 0
             neurio_data = self.tedapi.aggregate_neurio_data(


### PR DESCRIPTION
`METER_X` and `METER_Y` are specific to a Tesla electrical meter. If your system doesn't have these, Tesla's documentation says to get data from the Neurio. Solar-only installs tend to use Neurio, Powerwalls tend to use the Tesla meter.

References:
- https://energylibrary.tesla.com/docs/Public/EnergyStorage/Powerwall/General/MeteringGuide/en-us/GUID-932E78BF-6DFF-4CCA-9741-E4793E9F4314.html
- https://energylibrary.tesla.com/docs/Public/EnergyStorage/Powerwall/General/MeteringGuide/en-us/GUID-A46FB1D7-AEE5-4B66-99FF-39FE576F2B2D.html

# Testing
This allowed me to get current data from my Neurios on my Tesla inverter solar-only setup.