### PR TITLE
Insert empty battery_blocks array, if missing

### DIFF
--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -304,6 +304,8 @@ class TEDAPI:
                 except json.JSONDecodeError as e:
                     log.error(f"Error Decoding JSON: {e}")
                     data = {}
+                if 'battery_blocks' not in data:
+                    data["battery_blocks"] = []
                 log.debug(f"Configuration: {data}")
                 self.pwcachetime["config"] = time.time()
                 self.pwcache["config"] = data


### PR DESCRIPTION
This fixes pypowerwall for standalone inverters