### PR TITLE
fix: prevent shared-state race condition in stubs via factory functions

### DIFF
--- a/pypowerwall/cloud/pypowerwall_cloud.py
+++ b/pypowerwall/cloud/pypowerwall_cloud.py
@@ -675,7 +675,7 @@ class PyPowerwallCloud(PyPowerwallBase):
                 solar_inverters = 1
             else:
                 solar_inverters = 0
-            data = API_METERS_AGGREGATES_STUB
+            data = API_METERS_AGGREGATES_STUB()
             data['site'].update({
                 "last_communication_time": timestamp,
                 "instant_power": grid_power,
@@ -740,7 +740,7 @@ class PyPowerwallCloud(PyPowerwallBase):
                 # "grid_status": "Active"
                 if lookup(power, ("response", "grid_status")) in ["Active", "Unknown"]:
                     grid_status = "SystemGridConnected"
-            data = API_SYSTEM_STATUS_STUB  # TODO: see inside API_SYSTEM_STATUS_STUB definition
+            data = API_SYSTEM_STATUS_STUB()  # TODO: see inside API_SYSTEM_STATUS_STUB definition
             data.update({
                 "nominal_full_pack_energy": total_pack_energy,
                 "nominal_energy_remaining": energy_left,

--- a/pypowerwall/cloud/stubs.py
+++ b/pypowerwall/cloud/stubs.py
@@ -1,4 +1,6 @@
-API_METERS_AGGREGATES_STUB = {
+import copy
+
+_API_METERS_AGGREGATES_TEMPLATE = {
     "site": {
         "last_communication_time": None,
         "instant_power": None,
@@ -80,7 +82,11 @@ API_METERS_AGGREGATES_STUB = {
     }
 }
 
-API_SYSTEM_STATUS_STUB = {  # TODO: Fill in 0 values
+def API_METERS_AGGREGATES_STUB():
+    """Return a fresh copy of the API meters aggregates stub to prevent shared-state mutation."""
+    return copy.deepcopy(_API_METERS_AGGREGATES_TEMPLATE)
+
+_API_SYSTEM_STATUS_TEMPLATE = {  # TODO: Fill in 0 values
     "command_source": "Configuration",
     "battery_target_power": 0,
     "battery_target_reactive_power": 0,
@@ -119,3 +125,7 @@ API_SYSTEM_STATUS_STUB = {  # TODO: Fill in 0 values
     "inverter_nominal_usable_power": 0,
     "expected_energy_remaining": 0
 }
+
+def API_SYSTEM_STATUS_STUB():
+    """Return a fresh copy of the API system status stub to prevent shared-state mutation."""
+    return copy.deepcopy(_API_SYSTEM_STATUS_TEMPLATE)

--- a/pypowerwall/fleetapi/pypowerwall_fleetapi.py
+++ b/pypowerwall/fleetapi/pypowerwall_fleetapi.py
@@ -566,7 +566,7 @@ class PyPowerwallFleetAPI(PyPowerwallBase):
                 solar_inverters = 1
             else:
                 solar_inverters = 0
-            data = API_METERS_AGGREGATES_STUB
+            data = API_METERS_AGGREGATES_STUB()
             data['site'].update({
                 "last_communication_time": timestamp,
                 "instant_power": grid_power,
@@ -624,7 +624,7 @@ class PyPowerwallFleetAPI(PyPowerwallBase):
                 # "grid_status": "Active"
                 if power.get("grid_status") in ["Active", "Unknown"]:
                     grid_status = "SystemGridConnected"
-            data = API_SYSTEM_STATUS_STUB  # TODO: see inside API_SYSTEM_STATUS_STUB definition
+            data = API_SYSTEM_STATUS_STUB()  # TODO: see inside API_SYSTEM_STATUS_STUB definition
             data.update({
                 "nominal_full_pack_energy": total_pack_energy,
                 "nominal_energy_remaining": energy_left,

--- a/pypowerwall/fleetapi/stubs.py
+++ b/pypowerwall/fleetapi/stubs.py
@@ -1,4 +1,6 @@
-API_METERS_AGGREGATES_STUB = {
+import copy
+
+_API_METERS_AGGREGATES_TEMPLATE = {
     "site": {
         "last_communication_time": None,
         "instant_power": None,
@@ -80,7 +82,11 @@ API_METERS_AGGREGATES_STUB = {
     }
 }
 
-API_SYSTEM_STATUS_STUB = {  # TODO: Fill in 0 values
+def API_METERS_AGGREGATES_STUB():
+    """Return a fresh copy of the API meters aggregates stub to prevent shared-state mutation."""
+    return copy.deepcopy(_API_METERS_AGGREGATES_TEMPLATE)
+
+_API_SYSTEM_STATUS_TEMPLATE = {  # TODO: Fill in 0 values
     "command_source": "Configuration",
     "battery_target_power": 0,
     "battery_target_reactive_power": 0,
@@ -119,3 +125,7 @@ API_SYSTEM_STATUS_STUB = {  # TODO: Fill in 0 values
     "inverter_nominal_usable_power": 0,
     "expected_energy_remaining": 0
 }
+
+def API_SYSTEM_STATUS_STUB():
+    """Return a fresh copy of the API system status stub to prevent shared-state mutation."""
+    return copy.deepcopy(_API_SYSTEM_STATUS_TEMPLATE)

--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -384,7 +384,7 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
         if not isinstance(config, dict) or not isinstance(status, dict):
             return None
         timestamp = lookup(status, ("system", "time"))
-        data = API_METERS_AGGREGATES_STUB
+        data = API_METERS_AGGREGATES_STUB()
 
         # --- Site (Grid) ---
         site_vals = self._extract_site_section(status, config, force)
@@ -627,7 +627,7 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
         energy_left = lookup(status, ["control", "systemStatus", "nominalEnergyRemainingWh"])
         batteryBlocks = lookup(config, ["control", "batteryBlocks"]) or []
         battery_count = len(batteryBlocks)
-        data = API_SYSTEM_STATUS_STUB  # TODO: see inside API_SYSTEM_STATUS_STUB definition
+        data = API_SYSTEM_STATUS_STUB()  # TODO: see inside API_SYSTEM_STATUS_STUB definition
         blocks = self.tedapi.get_blocks(force=force)
         b = []
         for bk in blocks:

--- a/pypowerwall/tedapi/stubs.py
+++ b/pypowerwall/tedapi/stubs.py
@@ -1,4 +1,6 @@
-API_METERS_AGGREGATES_STUB = {
+import copy
+
+_API_METERS_AGGREGATES_TEMPLATE = {
     "site": {
         "last_communication_time": None,
         "instant_power": None,
@@ -80,7 +82,11 @@ API_METERS_AGGREGATES_STUB = {
     }
 }
 
-API_SYSTEM_STATUS_STUB = {  # TODO: Fill in 0 values
+def API_METERS_AGGREGATES_STUB():
+    """Return a fresh copy of the API meters aggregates stub to prevent shared-state mutation."""
+    return copy.deepcopy(_API_METERS_AGGREGATES_TEMPLATE)
+
+_API_SYSTEM_STATUS_TEMPLATE = {  # TODO: Fill in 0 values
     "command_source": "Configuration",
     "battery_target_power": 0,
     "battery_target_reactive_power": 0,
@@ -119,3 +125,7 @@ API_SYSTEM_STATUS_STUB = {  # TODO: Fill in 0 values
     "inverter_nominal_usable_power": 0,
     "expected_energy_remaining": 0
 }
+
+def API_SYSTEM_STATUS_STUB():
+    """Return a fresh copy of the API system status stub to prevent shared-state mutation."""
+    return copy.deepcopy(_API_SYSTEM_STATUS_TEMPLATE)


### PR DESCRIPTION
Using pypowerwall-server against two different power wall systems, the values shown in the Energy Summary field were sometimes (but not always!) incorrect.  Traced it back to pypowerwall using the same STUB memory for each gateway object, which was causing race conditions based on which gateway was last to update that STUB. 
 
 - Bug: API_METERS_AGGREGATES_STUB and API_SYSTEM_STATUS_STUB in all three
  stubs modules are module-level mutable dicts. Call sites do data = STUB (a
  reference) then .update() nested dicts in-place. When multiple gateways are
  polled concurrently from separate threads, both threads mutate the same object
   — whichever finishes last overwrites the other's data, causing both cached
  results to be identical.
  - Reproduction: Using pypowerwall-server, configure two gateways pointing at different Powerwall
  systems, enable concurrent polling. The Energy Summary doubles one gateway's
  output rather than summing both.
  - Fix: Renamed the template dicts to _*_TEMPLATE and replaced the module-level
   names with factory functions that return copy.deepcopy(template). All
  existing call sites updated to STUB(). No behaviour change for single-gateway
  users.

--Woof!