### PR TITLE
Add Command Line Arg for Auth-File Setting

### DIFF
--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -203,9 +203,13 @@ class Powerwall(object):
                 self.mode = "fleetapi"
             elif os.path.exists(os.path.join(self.authpath, AUTHFILE)):
                 if not self.email or self.email == "nobody@nowhere.com":
-                    with open(authpath + AUTHFILE, 'r') as file:
-                        auth = json.load(file)
-                    self.email = list(auth.keys())[0]
+                    auth_file_path = os.path.join(self.authpath, AUTHFILE)
+                    try:
+                        with open(auth_file_path, 'r') as file:
+                            auth = json.load(file)
+                        self.email = list(auth.keys())[0]
+                    except Exception as exc:
+                        log.debug(f"Failed to load auth file '{auth_file_path}': {exc}")
                 self.cloudmode = True
                 self.fleetapi = False
                 self.mode = "cloud"

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -74,6 +74,8 @@ version_args = subparsers.add_parser("version", help='Print version information'
 
 # Add a global debug flag
 p.add_argument("-debug", action="store_true", default=False, help="Enable debug output")
+p.add_argument("-authpath", type=str, default=None,
+               help="Override auth path (default uses PW_AUTH_PATH env var)")
 
 if len(sys.argv) == 1:
     p.print_help(sys.stderr)
@@ -82,6 +84,10 @@ if len(sys.argv) == 1:
 # parse args
 args = p.parse_args()
 command = args.command
+
+# Override authpath if provided on command line
+if getattr(args, 'authpath', None):
+    authpath = os.path.expanduser(args.authpath)
 
 # Set Debug Mode
 if args.debug:

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -85,9 +85,21 @@ if len(sys.argv) == 1:
 args = p.parse_args()
 command = args.command
 
-# Override authpath if provided on command line
-if getattr(args, 'authpath', None):
-    authpath = os.path.expanduser(args.authpath)
+# Priority: command-line value > PW_AUTH_PATH env var > current directory
+if args.authpath is not None:  # user explicitly provided (could be "" to force CWD)
+    if args.authpath.strip() == "":
+        authpath = ""  # current directory
+    else:
+        authpath = os.path.expanduser(args.authpath)
+else:
+    # If env var produced None (shouldn't) or still None-like, fallback to "" (cwd)
+    authpath = authpath or ""
+
+# Debug: Show final authpath resolution before using it
+if args.debug:
+    # Show absolute path if non-empty, otherwise indicate current directory
+    display_authpath = os.path.abspath(authpath) if authpath else os.path.abspath(os.getcwd())
+    print(f"[DEBUG] Using auth path: {display_authpath} (raw='{authpath}')")
 
 # Set Debug Mode
 if args.debug:


### PR DESCRIPTION
This pull request introduces improvements to the authentication path handling and error logging in the `pypowerwall` package. The main changes enhance usability by allowing users to override the authentication path via a command-line argument and improve debugging by logging errors when loading the authentication file fails.

**Authentication Path Handling:**
* Added a new `-authpath` command-line argument in `pypowerwall/__main__.py` to allow users to override the default authentication path, improving flexibility for different environments.
* Updated the initialization logic to use the provided authentication path and added error handling with debug logging if the authentication file cannot be loaded, making troubleshooting easier.

**Command-line Argument Processing:**
* Implemented logic to expand and set the overridden authentication path if specified on the command line, ensuring consistent path handling.…path