### PR TITLE
fix a bug where pypowerwall tool is unable to set reserve 0

### DIFF
--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -153,7 +153,7 @@ elif command == 'scan':
 # Set Powerwall Mode
 elif command == 'set':
     # If no arguments, print usage
-    if not args.mode and args.reserve != -1 and not args.current and not args.gridcharging and not args.gridexport:
+    if not args.mode and args.reserve == -1 and not args.current and not args.gridcharging and not args.gridexport:
         print("usage: pypowerwall set [-h] [-mode MODE] [-reserve RESERVE] [-current] [-gridcharging MODE] [-gridexport MODE]")
         sys.exit(1)
     import pypowerwall


### PR DESCRIPTION
args.reserve used to default to None. If you set `-reserve 0`, `not args.reserve` is still true, so code to set reserve to 0 would not run. default to -1 instead.