### PR TITLE
Additional values /json endpoint

### DIFF
--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,19 +1,82 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t74 (12 May 2025)
+
+* Add additional data elements to `/json` route:
+
+```json
+{
+  "grid": 2423,
+  "home": 3708.5000000000005,
+  "solar": 1307,
+  "battery": -26,
+  "soe": 70.88757396449705,
+  "grid_status": 1,
+  "reserve": 70.0,
+  "time_remaining_hours": 8.076041526223541,
+  "full_pack_energy": 42250,
+  "energy_remaining": 29950.000000000004,
+  "strings": {
+    "A": {
+      "State": "Pv_Active",
+      "Voltage": 188,
+      "Current": 1.5999999999999996,
+      "Power": 300.79999999999995,
+      "Connected": true
+    },
+    "B": {
+      "State": "Pv_Active",
+      "Voltage": 318,
+      "Current": 1.2999999999999998,
+      "Power": 413.3999999999999,
+      "Connected": true
+    },
+    "C": {
+      "State": "Pv_Active",
+      "Voltage": 152,
+      "Current": 1.7499999999999998,
+      "Power": 265.99999999999994,
+      "Connected": true
+    },
+    "D": {
+      "State": "Pv_Active",
+      "Voltage": 190,
+      "Current": 1.7499999999999998,
+      "Power": 332.49999999999994,
+      "Connected": true
+    },
+    "E": {
+      "State": "Pv_Active",
+      "Voltage": 0,
+      "Current": 0.09999999999999964,
+      "Power": 0.0,
+      "Connected": true
+    },
+    "F": {
+      "State": "Pv_Active_Parallel",
+      "Voltage": 0,
+      "Current": 0,
+      "Power": 0,
+      "Connected": true
+    }
+  }
+}
+```
+
 ### Proxy t73 (10 May 2025)
 
 * Add `/json` route to return basic metrics:
 
 ```json
 {
-"grid": -3,
-"home": 917.5,
-"solar": 5930,
-"battery": -5030,
-"soe": 61.391932759907306,
-"grid_status": 1,
-"reserve": 20,
-"time_remaining_hours": 17.03651226158038
+    "grid": -3,
+    "home": 917.5,
+    "solar": 5930,
+    "battery": -5030,
+    "soe": 61.391932759907306,
+    "grid_status": 1,
+    "reserve": 20,
+    "time_remaining_hours": 17.03651226158038
 }
 ```
 

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -587,7 +587,7 @@ class Handler(BaseHTTPRequestHandler):
             pod["backup_reserve_percent"] = pw.get_reserve()
             message: str = json.dumps(pod)
         elif request_path == '/json':
-            # JSON - Grid,Home,Solar,Battery,Level,GridStatus,Reserve
+            # JSON - Grid,Home,Solar,Battery,Level,GridStatus,Reserve,TimeRemaining,FullEnergy,RemainingEnergy,Strings
             d = pw.system_status() or {}
             values = {
                 'grid': pw.grid() or 0,
@@ -600,7 +600,7 @@ class Handler(BaseHTTPRequestHandler):
                 'time_remaining_hours': pw.get_time_remaining() or 0,
                 'full_pack_energy': get_value(d, 'nominal_full_pack_energy') or 0,
                 'energy_remaining': get_value(d, 'nominal_energy_remaining') or 0,
-                'strings': pw.strings(jsonformat=True) or {}
+                'strings': pw.strings(jsonformat=False) or {}
             }
             if not neg_solar and values['solar'] < 0:
                 # Shift negative solar to load

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -54,7 +54,7 @@ from transform import get_static, inject_js
 import pypowerwall
 from pypowerwall import parse_version
 
-BUILD = "t73"
+BUILD = "t74"
 ALLOWLIST = [
     '/api/status', '/api/site_info/site_name', '/api/meters/site',
     '/api/meters/solar', '/api/sitemaster', '/api/powerwalls',

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -588,6 +588,7 @@ class Handler(BaseHTTPRequestHandler):
             message: str = json.dumps(pod)
         elif request_path == '/json':
             # JSON - Grid,Home,Solar,Battery,Level,GridStatus,Reserve
+            d = pw.system_status() or {}
             values = {
                 'grid': pw.grid() or 0,
                 'home': pw.home() or 0, 
@@ -596,7 +597,9 @@ class Handler(BaseHTTPRequestHandler):
                 'soe': pw.level() or 0,
                 'grid_status': int(pw.grid_status() == 'UP'),
                 'reserve': pw.get_reserve() or 0,
-		'time_remaining_hours': pw.get_time_remaining() or 0
+                'time_remaining_hours': pw.get_time_remaining() or 0,
+                'full_pack_energy': get_value(d, 'nominal_full_pack_energy') or 0,
+                'energy_remaining': get_value(d, 'nominal_energy_remaining') or 0
             }
             if not neg_solar and values['solar'] < 0:
                 # Shift negative solar to load

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -599,7 +599,8 @@ class Handler(BaseHTTPRequestHandler):
                 'reserve': pw.get_reserve() or 0,
                 'time_remaining_hours': pw.get_time_remaining() or 0,
                 'full_pack_energy': get_value(d, 'nominal_full_pack_energy') or 0,
-                'energy_remaining': get_value(d, 'nominal_energy_remaining') or 0
+                'energy_remaining': get_value(d, 'nominal_energy_remaining') or 0,
+				'strings': pw.strings(jsonformat=True) or {}
             }
             if not neg_solar and values['solar'] < 0:
                 # Shift negative solar to load

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -600,7 +600,7 @@ class Handler(BaseHTTPRequestHandler):
                 'time_remaining_hours': pw.get_time_remaining() or 0,
                 'full_pack_energy': get_value(d, 'nominal_full_pack_energy') or 0,
                 'energy_remaining': get_value(d, 'nominal_energy_remaining') or 0,
-				'strings': pw.strings(jsonformat=True) or {}
+                'strings': pw.strings(jsonformat=True) or {}
             }
             if not neg_solar and values['solar'] < 0:
                 # Shift negative solar to load


### PR DESCRIPTION
I have added the following values to the `/json` endpoint:

`nominal_full_pack_energy`
`nominal_energy_remaining`
`strings`

`nominal_full_pack_energy `and `nominal_energy_remaining `are tested.

I cannot test the `strings `because I have a SolarEdge inverter.