### PR TITLE
Begin refactoring do_GET in the proxy into functions with the /freq endpoint

### DIFF
--- a/proxy/server.py
+++ b/proxy/server.py
@@ -1148,7 +1148,7 @@ class Handler(BaseHTTPRequestHandler):
             request_path = "/" + new_path
 
         # Old path handling for until migration to functions is complete.
-        if not request_path in self.GET_PATH_HANDLERS:
+        if request_path not in self.GET_PATH_HANDLERS:
             self._do_get_branches(request_path)
             return
 

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -930,7 +930,6 @@ class Handler(BaseHTTPRequestHandler):
             proxystats["errors"] += 1
             return ""
 
-
     def do_POST(self):
         global proxystats
         contenttype = "application/json"

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -1584,7 +1584,7 @@ class Handler(BaseHTTPRequestHandler):
 
             message = cached_route_handler("/alerts/pw", generate_alerts_pw)
         elif request_path == "/freq":
-            # No longer handled here.
+            # Now handled by get_handle_freq in GET_PATH_HANDLERS
             return
         elif request_path == "/pod":
             # Powerwall Battery Data

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -88,12 +88,13 @@ import resource
 import signal
 import ssl
 import sys
-import time
 import threading
+import time
+from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
-from typing import Optional
-from urllib.parse import urlparse, parse_qs
+from typing import Final
+from urllib.parse import parse_qs, urlparse
 
 import requests
 import urllib3
@@ -109,26 +110,22 @@ except ImportError:  # noqa: BLE001 - fall back to other strategies
         from proxy.transform import get_static, inject_js  # type: ignore
     except ImportError:  # noqa: BLE001
         from transform import get_static, inject_js  # type: ignore  # Last resort
+
 import pypowerwall
 from pypowerwall import parse_version
-from pypowerwall.exceptions import (
-    PyPowerwallInvalidConfigurationParameter,
-    InvalidBatteryReserveLevelException,
-)
-from pypowerwall.tedapi.exceptions import (
-    PyPowerwallTEDAPINoTeslaAuthFile,
-    PyPowerwallTEDAPITeslaNotConnected,
-    PyPowerwallTEDAPINotImplemented,
-    PyPowerwallTEDAPIInvalidPayload,
-)
+from pypowerwall.exceptions import (InvalidBatteryReserveLevelException,
+                                    PyPowerwallInvalidConfigurationParameter)
 from pypowerwall.fleetapi.exceptions import (
-    PyPowerwallFleetAPINoTeslaAuthFile,
-    PyPowerwallFleetAPITeslaNotConnected,
-    PyPowerwallFleetAPINotImplemented,
-    PyPowerwallFleetAPIInvalidPayload,
-)
+    PyPowerwallFleetAPIInvalidPayload, PyPowerwallFleetAPINoTeslaAuthFile,
+    PyPowerwallFleetAPINotImplemented, PyPowerwallFleetAPITeslaNotConnected)
+from pypowerwall.tedapi.exceptions import (PyPowerwallTEDAPIInvalidPayload,
+                                           PyPowerwallTEDAPINoTeslaAuthFile,
+                                           PyPowerwallTEDAPINotImplemented,
+                                           PyPowerwallTEDAPITeslaNotConnected)
 
-BUILD = "t87"
+BUILD: Final[str] = "t87"
+UTF_8: Final[str] = "utf-8"
+
 ALLOWLIST = [
     "/api/status",
     "/api/site_info/site_name",
@@ -484,20 +481,20 @@ def get_performance_cached(cache_key):
     """
     Get cached endpoint response for performance optimization.
     Uses standard cache_expire TTL (typically 5 seconds).
-    
+
     Args:
         cache_key: The cache key (e.g., '/csv/v2', '/json', '/freq', '/pod')
-    
+
     Returns:
         Cached response string if available and fresh, None otherwise
     """
     with _performance_cache_lock:
         if cache_key not in _performance_cache:
             return None
-        
+
         data, timestamp = _performance_cache[cache_key]
         age = time.time() - timestamp
-        
+
         # Use standard cache_expire (same as pypowerwall's internal cache)
         if age < cache_expire:
             log.debug(f"Performance cache hit for {cache_key} (age: {age:.2f}s)")
@@ -510,7 +507,7 @@ def get_performance_cached(cache_key):
 def cache_performance_response(cache_key, data):
     """
     Cache endpoint response for performance optimization.
-    
+
     Args:
         cache_key: The cache key (e.g., '/csv/v2', '/json', '/freq', '/pod')
         data: The response string to cache
@@ -523,10 +520,10 @@ def cache_performance_response(cache_key, data):
 def performance_cached(cache_key):
     """
     Decorator for performance caching of route handlers.
-    
+
     Args:
         cache_key: The cache key to use (e.g., '/vitals', '/strings', '/freq')
-    
+
     Returns:
         Decorator function that wraps route handlers with caching logic
     """
@@ -536,16 +533,16 @@ def performance_cached(cache_key):
             cached_response = get_performance_cached(cache_key)
             if cached_response is not None:
                 return cached_response
-            
+
             # Cache miss - generate fresh data
             result = func(*args, **kwargs)
-            
+
             # Only cache non-None results
             if result is not None:
                 cache_performance_response(cache_key, result)
-            
+
             return result
-        
+
         return wrapper
     return decorator
 
@@ -553,11 +550,11 @@ def performance_cached(cache_key):
 def cached_route_handler(cache_key, data_generator):
     """
     Helper function for performance-cached route handling.
-    
+
     Args:
         cache_key: The cache key to use for this route
         data_generator: Function that generates the response data
-    
+
     Returns:
         Cached response if available, otherwise fresh data (and caches it)
     """
@@ -565,14 +562,14 @@ def cached_route_handler(cache_key, data_generator):
     cached_response = get_performance_cached(cache_key)
     if cached_response is not None:
         return cached_response
-    
+
     # Cache miss - generate fresh data
     result = data_generator()
-    
+
     # Only cache non-None results
     if result is not None:
         cache_performance_response(cache_key, result)
-    
+
     return result
 
 
@@ -892,6 +889,24 @@ class Handler(BaseHTTPRequestHandler):
         hostaddr, hostport = self.client_address[:2]
         return hostaddr
 
+
+    def send_json_response(self, data, status_code=HTTPStatus.OK, content_type='application/json') -> str:
+        global proxystats
+        response = json.dumps(data)
+        try:
+            self.send_response(status_code)
+            self.send_header('Content-type', content_type)
+            self.send_header('Content-Length', str(len(response)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            if self.wfile.write(response.encode(UTF_8)) > 0:
+                return response
+        except Exception as exc:
+            log.debug(f"Error sending response: {exc}")
+            proxystats["errors"] += 1
+        return response
+
+
     def do_POST(self):
         global proxystats
         contenttype = "application/json"
@@ -1041,10 +1056,62 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(message.encode("utf8"))
 
+    def get_handle_freq(self) -> str:
+        # Frequency, Current, Voltage and Grid Status
+        def generate_freq() -> str:
+            fcv = {}
+            idx = 1
+            # Pull freq, current, voltage of each Powerwall via system_status
+            d = safe_pw_call(pw.system_status) or {}
+            if "battery_blocks" in d:
+                for block in d["battery_blocks"]:
+                    fcv["PW%d_name" % idx] = None  # Placeholder for vitals
+                    fcv["PW%d_PINV_Fout" % idx] = get_value(block, "f_out")
+                    fcv["PW%d_PINV_VSplit1" % idx] = None  # Placeholder for vitals
+                    fcv["PW%d_PINV_VSplit2" % idx] = None  # Placeholder for vitals
+                    fcv["PW%d_PackagePartNumber" % idx] = get_value(
+                        block, "PackagePartNumber"
+                    )
+                    fcv["PW%d_PackageSerialNumber" % idx] = get_value(
+                        block, "PackageSerialNumber"
+                    )
+                    fcv["PW%d_p_out" % idx] = get_value(block, "p_out")
+                    fcv["PW%d_q_out" % idx] = get_value(block, "q_out")
+                    fcv["PW%d_v_out" % idx] = get_value(block, "v_out")
+                    fcv["PW%d_f_out" % idx] = get_value(block, "f_out")
+                    fcv["PW%d_i_out" % idx] = get_value(block, "i_out")
+                    idx = idx + 1
+            # Pull freq, current, voltage of each Powerwall via vitals if available
+            vitals = safe_pw_call(pw.vitals) or {}
+            idx = 1
+            for device in vitals:
+                d = vitals[device]
+                if device.startswith("TEPINV"):
+                    # PW freq
+                    fcv["PW%d_name" % idx] = device
+                    fcv["PW%d_PINV_Fout" % idx] = get_value(d, "PINV_Fout")
+                    fcv["PW%d_PINV_VSplit1" % idx] = get_value(d, "PINV_VSplit1")
+                    fcv["PW%d_PINV_VSplit2" % idx] = get_value(d, "PINV_VSplit2")
+                    idx = idx + 1
+                if device.startswith("TESYNC") or device.startswith("TEMSA"):
+                    # Island and Meter Metrics from Backup Gateway or Backup Switch
+                    for i in d:
+                        if i.startswith("ISLAND") or i.startswith("METER"):
+                            fcv[i] = d[i]
+            fcv["grid_status"] = safe_pw_call(pw.grid_status, "numeric")
+            return json.dumps(fcv)
+
+        message = cached_route_handler("/freq", generate_freq)
+        return self.send_json_response(json.loads(message))
+
+    # Map paths to handler functions
+    GET_PATH_HANDLERS = {
+        '/freq': get_handle_freq,
+    }
+
     def do_GET(self):
-        global proxystats
-        self.send_response(200)
-        contenttype = "application/json"
+        """Handle GET requests."""
+        self.send_response(HTTPStatus.OK)
 
         # If set, remove the api_base_url from the requested path. This allows installing the
         # the proxy on a path without impacting the use of Telegraf or other integrations. Python 3.9+
@@ -1052,6 +1119,42 @@ class Handler(BaseHTTPRequestHandler):
         new_path = request_path.removeprefix(api_base_url)
         if new_path is not request_path:
             request_path = "/" + new_path
+
+        # Old path handling for until migration to functions is complete.
+        if not request_path in self.GET_PATH_HANDLERS:
+            self._do_get_branches(request_path)
+            return
+
+        # New path handling via function mapping. Intent is to migrate all paths to this method.
+        result: str = self.GET_PATH_HANDLERS[request_path](self)
+
+        API_PATHS = frozenset({"/aggregates", "/soe", "/vitals", "/strings"})
+        def _is_api_endpoint(path: str) -> bool:
+            return path.startswith("/api/") or path in API_PATHS
+
+        message = None
+        global proxystats
+        with proxystats_lock:
+            if not result:  # None or ""
+                proxystats["timeout"] += 1
+                # JSON null for API endpoints
+                message = "null" if _is_api_endpoint(request_path) else "TIMEOUT!"
+            elif result == "ERROR!":
+                proxystats["errors"] += 1
+                message = "ERROR!"
+            else:
+                proxystats["gets"] += 1
+                proxystats["uri"][request_path] = proxystats["uri"].get(request_path, 0) + 1
+
+        if message is not None:
+            result = self.send_json_response(json.loads(message))
+
+
+    # Eventually the plan is to move everything in this "god" function
+    # to individual handler functions mapped in GET_PATH_HANDLERS above.
+    def _do_get_branches(self, request_path: str):
+        global proxystats
+        contenttype = "application/json"
 
         if request_path == "/aggregates" or request_path == "/api/meters/aggregates":
             # Meters - JSON
@@ -1110,12 +1213,12 @@ class Handler(BaseHTTPRequestHandler):
             # CSV2 Output - Grid,Home,Solar,Battery,Level,GridStatus,Reserve
             # Add ?headers to include CSV headers, e.g. http://localhost:8675/csv?headers
             contenttype = "text/plain; charset=utf-8"
-            
+
             # Determine endpoint and whether to include headers
             is_v2 = request_path.startswith("/csv/v2")
             include_headers = "headers" in request_path
             cache_key = f"/csv/v2{'_headers' if include_headers else ''}" if is_v2 else f"/csv{'_headers' if include_headers else ''}"
-            
+
             def generate_csv():
                 # Optimization: Use single aggregates call for all power values
                 aggregates = safe_endpoint_call("/aggregates", pw.poll, "/api/meters/aggregates", jsonformat=False)
@@ -1126,21 +1229,21 @@ class Handler(BaseHTTPRequestHandler):
                     home = aggregates.get('load', {}).get('instant_power', 0)
                 else:
                     grid = solar = battery = home = 0
-                
+
                 # Apply negative solar correction if configured
                 if not neg_solar and solar < 0:
                     # Shift energy from solar to load
                     home -= solar
                     solar = 0
-                
+
                 # Get battery level - poll() handles caching internally
                 batterylevel = safe_pw_call(pw.level) or 0
-                
+
                 if is_v2:
                     # Get grid status and reserve - these use cached data internally
                     gridstatus = 1 if safe_pw_call(pw.grid_status) == "UP" else 0
                     reserve = safe_pw_call(pw.get_reserve) or 0
-                
+
                 # Build CSV response
                 if is_v2:
                     result = ""
@@ -1169,7 +1272,7 @@ class Handler(BaseHTTPRequestHandler):
                         batterylevel,
                     )
                 return result
-            
+
             message = cached_route_handler(cache_key, generate_csv)
         elif request_path == "/vitals":
             # Vitals Data - JSON
@@ -1222,7 +1325,7 @@ class Handler(BaseHTTPRequestHandler):
                     proxystats["mem_cache"]["error_counts"] = {
                         "entries": len(_error_counts),
                         "size_bytes": sys.getsizeof(_error_counts) + sum(
-                            sys.getsizeof(k) + sys.getsizeof(v) 
+                            sys.getsizeof(k) + sys.getsizeof(v)
                             for k, v in _error_counts.items()
                         ),
                     }
@@ -1230,7 +1333,7 @@ class Handler(BaseHTTPRequestHandler):
                         "entries": len(_network_error_summary),
                         "size_bytes": sys.getsizeof(_network_error_summary) + sum(
                             sys.getsizeof(k) + sys.getsizeof(v) + sum(
-                                sys.getsizeof(ek) + sys.getsizeof(ev) 
+                                sys.getsizeof(ek) + sys.getsizeof(ev)
                                 for ek, ev in v.items()
                             ) for k, v in _network_error_summary.items()
                         ),
@@ -1259,7 +1362,7 @@ class Handler(BaseHTTPRequestHandler):
                         "entries": len(_endpoint_stats),
                         "size_bytes": sys.getsizeof(_endpoint_stats) + sum(
                             sys.getsizeof(k) + sys.getsizeof(v) + sum(
-                                sys.getsizeof(ek) + sys.getsizeof(ev) 
+                                sys.getsizeof(ek) + sys.getsizeof(ev)
                                 for ek, ev in v.items()
                             ) for k, v in _endpoint_stats.items()
                         ),
@@ -1419,7 +1522,7 @@ class Handler(BaseHTTPRequestHandler):
                         pwtemp[key] = temps[i]
                         idx = idx + 1
                 return json.dumps(pwtemp)
-            
+
             message = cached_route_handler("/temps/pw", generate_temps_pw)
         elif request_path == "/alerts":
             # Alerts
@@ -1435,54 +1538,11 @@ class Handler(BaseHTTPRequestHandler):
                     for alert in alerts:
                         pwalerts[alert] = 1
                     return json.dumps(pwalerts) or json.dumps({})
-            
+
             message = cached_route_handler("/alerts/pw", generate_alerts_pw)
         elif request_path == "/freq":
-            # Frequency, Current, Voltage and Grid Status
-            def generate_freq():
-                fcv = {}
-                idx = 1
-                # Pull freq, current, voltage of each Powerwall via system_status
-                d = safe_pw_call(pw.system_status) or {}
-                if "battery_blocks" in d:
-                    for block in d["battery_blocks"]:
-                        fcv["PW%d_name" % idx] = None  # Placeholder for vitals
-                        fcv["PW%d_PINV_Fout" % idx] = get_value(block, "f_out")
-                        fcv["PW%d_PINV_VSplit1" % idx] = None  # Placeholder for vitals
-                        fcv["PW%d_PINV_VSplit2" % idx] = None  # Placeholder for vitals
-                        fcv["PW%d_PackagePartNumber" % idx] = get_value(
-                            block, "PackagePartNumber"
-                        )
-                        fcv["PW%d_PackageSerialNumber" % idx] = get_value(
-                            block, "PackageSerialNumber"
-                        )
-                        fcv["PW%d_p_out" % idx] = get_value(block, "p_out")
-                        fcv["PW%d_q_out" % idx] = get_value(block, "q_out")
-                        fcv["PW%d_v_out" % idx] = get_value(block, "v_out")
-                        fcv["PW%d_f_out" % idx] = get_value(block, "f_out")
-                        fcv["PW%d_i_out" % idx] = get_value(block, "i_out")
-                        idx = idx + 1
-                # Pull freq, current, voltage of each Powerwall via vitals if available
-                vitals = safe_pw_call(pw.vitals) or {}
-                idx = 1
-                for device in vitals:
-                    d = vitals[device]
-                    if device.startswith("TEPINV"):
-                        # PW freq
-                        fcv["PW%d_name" % idx] = device
-                        fcv["PW%d_PINV_Fout" % idx] = get_value(d, "PINV_Fout")
-                        fcv["PW%d_PINV_VSplit1" % idx] = get_value(d, "PINV_VSplit1")
-                        fcv["PW%d_PINV_VSplit2" % idx] = get_value(d, "PINV_VSplit2")
-                        idx = idx + 1
-                    if device.startswith("TESYNC") or device.startswith("TEMSA"):
-                        # Island and Meter Metrics from Backup Gateway or Backup Switch
-                        for i in d:
-                            if i.startswith("ISLAND") or i.startswith("METER"):
-                                fcv[i] = d[i]
-                fcv["grid_status"] = safe_pw_call(pw.grid_status, "numeric")
-                return json.dumps(fcv)
-            
-            message = cached_route_handler("/freq", generate_freq)
+            # No longer handled here.
+            return
         elif request_path == "/pod":
             # Powerwall Battery Data
             def generate_pod():
@@ -1600,7 +1660,7 @@ class Handler(BaseHTTPRequestHandler):
                 pod["time_remaining_hours"] = safe_pw_call(pw.get_time_remaining)
                 pod["backup_reserve_percent"] = safe_pw_call(pw.get_reserve)
                 return json.dumps(pod)
-            
+
             message = cached_route_handler("/pod", generate_pod)
         elif request_path == "/json":
             # JSON - Grid,Home,Solar,Battery,Level,GridStatus,Reserve,TimeRemaining,FullEnergy,RemainingEnergy,Strings
@@ -1614,13 +1674,13 @@ class Handler(BaseHTTPRequestHandler):
                     home = aggregates.get('load', {}).get('instant_power', 0)
                 else:
                     grid = solar = battery = home = 0
-                
+
                 # Apply negative solar correction if configured
                 if not neg_solar and solar < 0:
                     # Shift energy from solar to load
                     home -= solar
                     solar = 0
-                
+
                 # Get remaining data
                 d = safe_pw_call(pw.system_status) or {}
                 values = {
@@ -1637,7 +1697,7 @@ class Handler(BaseHTTPRequestHandler):
                     "strings": safe_pw_call(pw.strings, jsonformat=False) or {},
                 }
                 return json.dumps(values)
-            
+
             message = cached_route_handler("/json", generate_json)
         elif request_path == "/version":
             # Firmware Version

--- a/proxy/tests/test_csv_endpoints.py
+++ b/proxy/tests/test_csv_endpoints.py
@@ -118,7 +118,7 @@ class BaseDoGetTest(unittest.TestCase):
         result = self.get_written_json()
         self.assertIn(expected_key, result)
         self.assertEqual(result[expected_key], expected_value)
-        
+
     def do_get(self, path: str) -> str:
         """
         Run Handler.do_GET for a given path under the standard patches
@@ -211,7 +211,7 @@ class TestDoGetAggregatesEndpoints(BaseDoGetTest):
             mock_cache_write.assert_called_once()
             cache_key, cached_json = mock_cache_write.call_args[0]
             self.assertEqual(cache_key, "/aggregates")
-            
+
             cached_data = json.loads(cached_json)
             self.assertEqual(cached_data["solar"]["instant_power"], 0)  # Should be clamped to 0
             self.assertEqual(cached_data["load"]["instant_power"], 1800)  # Should be 1500 - (-300) = 1800
@@ -228,7 +228,7 @@ class TestDoGetAggregatesEndpoints(BaseDoGetTest):
             "solar": {"instant_power": 0},
             "load": {"instant_power": 1800}
         })
-        
+
         with patch('proxy.server.get_performance_cached', return_value=cached_processed_data):
             self.handler.path = "/aggregates"
             mock_pw.poll = Mock()
@@ -246,7 +246,7 @@ class TestDoGetAggregatesEndpoints(BaseDoGetTest):
             self.assertEqual(result["load"]["instant_power"], 1800)
 
     @common_patches
-    @patch('proxy.server.pw') 
+    @patch('proxy.server.pw')
     @patch('proxy.server.neg_solar', False)
     @patch('proxy.server.safe_endpoint_call')
     @patch('proxy.server.cache_performance_response')
@@ -258,7 +258,7 @@ class TestDoGetAggregatesEndpoints(BaseDoGetTest):
                 "expected": {"solar": {"instant_power": 0}, "load": {"instant_power": 900}}
             },
             {
-                "input": {"solar": {"instant_power": -750}, "load": {"instant_power": 2000}}, 
+                "input": {"solar": {"instant_power": -750}, "load": {"instant_power": 2000}},
                 "expected": {"solar": {"instant_power": 0}, "load": {"instant_power": 2750}}
             }
         ]
@@ -267,7 +267,7 @@ class TestDoGetAggregatesEndpoints(BaseDoGetTest):
             with self.subTest(scenario=i):
                 mock_cache_write.reset_mock()
                 mock_safe_call.reset_mock()
-                
+
                 with patch('proxy.server.get_performance_cached', return_value=None):
                     self.handler.path = "/aggregates"
                     mock_safe_call.return_value = scenario["input"]
@@ -278,13 +278,13 @@ class TestDoGetAggregatesEndpoints(BaseDoGetTest):
                     mock_cache_write.assert_called_once()
                     cache_key, cached_json = mock_cache_write.call_args[0]
                     cached_data = json.loads(cached_json)
-                    
-                    self.assertEqual(cached_data["solar"]["instant_power"], 
+
+                    self.assertEqual(cached_data["solar"]["instant_power"],
                                    scenario["expected"]["solar"]["instant_power"])
-                    self.assertEqual(cached_data["load"]["instant_power"], 
+                    self.assertEqual(cached_data["load"]["instant_power"],
                                    scenario["expected"]["load"]["instant_power"])
 
-    @common_patches  
+    @common_patches
     @patch('proxy.server.pw')
     @patch('proxy.server.neg_solar', True)  # Test with neg_solar ENABLED
     @patch('proxy.server.safe_endpoint_call')
@@ -305,7 +305,7 @@ class TestDoGetAggregatesEndpoints(BaseDoGetTest):
         mock_cache_write.assert_called_once()
         cache_key, cached_json = mock_cache_write.call_args[0]
         cached_data = json.loads(cached_json)
-        
+
         self.assertEqual(cached_data["solar"]["instant_power"], -200)  # Should preserve negative
         self.assertEqual(cached_data["load"]["instant_power"], 1000)   # Should remain unchanged
 
@@ -374,7 +374,7 @@ class TestCSVEndpoints(BaseDoGetTest):
         with patch.dict('proxy.server._performance_cache', {}, clear=True):
             self.handler.path = "/csv"
             mock_pw.poll = Mock()
-            
+
             # Mock the aggregates call
             mock_safe_endpoint_call.return_value = {
                 'site': {'instant_power': 100.5},
@@ -382,12 +382,12 @@ class TestCSVEndpoints(BaseDoGetTest):
                 'battery': {'instant_power': -50.75},
                 'load': {'instant_power': 250.0}
             }
-            
+
             # Mock the level call
             mock_safe_pw_call.return_value = 45.5
-            
+
             self.handler.do_GET()
-            
+
             self.handler.send_response.assert_called_with(HTTPStatus.OK)
             result = self.get_written_text()
             self.assertEqual(result, "100.50,250.00,200.25,-50.75,45.50\n")
@@ -402,18 +402,18 @@ class TestCSVEndpoints(BaseDoGetTest):
         with patch.dict('proxy.server._performance_cache', {}, clear=True):
             self.handler.path = "/csv?headers"
             mock_pw.poll = Mock()
-            
+
             mock_safe_endpoint_call.return_value = {
                 'site': {'instant_power': 100},
                 'solar': {'instant_power': 200},
                 'battery': {'instant_power': -50},
                 'load': {'instant_power': 250}
             }
-            
+
             mock_safe_pw_call.return_value = 45.5
-            
+
             self.handler.do_GET()
-            
+
             result = self.get_written_text()
             self.assertIn("Grid,Home,Solar,Battery,BatteryLevel\n", result)
             self.assertIn("100.00,250.00,200.00,-50.00,45.50\n", result)
@@ -428,18 +428,18 @@ class TestCSVEndpoints(BaseDoGetTest):
         with patch.dict('proxy.server._performance_cache', {}, clear=True):
             self.handler.path = "/csv"
             mock_pw.poll = Mock()
-            
+
             mock_safe_endpoint_call.return_value = {
                 'site': {'instant_power': 123.456},
                 'solar': {'instant_power': 234.567},
                 'battery': {'instant_power': -345.678},
                 'load': {'instant_power': 456.789}
             }
-            
+
             mock_safe_pw_call.return_value = 67.89
-            
+
             self.handler.do_GET()
-            
+
             result = self.get_written_text()
             self.assertEqual(result, "123.46,456.79,234.57,-345.68,67.89\n")
 
@@ -453,18 +453,18 @@ class TestCSVEndpoints(BaseDoGetTest):
         with patch.dict('proxy.server._performance_cache', {}, clear=True):
             self.handler.path = "/csv"
             mock_pw.poll = Mock()
-            
+
             mock_safe_endpoint_call.return_value = {
                 'site': {'instant_power': 100},
                 'solar': {'instant_power': -50},
                 'battery': {'instant_power': 200},
                 'load': {'instant_power': 250}
             }
-            
+
             mock_safe_pw_call.return_value = 50.0
-            
+
             self.handler.do_GET()
-            
+
             result = self.get_written_text()
             self.assertEqual(result, "100.00,250.00,-50.00,200.00,50.00\n")
 
@@ -478,18 +478,18 @@ class TestCSVEndpoints(BaseDoGetTest):
         with patch.dict('proxy.server._performance_cache', {}, clear=True):
             self.handler.path = "/csv"
             mock_pw.poll = Mock()
-            
+
             mock_safe_endpoint_call.return_value = {
                 'site': {'instant_power': 100},
                 'solar': {'instant_power': -50},
                 'battery': {'instant_power': 200},
                 'load': {'instant_power': 250}
             }
-            
+
             mock_safe_pw_call.return_value = 50.0
-            
+
             self.handler.do_GET()
-            
+
             result = self.get_written_text()
             # Solar should be clamped to 0, and load adjusted: 250 - (-50) = 300
             self.assertEqual(result, "100.00,300.00,0.00,200.00,50.00\n")
@@ -504,13 +504,13 @@ class TestCSVEndpoints(BaseDoGetTest):
         with patch.dict('proxy.server._performance_cache', {}, clear=True):
             self.handler.path = "/csv"
             mock_pw.poll = Mock()
-            
+
             # Return None for aggregates (timeout/error case)
             mock_safe_endpoint_call.return_value = None
             mock_safe_pw_call.return_value = 0
-            
+
             self.handler.do_GET()
-            
+
             result = self.get_written_text()
             self.assertEqual(result, "0.00,0.00,0.00,0.00,0.00\n")
 
@@ -524,17 +524,17 @@ class TestCSVEndpoints(BaseDoGetTest):
         with patch.dict('proxy.server._performance_cache', {}, clear=True):
             self.handler.path = "/csv"
             mock_pw.poll = Mock()
-            
+
             mock_safe_endpoint_call.return_value = {
                 'site': {'instant_power': 0},
                 'solar': {'instant_power': 0},
                 'battery': {'instant_power': 0},
                 'load': {'instant_power': 0}
             }
-            
+
             mock_safe_pw_call.return_value = 0
-            
+
             self.handler.do_GET()
-            
+
             result = self.get_written_text()
             self.assertEqual(result, "0.00,0.00,0.00,0.00,0.00\n")

--- a/proxy/tests/test_dispatch.py
+++ b/proxy/tests/test_dispatch.py
@@ -1,0 +1,13 @@
+import unittest
+
+from proxy.server import Handler
+
+
+class TestDispatchHandlers(unittest.TestCase):
+    def test_freq_handler_registered(self):
+        self.assertIn('/freq', Handler.GET_PATH_HANDLERS)
+        self.assertTrue(callable(Handler.GET_PATH_HANDLERS['/freq']))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/proxy/transform.py
+++ b/proxy/transform.py
@@ -1,7 +1,13 @@
 import os
 import logging
 
-from bs4 import BeautifulSoup as Soup
+try:
+    from bs4 import BeautifulSoup as Soup
+except Exception:
+    # bs4 is an optional dependency for HTML injection used by the web UI.
+    # Provide a minimal fallback so tests can import the module when bs4
+    # is not installed. The fallback `inject_js` will be a no-op.
+    Soup = None
 
 logging.basicConfig(
     format="%(asctime)s [%(name)s] [%(levelname)s] %(message)s",
@@ -55,6 +61,10 @@ def get_static(web_root, fpath):
 
 
 def inject_js(htmlsrc, *args):
+    if Soup is None:
+        # BeautifulSoup not available; return HTML unchanged
+        return htmlsrc
+
     soup = Soup(htmlsrc, "html.parser")
 
     for fpath in args:

--- a/proxy/transform.py
+++ b/proxy/transform.py
@@ -3,7 +3,7 @@ import logging
 
 try:
     from bs4 import BeautifulSoup as Soup
-except Exception:
+except ImportError:
     # bs4 is an optional dependency for HTML injection used by the web UI.
     # Provide a minimal fallback so tests can import the module when bs4
     # is not installed. The fallback `inject_js` will be a no-op.


### PR DESCRIPTION
# Summary
The `do_GET` and `do_POST` handlers are massive monolithic "god" functions with a lot of tight coupling and reliance on large global structures.

This introduces an idiom to slowly shift the branch-based conditionals to functions mapped by the requested HTTP path. This will enable better encapsulation, separation of concerns, testability, and eventually pave the way for multiple TEGs to be processed by a single proxy.

# Testing
That's the purpose of the unit tests. If they pass, in theory, no further testing is needed as that's what unit test do: Allow you to refactor without fear ;)