### PR TITLE
v0.15.2 - Protobuf Support

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,14 +2,14 @@
 
 ## v0.15.2 - Minor Fixes
 
-* Fix: Remove `<5` upper cap on `protobuf` runtime dependency — constraint is now `protobuf>=4.25.1`; pb2 files generated with 4.25.x are compatible with 5.x, 6.x, and 7.x runtimes (confirmed tested up to 7.34.1) and the cap was causing pip conflicts for users with newer protobuf versions installed (e.g. via TensorFlow)
+* Fix: Remove `<5` upper cap on `protobuf` runtime dependency — constraint is now `protobuf>=4.25.1`; pb2 files generated with 4.25.x are compatible with 5.x, 6.x, and 7.x runtimes (confirmed and tested up to 7.34.1) and the cap was causing pip conflicts for users with newer protobuf versions installed (e.g. via TensorFlow)
 
 ## v0.15.1 - Code Quality and Build Pipeline Improvements
 
 * Fix: Remove duplicate stub methods `get_grid_charging()` and `get_grid_export()` in `pypowerwall_tedapi.py` that were left over from a merge — the real implementations (reading/writing config via v1r transport) were already present and being shadowed
 * Fix: Update `pwsimulator` `stub.py` to use `ssl.SSLContext` API replacing the removed `ssl.wrap_socket()` call, which caused the simulator container to silently exit on Python 3.12+
 * Fix: Remove `linux/arm/v7` platform from `pwsimulator` Docker build (`upload.sh`) — platform is no longer supported
-* Fix: Correct protobuf runtime dependency — `protobuf>=3.20.0` was misleading; pb2 files generated with 4.25.x require `protobuf>=4.25.1,<5`
+* Fix: Correct protobuf runtime dependency — `protobuf>=3.20.0` was misleading; set floor to `protobuf>=4.25.1` (the `<5` upper cap added here was subsequently lifted in v0.15.2)
 * Add: `.pylintrc` with `[MESSAGES CONTROL]` disable list (restored), `[SIMILARITIES]` config, and `ignore-paths` to skip auto-generated `*_pb2.py` files
 * Add: `tools/gen_proto.sh` — script to regenerate all `*_pb2.py` files from `.proto` sources using pinned `grpcio-tools`
 * Add: `tools/requirements-tools.txt` — pinned dev tools (`grpcio-tools<1.64`, `protobuf<5`) to ensure pb2 files are generated consistently with a compatible protobuf version

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v0.15.2 - Minor Fixes
+
+* Fix: Remove `<5` upper cap on `protobuf` runtime dependency — constraint is now `protobuf>=4.25.1`; pb2 files generated with 4.25.x are compatible with 5.x, 6.x, and 7.x runtimes (confirmed tested up to 7.34.1) and the cap was causing pip conflicts for users with newer protobuf versions installed (e.g. via TensorFlow)
+
 ## v0.15.1 - Code Quality and Build Pipeline Improvements
 
 * Fix: Remove duplicate stub methods `get_grid_charging()` and `get_grid_export()` in `pypowerwall_tedapi.py` that were left over from a merge — the real implementations (reading/writing config via v1r transport) were already present and being shadowed

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,2 +1,2 @@
-pypowerwall==0.15.1
+pypowerwall==0.15.2
 bs4==0.0.2

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -89,7 +89,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 15, 1)
+version_tuple = (0, 15, 2)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # This file is used to install the necessary Python packages for the project.
 requests
-protobuf>=4.25.1,<5
+protobuf>=4.25.1
 python-dotenv
 pyroute2
 bs4

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'requests',
-        'protobuf>=4.25.1,<5',
+        'protobuf>=4.25.1',
         'python-dotenv',
         'pyroute2',
         'bs4',


### PR DESCRIPTION
## v0.15.2 - Minor Fixes

* Fix: Remove `<5` upper cap on `protobuf` runtime dependency — constraint is now `protobuf>=4.25.1`; pb2 files generated with 4.25.x are compatible with 5.x, 6.x, and 7.x runtimes (confirmed tested up to 7.34.1) and the cap was causing pip conflicts for users with newer protobuf versions installed (e.g. via TensorFlow)