### PR TITLE
Fix error handling in  component data handling in TEDAPI

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.12.11 - Error Handling
+
+* Fix error handling in component data handling in TEDAPI.
+
 ## v0.12.10 - Power Flow and Other Fixes
 
 * Add PROXY_BASE_URL option for reverse proxying by @mccahan in https://github.com/jasonacox/pypowerwall/pull/155

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -88,7 +88,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 12, 10)
+version_tuple = (0, 12, 11)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -943,7 +943,7 @@ class TEDAPI:
 
         # Iterate over each component in the "msa" list
         components = data.get("components", {})
-        if components:
+        if isinstance(components, dict):
             for component in components.get("msa", []):
                 signals = component.get("signals", [])
                 fan_speeds = {

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -943,18 +943,19 @@ class TEDAPI:
 
         # Iterate over each component in the "msa" list
         components = data.get("components", {})
-        for component in components.get("msa", []):
-            signals = component.get("signals", [])
-            fan_speeds = {
-                signal["name"]: signal["value"]
-                for signal in signals
-                if signal.get("name") in fan_speed_signal_names and signal.get("value") is not None
-            }
-            if not fan_speeds:
-                continue
-            componentPartNumber = component.get("partNumber")
-            componentSerialNumber = component.get("serialNumber")
-            result[f"PVAC--{componentPartNumber}--{componentSerialNumber}"] = fan_speeds
+        if components:
+            for component in components.get("msa", []):
+                signals = component.get("signals", [])
+                fan_speeds = {
+                    signal["name"]: signal["value"]
+                    for signal in signals
+                    if signal.get("name") in fan_speed_signal_names and signal.get("value") is not None
+                }
+                if not fan_speeds:
+                    continue
+                componentPartNumber = component.get("partNumber")
+                componentSerialNumber = component.get("serialNumber")
+                result[f"PVAC--{componentPartNumber}--{componentSerialNumber}"] = fan_speeds
         return result
 
     def get_fan_speeds(self, force=False):


### PR DESCRIPTION
## v0.12.11 - Error Handling

* Fix error handling in component data handling in TEDAPI.

Addresses error as seen in logs:

-------------------------------------
AttributeError: 'NoneType' object has no attribute 'get'
----------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/socketserver.py", line 683, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/local/lib/python3.10/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/local/lib/python3.10/socketserver.py", line 747, in __init__
    self.handle()
  File "/usr/local/lib/python3.10/http/server.py", line 433, in handle
    self.handle_one_request()
  File "/usr/local/lib/python3.10/http/server.py", line 421, in handle_one_request
    method()
  File "/app/server.py", line 501, in do_GET
    vitals = pw.vitals() or {}
  File "/app/pypowerwall/__init__.py", line 379, in vitals
    output = self.client.vitals()
  File "/app/pypowerwall/tedapi/pypowerwall_tedapi.py", line 562, in vitals
    return self.tedapi.vitals()
  File "/app/pypowerwall/tedapi/__init__.py", line 1078, in vitals
    fan_speeds = self.extract_fan_speeds(status)
  File "/app/pypowerwall/tedapi/__init__.py", line 946, in extract_fan_speeds
    for component in components.get("msa", []):
AttributeError: 'NoneType' object has no attribute 'get'


https://github.com/jasonacox/pypowerwall/pull/169