### PR TITLE
Add curl to Dockerfiles to use in healthchecks instead of wget

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # RELEASE NOTES
 
+## v0.14.3 - Docker Curl
+
+* Add curl to Dockerfiles to use in healthchecks instead of wget by @goodoldme in http://github.com/jasonacox/pypowerwall/pull/223.
 
 ## v0.14.2 - Misc
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,5 @@
 # RELEASE NOTES
 
-## v0.14.3 - Docker Curl
-
-* Add curl to Dockerfiles to use in healthchecks instead of wget by @goodoldme in http://github.com/jasonacox/pypowerwall/pull/223.
-
 ## v0.14.2 - Misc
 
 * Move API lock timeout messages in exponential backoff mechanism to DEBUG logging to prevent noise for regular users.

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10-alpine
 WORKDIR /app
 
 # Install git (and build dependencies if needed)
-RUN apk add --no-cache git
+RUN apk add --no-cache git curl
 
 COPY requirements.txt /app/requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt

--- a/proxy/Dockerfile.beta
+++ b/proxy/Dockerfile.beta
@@ -3,7 +3,7 @@ FROM python:3.10-alpine
 WORKDIR /app
 
 # Install git (and build dependencies if needed)
-RUN apk add --no-cache git
+RUN apk add --no-cache git curl
 
 COPY beta.txt /app/requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,8 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t83 (5 Oct 2025)
+
+* dd curl to Dockerfiles to use in healthchecks instead of wget by @goodoldme in http://github.com/jasonacox/pypowerwall/pull/223.
 
 ### Proxy t82 (6 Sep 2025)
 

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -128,7 +128,7 @@ from pypowerwall.fleetapi.exceptions import (
     PyPowerwallFleetAPIInvalidPayload,
 )
 
-BUILD = "t82"
+BUILD = "t83"
 ALLOWLIST = [
     "/api/status",
     "/api/site_info/site_name",


### PR DESCRIPTION
Added curl to Dockerfiles to use in healthchecks instead of wget to fix [issue ](https://github.com/jasonacox/Powerwall-Dashboard/issues/693)