### PR TITLE
v2.9.2 - Fix TeslaPy backup history API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ tools/tedapi/pw3.json
 tools/tedapi/test.py
 proxy/.beta_version
 cleanroom
+tools/tesla-history/

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -88,7 +88,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 14, 4)
+version_tuple = (0, 14, 5)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/cloud/teslapy/README.md
+++ b/pypowerwall/cloud/teslapy/README.md
@@ -2,13 +2,15 @@
 
 TeslaPy is a Python API that lets you monitor and control Tesla products remotely. It is based on [unofficial documentation](https://tesla-api.timdorr.com/) of the Tesla Motors Owner API.
 
-## Local Copy Notice
+## Fork Notice
 
-**Note:** This project is temporarily using a local copy of the TeslaPy library (version 2.9.1) until the original repository publishes this version to PyPI. All credit for TeslaPy goes to the original author, Tim Dorssers, and repository:
+**Note:** This is a fork of the TeslaPy library, originally forked from version 2.9.0:
 
 https://github.com/tdorssers/TeslaPy
 
-This local inclusion is for compatibility and stability only. Please see the upstream repository for the latest updates and license information.
+This fork is maintained as part of pypowerwall to provide timely fixes for Tesla API changes. The original TeslaPy repository is no longer actively maintained, and this fork includes pypowerwall-specific patches and updates to maintain compatibility with Tesla's evolving API.
+
+All credit for the original TeslaPy implementation goes to Tim Dorssers. See RELEASE.md for changes made in this fork.
 
 ## License
 

--- a/pypowerwall/cloud/teslapy/RELEASE.md
+++ b/pypowerwall/cloud/teslapy/RELEASE.md
@@ -1,0 +1,27 @@
+# TeslaPy Release Notes
+
+This fork is maintained as part of pypowerwall. Original repository: https://github.com/tdorssers/TeslaPy
+
+## v2.9.2 - Fix Backup History API Endpoint
+
+* Fix backup event history retrieval after Tesla deprecated `/api/v2/energy_site/backup_history` endpoint
+* Update `get_history_data()` to use `CALENDAR_HISTORY_DATA` endpoint when `kind='backup'`
+* Addresses issue where backup history queries returned 410 Gone errors
+* See: https://github.com/jasonacox/Powerwall-Dashboard/issues/714
+
+## v2.9.1 - Initial Fork
+
+* Forked from TeslaPy version 2.9.0 (https://github.com/tdorssers/TeslaPy)
+* Embedded into pypowerwall to provide timely fixes for Tesla API changes
+* Original TeslaPy repository is no longer actively maintained
+* See: https://github.com/jasonacox/pypowerwall/issues/197
+
+---
+
+## Original TeslaPy Credits
+
+TeslaPy was created and maintained by Tim Dorssers.
+
+Copyright (c) 2019 Tim Dorssers
+
+Licensed under the MIT License. See the LICENSE file for details.

--- a/pypowerwall/cloud/teslapy/__init__.py
+++ b/pypowerwall/cloud/teslapy/__init__.py
@@ -2,11 +2,15 @@
 RFC compliant OAuth 2 Single Sign-On service. Tokens are saved to 'cache.json'
 for reuse and refreshed automatically. The vehicle option codes are loaded from
 'option_codes.json' and the API endpoints are loaded from 'endpoints.json'.
+
+This is a fork of TeslaPy (https://github.com/tdorssers/TeslaPy) maintained as
+part of pypowerwall (https://github.com/jasonacox/pypowerwall) with fixes for
+Tesla API changes. See RELEASE.md for details.
 """
 
 # Author: Tim Dorssers
 
-__version__ = '2.9.1'
+__version__ = '2.9.2'
 
 import os
 import ast
@@ -805,6 +809,11 @@ class Product(JsonDict):
                     '2021-02-27T07:59:59.999Z'
         installation_timezone: Timezone of installation location for 'savings'
         """
+        # Tesla moved backup history to calendar_history endpoint
+        if kind == 'backup':
+            return self.api('CALENDAR_HISTORY_DATA', kind=kind, period=period,
+                            start_date=start_date, end_date=end_date,
+                            time_zone=timezone)['response']
         return self.api('HISTORY_DATA', kind=kind, period=period,
                         start_date=start_date, end_date=end_date,
                         installation_timezone=installation_timezone,


### PR DESCRIPTION
This pull request updates the TeslaPy integration within pypowerwall to address recent Tesla API changes and clarifies the project's forking status. The most significant change is a fix for backup event history retrieval, ensuring continued compatibility with Tesla's evolving API. Documentation has also been updated to reflect the fork and outline changes.

**Tesla API compatibility fixes:**
* Updated `get_history_data()` in `teslapy/__init__.py` to use the `CALENDAR_HISTORY_DATA` endpoint for `kind='backup'`, addressing 410 Gone errors after Tesla deprecated the old endpoint.

**Version and release management:**
* Bumped TeslaPy fork version to `2.9.2` in `teslapy/__init__.py` and `pypowerwall/__init__.py` to reflect the API fix. [[1]](diffhunk://#diff-895835301bd9542054af5261436298f85c5bc9d838b07ce6e20ae7b9b0bb0147R5-R13) [[2]](diffhunk://#diff-c3c2ae850adc019cf48d1243c8e21c1333dcfd608e37abd642c9a7427c246e62L91-R91)
* Added a new `RELEASE.md` file in `teslapy/` documenting the fork, the backup history fix, and credits to the original author.

**Documentation and project clarification:**
* Updated `README.md` in `teslapy/` to clarify that this is a maintained fork of the original TeslaPy, now embedded in pypowerwall for timely API fixes.
* Added a note to the module docstring in `teslapy/__init__.py` describing the fork and referencing `RELEASE.md` for details.

## Integration Example

Installation

```bash
pip install pypowerwall
```

Code Change

```python
# migrate from
from teslapy import Tesla, Retry, JsonDict, Battery, SolarPanel

# to this
from pypowerwall.cloud.teslapy import Tesla, Retry, JsonDict, Battery, SolarPanel
```