### PR TITLE
Add fan speed routes and update proxy version to t71

### DIFF
--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,9 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t71 (6 Apr 2025)
+
+* Add routes for fan speeds: `/fans` and `/fans/pw` (simple enumerated values for dashboard)
+
 ### Proxy t70 (25 Mar 2025)
 
 pyPowerwall v0.12.9:

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -719,7 +719,7 @@ class Handler(BaseHTTPRequestHandler):
         elif request_path == '/fans':
             # Fan speeds in raw format
             message = json.dumps(pw.tedapi.get_fan_speeds() if pw.tedapi else {})
-        elif self.path.startswith('/fans/pw'):
+        elif request_path.startswith('/fans/pw'):
             # Fan speeds in simplified format (e.g. FAN1_actual, FAN1_target)
             if pw.tedapi:
                 fans = {}


### PR DESCRIPTION
### Proxy t71 (6 Apr 2025)

* Add routes for fan speeds: `/fans` and `/fans/pw` (simple enumerated values for dashboard)
