### PR TITLE
Simple vitals endpoint for external integration

### DIFF
--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,9 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t73 (10 May 2025)
+
+* Add `/json` route to return basic metrics (Grid,Home,Solar,Battery,Level,GridStatus,Reserve)
+
 ### Proxy t72 (16 Apr 2025)
 
 * Add routes to map library functions into `/pw/` APIs (e.g. /pw/power)

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -2,7 +2,20 @@
 
 ### Proxy t73 (10 May 2025)
 
-* Add `/json` route to return basic metrics (Grid,Home,Solar,Battery,Level,GridStatus,Reserve)
+* Add `/json` route to return basic metrics:
+
+```json
+{
+"grid": -3,
+"home": 917.5,
+"solar": 5930,
+"battery": -5030,
+"soc": 61.391932759907306,
+"grid_status": 1,
+"reserve": 20,
+"time_remaining_hours": 17.03651226158038
+}
+```
 
 ### Proxy t72 (16 Apr 2025)
 

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -10,7 +10,7 @@
 "home": 917.5,
 "solar": 5930,
 "battery": -5030,
-"soc": 61.391932759907306,
+"soe": 61.391932759907306,
 "grid_status": 1,
 "reserve": 20,
 "time_remaining_hours": 17.03651226158038

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -596,7 +596,7 @@ class Handler(BaseHTTPRequestHandler):
                 'soc': pw.level() or 0,
                 'grid_status': int(pw.grid_status() == 'UP'),
                 'reserve': pw.get_reserve() or 0,
-				'time_remaining_hours': pw.get_time_remaining() or 0
+		'time_remaining_hours': pw.get_time_remaining() or 0
             }
             if not neg_solar and values['solar'] < 0:
                 # Shift negative solar to load

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -54,7 +54,7 @@ from transform import get_static, inject_js
 import pypowerwall
 from pypowerwall import parse_version
 
-BUILD = "t72"
+BUILD = "t73"
 ALLOWLIST = [
     '/api/status', '/api/site_info/site_name', '/api/meters/site',
     '/api/meters/solar', '/api/sitemaster', '/api/powerwalls',

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -593,7 +593,7 @@ class Handler(BaseHTTPRequestHandler):
                 'home': pw.home() or 0, 
                 'solar': pw.solar() or 0,
                 'battery': pw.battery() or 0,
-                'soc': pw.level() or 0,
+                'soe': pw.level() or 0,
                 'grid_status': int(pw.grid_status() == 'UP'),
                 'reserve': pw.get_reserve() or 0,
 		'time_remaining_hours': pw.get_time_remaining() or 0

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -586,6 +586,22 @@ class Handler(BaseHTTPRequestHandler):
             pod["time_remaining_hours"] = pw.get_time_remaining()
             pod["backup_reserve_percent"] = pw.get_reserve()
             message: str = json.dumps(pod)
+        elif request_path == '/json':
+            # JSON - Grid,Home,Solar,Battery,Level,GridStatus,Reserve
+            values = {
+                'grid': pw.grid() or 0,
+                'home': pw.home() or 0, 
+                'solar': pw.solar() or 0,
+                'battery': pw.battery() or 0,
+                'soc': pw.level() or 0,
+                'grid_status': int(pw.grid_status() == 'UP'),
+                'reserve': pw.get_reserve() or 0
+            }
+            if not neg_solar and values['solar'] < 0:
+                # Shift negative solar to load
+                values['home'] -= values['solar']
+                values['solar'] = 0
+            message: str = json.dumps(values)			
         elif request_path == '/version':
             # Firmware Version
             version = pw.version()

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -595,7 +595,8 @@ class Handler(BaseHTTPRequestHandler):
                 'battery': pw.battery() or 0,
                 'soc': pw.level() or 0,
                 'grid_status': int(pw.grid_status() == 'UP'),
-                'reserve': pw.get_reserve() or 0
+                'reserve': pw.get_reserve() or 0,
+				'time_remaining_hours': pw.get_time_remaining() or 0
             }
             if not neg_solar and values['solar'] < 0:
                 # Shift negative solar to load


### PR DESCRIPTION
For details see: https://github.com/jasonacox/pypowerwall/discussions/163

New `/json` endpoint that returns the following values as JSON:

`/api/meters/aggregates` for `.solar.instant_power`
`/api/meters/aggregates` for `.battery.instant_power`
`/api/meters/aggregates` for `.load.instant_power`
`/api/meters/aggregates` for `.site.instant_power`
`/soe` for `.percentage`
`/pod` for `.time_remaining_hours`

Tested with my own Powerwall 2.