### PR TITLE
Add CLI for Auth File

### DIFF
--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -203,9 +203,13 @@ class Powerwall(object):
                 self.mode = "fleetapi"
             elif os.path.exists(os.path.join(self.authpath, AUTHFILE)):
                 if not self.email or self.email == "nobody@nowhere.com":
-                    with open(authpath + AUTHFILE, 'r') as file:
-                        auth = json.load(file)
-                    self.email = list(auth.keys())[0]
+                    auth_file_path = os.path.join(self.authpath, AUTHFILE)
+                    try:
+                        with open(auth_file_path, 'r') as file:
+                            auth = json.load(file)
+                        self.email = list(auth.keys())[0]
+                    except Exception as exc:
+                        log.debug(f"Failed to load auth file '{auth_file_path}': {exc}")
                 self.cloudmode = True
                 self.fleetapi = False
                 self.mode = "cloud"

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -74,6 +74,8 @@ version_args = subparsers.add_parser("version", help='Print version information'
 
 # Add a global debug flag
 p.add_argument("-debug", action="store_true", default=False, help="Enable debug output")
+p.add_argument("-authpath", type=str, default=None,
+               help="Override auth path (default uses PW_AUTH_PATH env var)")
 
 if len(sys.argv) == 1:
     p.print_help(sys.stderr)
@@ -82,6 +84,10 @@ if len(sys.argv) == 1:
 # parse args
 args = p.parse_args()
 command = args.command
+
+# Override authpath if provided on command line
+if getattr(args, 'authpath', None):
+    authpath = os.path.expanduser(args.authpath)
 
 # Set Debug Mode
 if args.debug:


### PR DESCRIPTION
This pull request introduces improvements to the authentication handling and command-line interface for the `pypowerwall` project. The main changes increase flexibility for specifying authentication paths and improve error handling when loading authentication files.

Authentication path improvements:

* Added a new `-authpath` command-line argument in `pypowerwall/__main__.py` to allow users to override the default authentication path, making it easier to specify custom locations for auth files.
* Updated the main script to use the provided `authpath` argument when present, expanding user control over authentication file locations.

Error handling enhancements:

* Improved error handling in the authentication file loading logic in `pypowerwall/__init__.py` by wrapping the file read in a try/except block and logging debug information if loading fails, making the process more robust and easier to troubleshoot.…path