### PR TITLE
Fix bug in extract_fan_speeds() 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 * Fix for
 TypeError: PyPowerwallTEDAPI.vitals() got an unexpected keyword argument 'force' by @F1p in https://github.com/jasonacox/pypowerwall/pull/164
 * Catch error condition when components payload is empty or malformed. Bug in extract_fan_speeds() reported by by @jgleigh in jasonacox/Powerwall-Dashboard#392 and https://github.com/jasonacox/pypowerwall/issues/167
+* Issue #162: add /pw/XXX endpoints to expose Powerwall() API methods by @JohnJ9ml in https://github.com/jasonacox/pypowerwall/pull/166
 
 ## v0.12.9 - Fan Speeds
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 # RELEASE NOTES
 
+## v0.12.10 - Power Flow and Other Fixes
+
+* Add PROXY_BASE_URL option for reverse proxying by @mccahan in https://github.com/jasonacox/pypowerwall/pull/155
+* Fix issue with power flow animation showing blank when opened more than once by @mccahan in https://github.com/jasonacox/pypowerwall/pull/156
+* Add fan speed routes and update proxy version to t71 by @jasonacox in https://github.com/jasonacox/pypowerwall/pull/161
+* Fix for
+TypeError: PyPowerwallTEDAPI.vitals() got an unexpected keyword argument 'force' by @F1p in https://github.com/jasonacox/pypowerwall/pull/164
+* Catch error condition when components payload is empty or malformed. Bug in extract_fan_speeds() reported by by @jgleigh in jasonacox/Powerwall-Dashboard#392 and https://github.com/jasonacox/pypowerwall/issues/167
+
 ## v0.12.9 - Fan Speeds
 
 * Add PVAC fan speeds to TEDAPI vitals monitoring (PVAC_Fan_Speed_Actual_RPM and PVAC_Fan_Speed_Target_RPM).

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -3,6 +3,7 @@
 ### Proxy t71 (6 Apr 2025)
 
 * Add routes for fan speeds: `/fans` and `/fans/pw` (simple enumerated values for dashboard)
+* Add API routes /pw/* to expose Powerwall() API methods (e.g. /pw/power) by @JohnJ9ml in https://github.com/jasonacox/pypowerwall/pull/166
 
 ### Proxy t70 (25 Mar 2025)
 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -88,7 +88,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 12, 9)
+version_tuple = (0, 12, 10)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -935,13 +935,17 @@ class TEDAPI:
 
     # Helper Function
     def extract_fan_speeds(self, data) -> Dict[str, Dict[str, str]]:
+        if not isinstance(data, dict):
+            return {}
+
         fan_speed_signal_names = {"PVAC_Fan_Speed_Actual_RPM", "PVAC_Fan_Speed_Target_RPM"}
 
-        # List to store the valid fan speed values
+        # List to store the valid fan speed values  
         result = {}
 
         # Iterate over each component in the "msa" list
-        for component in data.get("components", {}).get("msa", []):
+        components = data.get("components", {})
+        for component in components.get("msa", []):
             signals = component.get("signals", [])
             fan_speeds = {
                 signal["name"]: signal["value"]


### PR DESCRIPTION
v0.12.10 - Power Flow and Other Fixes

* Catch error condition when components payload is empty or malformed. Bug in extract_fan_speeds() reported by by @jgleigh in jasonacox/Powerwall-Dashboard#392 and https://github.com/jasonacox/pypowerwall/issues/167

Closes #167 