### PR TITLE
feat: add go_off_grid() and reconnect_grid() for Powerwall island mode control

### DIFF
--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -967,7 +967,7 @@ class Powerwall(object):
         """
         return self.client.get_grid_export()
 
-    def go_off_grid(self) -> Optional[dict]:
+    def go_off_grid(self, confirm: bool = False) -> Optional[dict]:
         """
         Physically disconnect the Powerwall from the grid (open contactor).
 
@@ -977,6 +977,9 @@ class Powerwall(object):
         dropout during the contactor transition.
 
         Note:
+            This operation requires explicit confirmation. Pass
+            confirm=True to send the command.
+
             On both Powerwall 2 and Powerwall 3, this requires a signed
             RoutableMessage via the cloud device_command endpoint's
             routable_message field. The unsigned grpc_command path is
@@ -991,6 +994,9 @@ class Powerwall(object):
         Returns:
             Dictionary with operation results, or None if unsupported.
         """
+        if not confirm:
+            log.error("go_off_grid requires confirm=True")
+            return None
         if hasattr(self.client, 'go_off_grid'):
             return self.client.go_off_grid()
         log.error("go_off_grid is not supported by %s backend", type(self.client).__name__)

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -967,6 +967,47 @@ class Powerwall(object):
         """
         return self.client.get_grid_export()
 
+    def go_off_grid(self) -> Optional[dict]:
+        """
+        Physically disconnect the Powerwall from the grid (open contactor).
+
+        Sends setIslandModeRequest(mode=6) which physically opens the grid
+        contactor, islanding the home. Solar continues producing and the
+        battery serves home load. Causes ~30s solar dropout during the
+        contactor transition.
+
+        Note:
+            On Powerwall 3, this requires a signed RoutableMessage via the
+            device_command endpoint's routable_message field. The unsigned
+            grpc_command path is accepted but does not physically operate
+            the contactor.
+
+            On Powerwall 2, this uses the local REST endpoint
+            /api/v2/islanding/mode.
+
+        Returns:
+            Dictionary with operation results, or None if unsupported.
+        """
+        if hasattr(self.client, 'go_off_grid'):
+            return self.client.go_off_grid()
+        log.error("go_off_grid is not supported in the current mode")
+        return None
+
+    def reconnect_grid(self) -> Optional[dict]:
+        """
+        Reconnect the Powerwall to the grid (close contactor).
+
+        Sends setIslandModeRequest(mode=1) which physically closes the
+        grid contactor, reconnecting the home to the utility grid.
+
+        Returns:
+            Dictionary with operation results, or None if unsupported.
+        """
+        if hasattr(self.client, 'reconnect_grid'):
+            return self.client.reconnect_grid()
+        log.error("reconnect_grid is not supported in the current mode")
+        return None
+
     def _validate_init_configuration(self):
 
         # Basic user input validation for starters. Can be expanded to limit other parameters such as cache

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -971,26 +971,29 @@ class Powerwall(object):
         """
         Physically disconnect the Powerwall from the grid (open contactor).
 
-        Sends setIslandModeRequest(mode=6) which physically opens the grid
-        contactor, islanding the home. Solar continues producing and the
-        battery serves home load. Causes ~30s solar dropout during the
-        contactor transition.
+        Sends setIslandModeRequest(mode=6, force=True) which physically
+        opens the grid contactor, islanding the home. Solar continues
+        producing and the battery serves home load. Causes ~30s solar
+        dropout during the contactor transition.
 
         Note:
-            On Powerwall 3, this requires a signed RoutableMessage via the
-            device_command endpoint's routable_message field. The unsigned
-            grpc_command path is accepted but does not physically operate
-            the contactor.
+            On both Powerwall 2 and Powerwall 3, this requires a signed
+            RoutableMessage via the cloud device_command endpoint's
+            routable_message field. The unsigned grpc_command path is
+            accepted by the gateway but does not physically operate the
+            contactor. The local REST endpoint /api/v2/islanding/mode
+            requires installer-level auth and is not usable with the
+            customer login role.
 
-            On Powerwall 2, this uses the local REST endpoint
-            /api/v2/islanding/mode.
+            force=True is required — without it the gateway acknowledges
+            the command but does not open the contactor.
 
         Returns:
             Dictionary with operation results, or None if unsupported.
         """
         if hasattr(self.client, 'go_off_grid'):
             return self.client.go_off_grid()
-        log.error("go_off_grid is not supported in the current mode")
+        log.error("go_off_grid is not supported by %s backend", type(self.client).__name__)
         return None
 
     def reconnect_grid(self) -> Optional[dict]:
@@ -1005,7 +1008,7 @@ class Powerwall(object):
         """
         if hasattr(self.client, 'reconnect_grid'):
             return self.client.reconnect_grid()
-        log.error("reconnect_grid is not supported in the current mode")
+        log.error("reconnect_grid is not supported by %s backend", type(self.client).__name__)
         return None
 
     def _validate_init_configuration(self):

--- a/pypowerwall/tests/unit/test_powerwall_core.py
+++ b/pypowerwall/tests/unit/test_powerwall_core.py
@@ -60,6 +60,16 @@ class StubClient(PyPowerwallBase):
     def get_time_remaining(self):
         return 4.5
 
+
+class StubClientWithIslanding(StubClient):
+    def __init__(self):
+        super().__init__()
+        self.go_off_grid_calls = 0
+
+    def go_off_grid(self):
+        self.go_off_grid_calls += 1
+        return {'result': 'ok'}
+
 @pytest.fixture(name="pw")
 def fixture_powerwall():
     # Instantiate Powerwall but replace its client with our stub
@@ -135,6 +145,20 @@ def test_temps(pw):
 
 def test_site_name(pw):
     assert pw.site_name() == 'Test Site'
+
+
+def test_go_off_grid_requires_confirm(pw):
+    pw.client = StubClientWithIslanding()
+    out = pw.go_off_grid()
+    assert out is None
+    assert pw.client.go_off_grid_calls == 0
+
+
+def test_go_off_grid_with_confirm_delegates(pw):
+    pw.client = StubClientWithIslanding()
+    out = pw.go_off_grid(confirm=True)
+    assert out == {'result': 'ok'}
+    assert pw.client.go_off_grid_calls == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `go_off_grid()` and `reconnect_grid()` methods to the `Powerwall` class for physical grid contactor control.

## Discovery

Reverse-engineered via mitmproxy capture of the Tesla mobile app and confirmed on live systems:

- `setIslandModeRequest(mode=6, force=True)` — physically opens the grid contactor (off-grid)
- `setIslandModeRequest(mode=1, force=False)` — physically closes the grid contactor (reconnect)
- `mode=2` (previously assumed by the community to be off-grid) is accepted by the gateway but **does not physically operate the contactor** on either PW2 or PW3
- `force=True` is required for off-grid — without it the gateway acknowledges the command but does not open the contactor

## Signed Commands Required (Both PW2 and PW3)

On both Powerwall 2 and Powerwall 3, the command must be delivered as a **signed RoutableMessage** via the cloud `device_command` endpoint:

1. Pair an RSA-4096 key with the gateway via `add_authorized_client_request` (requires physical DC isolator toggle for verification — key must reach state=3)
2. Build a `MessageEnvelope` with `deliveryChannel=2` (HERMES_COMMAND), `sender.authorizedClient=1`, `recipient.din=<gateway_din>`, `teg.setIslandModeRequest(mode=6, force=True)`
3. Wrap in a `RoutableMessage` (field 6=domain 7, field 10=envelope bytes) with RSA-PKCS1v15-SHA512 signature over TLV-encoded payload
4. Base64-encode and POST as the `routable_message` field (not `energy_device_message`) in `POST /api/1/energy_sites/{id}/device_command`

### What does NOT work
- **Unsigned `grpc_command` via `/command`** — gateway returns "signature required: no authorized client public key"
- **Local REST `/api/v2/islanding/mode`** — requires installer-level auth, customer role gets 403
- **`triggerIslandingBlackStartRequest`** — blocked by Tesla's powergate (400) on all cloud paths
- **`mode=2`** — sets a preference only, does not operate contactor
- **`force=False`** — gateway acknowledges but does not island
- **Cloud backup+100% reserve** — does not physically island

## This PR

Adds the public API surface (`go_off_grid()`, `reconnect_grid()`) with `hasattr` delegation to the backend client. Backend implementations (fleetapi, tedapi, cloud, local) are left as stubs — this PR documents the protocol so implementers know exactly what to build.

## Review Fixes

- Updated docstrings: PW2 uses the same signed cloud path as PW3 (not local REST)
- Added `force=True` documentation
- Error messages now include backend class name per Sam's review

## Confirmed Working

- **Powerwall 2** firmware 26.10.0 — signed `routable_message` via `device_command`, mode=6, force=True
- **Powerwall 3** firmware 26.2.1 — same method

Both confirmed via [PowerSync](https://github.com/bolagnaise/PowerSync).