### PR TITLE
Fix TypeError when solar signal value is None on PW3 without solar panels

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,23 @@
 # RELEASE NOTES
 
+## v0.15.3 - PW3 No-Solar None Handling
+
+* Update scanner to use cidr by @Nexarian in https://github.com/jasonacox/pypowerwall/pull/266
+* Add go_off_grid() and reconnect_grid() for Powerwall island mode control by @bolagnaise in https://github.com/jasonacox/pypowerwall/pull/277
+* Fix: Prevent `TypeError` in Powerwall 3 TEDAPI vitals parsing when `PCH_PvVoltage*` or `PCH_PvCurrent*` signals are `None` on systems without solar panels - by @anopheles in https://github.com/jasonacox/pypowerwall/pull/278
+     * `get_pw3_vitals()` now guards `None` values before performing `> 0` comparisons
+     * PV measured voltage, current, and power now safely report `0` when the gateway returns missing PV values
+     * Prevents downstream failures in endpoints derived from PW3 vitals, including `/api/meters/aggregates`
+     * Adds regression coverage for PW3 systems without solar panels so the no-solar path no longer raises and remains locked in by tests
+
+* Release prep:
+     * Bump library version to `0.15.3`
+     * Update proxy pinned dependency to `pypowerwall==0.15.3`
+     * Fix PyPI upload cleanup script to remove `pypowerwall.egg-info` instead of stale `tinytuya.egg-info`
+
 ## v0.15.2 - Minor Fixes
 
+* v0.15.2 - Protobuf Support by @jasonacox in https://github.com/jasonacox/pypowerwall/pull/276
 * Fix: Remove `<5` upper cap on `protobuf` runtime dependency — constraint is now `protobuf>=4.25.1`; pb2 files generated with 4.25.x are compatible with 5.x, 6.x, and 7.x runtimes (confirmed and tested up to 7.34.1) and the cap was causing pip conflicts for users with newer protobuf versions installed (e.g. via TensorFlow)
 
 ## v0.15.1 - Code Quality and Build Pipeline Improvements

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,2 +1,2 @@
-pypowerwall==0.15.2
+pypowerwall==0.15.3
 bs4==0.0.2

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -89,7 +89,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 15, 2)
+version_tuple = (0, 15, 3)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -1163,9 +1163,9 @@ class TEDAPI:
                                 if f'PCH_PvState_{n}' == signal['name']:
                                     pv_state = signal['textValue']
                                 elif f'PCH_PvVoltage{n}' == signal['name']:
-                                    pv_voltage = signal['value'] if signal['value'] > 0 else 0
+                                    pv_voltage = signal['value'] if signal['value'] is not None and signal['value'] > 0 else 0
                                 elif f'PCH_PvCurrent{n}' == signal['name']:
-                                    pv_current = signal['value'] if signal['value'] > 0 else 0
+                                    pv_current = signal['value'] if signal['value'] is not None and signal['value'] > 0 else 0
                                 elif 'PCH_AcFrequency' == signal['name']:
                                     response[f"PVAC--{pw_din}"]["PVAC_Fout"] = signal['value']
                                     response[f"TEPINV--{pw_din}"]["PINV_Fout"] = signal['value']

--- a/pypowerwall/tests/tedapi/test_init.py
+++ b/pypowerwall/tests/tedapi/test_init.py
@@ -198,6 +198,33 @@ LEADER_PAYLOAD = json.dumps({
     }
 })
 
+NONE_SOLAR_PAYLOAD = json.dumps({
+    "components": {
+        "pws": [{"signals": [], "activeAlerts": []}],
+        "pch": [{"signals": [
+            {"name": "PCH_PvState_A", "value": 0, "textValue": "Pv_Standby", "boolValue": False, "timestamp": 0},
+            {"name": "PCH_PvVoltageA", "value": None, "textValue": "", "boolValue": False, "timestamp": 0},
+            {"name": "PCH_PvCurrentA", "value": None, "textValue": "", "boolValue": False, "timestamp": 0},
+            {"name": "PCH_AcFrequency", "value": 60.0, "textValue": "", "boolValue": False, "timestamp": 0},
+            {"name": "PCH_AcVoltageAN", "value": 120, "textValue": "", "boolValue": False, "timestamp": 0},
+            {"name": "PCH_AcVoltageBN", "value": 120, "textValue": "", "boolValue": False, "timestamp": 0},
+            {"name": "PCH_AcVoltageAB", "value": 240, "textValue": "", "boolValue": False, "timestamp": 0},
+            {"name": "PCH_BatteryPower", "value": 0, "textValue": "", "boolValue": False, "timestamp": 0},
+            {"name": "PCH_AcMode", "value": 0, "textValue": "AC_Connected", "boolValue": False, "timestamp": 0},
+        ], "activeAlerts": []}],
+        "bms": [
+            {"signals": [
+                {"name": "BMS_nominalEnergyRemaining", "value": 10.0, "textValue": "", "boolValue": False, "timestamp": 0},
+                {"name": "BMS_nominalFullPackEnergy", "value": 13.5, "textValue": "", "boolValue": False, "timestamp": 0},
+            ], "activeAlerts": []},
+        ],
+        "hvp": [
+            {"partNumber": "1707000-11-J", "serialNumber": "TG12000000001Z", "signals": [], "activeAlerts": []},
+        ],
+        "baggr": [{"signals": [], "activeAlerts": []}],
+    }
+})
+
 BATTERY_BLOCKS = [
     {
         "vin": LEADER_DIN,
@@ -315,3 +342,28 @@ class TestV1rFollowerSkip:
 
         # Should be called 3 times — once per battery block
         assert mock_post.call_count == 3
+
+
+class TestPW3NullSolarSignals:
+    """Regression tests for PW3 systems without solar panels (PCH_PvVoltage*/PvCurrent* = None)."""
+
+    def test_get_pw3_vitals_none_pv_signals_no_raise(self, mock_v1r_tedapi):
+        """get_pw3_vitals() must not raise TypeError when PV voltage/current signals are None."""
+        api = mock_v1r_tedapi
+        with patch.object(api, '_post_tedapi', return_value=b'mock'), \
+             patch.object(api, '_parse_v1r_query_response', return_value=NONE_SOLAR_PAYLOAD):
+            result = api.get_pw3_vitals()
+
+        assert result is not None
+
+    def test_get_pw3_vitals_none_pv_signals_reported_as_zero(self, mock_v1r_tedapi):
+        """PV measured voltage, current, and power must be 0 when signal values are None."""
+        api = mock_v1r_tedapi
+        with patch.object(api, '_post_tedapi', return_value=b'mock'), \
+             patch.object(api, '_parse_v1r_query_response', return_value=NONE_SOLAR_PAYLOAD):
+            result = api.get_pw3_vitals()
+
+        pvac = result[f"PVAC--{LEADER_DIN}"]
+        assert pvac["PVAC_PVMeasuredVoltage_A"] == 0
+        assert pvac["PVAC_PVCurrent_A"] == 0
+        assert pvac["PVAC_PVMeasuredPower_A"] == 0

--- a/tools/tedapi/PW3_Strings.py
+++ b/tools/tedapi/PW3_Strings.py
@@ -224,9 +224,9 @@ for battery in battery_blocks:
                         if f'PCH_PvState_{n}' == signal['name']:
                             pv_state = signal['textValue']
                         elif f'PCH_PvVoltage{n}' == signal['name']:
-                            pv_voltage = signal['value']
+                            pv_voltage = signal['value'] if signal['value'] is not None else 0
                         elif f'PCH_PvCurrent{n}' == signal['name']:
-                            pv_current = signal['value']
+                            pv_current = signal['value'] if signal['value'] is not None else 0
                 pv_power = pv_voltage * pv_current
                 i = n + string_suffix[battery_i]
                 # Print and record the strings data

--- a/tools/tedapi/PW3_Vitals.py
+++ b/tools/tedapi/PW3_Vitals.py
@@ -243,9 +243,9 @@ def get_pw3_vitals(components=None, config=None, din=None, gw_pwd=None):
                             if f'PCH_PvState_{n}' == signal['name']:
                                 pv_state = signal['textValue']
                             elif f'PCH_PvVoltage{n}' == signal['name']:
-                                pv_voltage = signal['value'] if signal['value'] > 0 else 0
+                                pv_voltage = signal['value'] if signal['value'] is not None and signal['value'] > 0 else 0
                             elif f'PCH_PvCurrent{n}' == signal['name']:
-                                pv_current = signal['value'] if signal['value'] > 0 else 0
+                                pv_current = signal['value'] if signal['value'] is not None and signal['value'] > 0 else 0
                             elif f'PCH_AcFrequency' == signal['name']:
                                 response[f"PVAC--{pw_din}"][f"PVAC_Fout"] = signal['value']
                             elif f'PCH_AcVoltageAN' == signal['name']:


### PR DESCRIPTION
On Powerwall 3 systems without solar panels, PCH_PvVoltage and PCH_PvCurrent signals have a None value. The comparison `signal['value'] > 0` throws TypeError: '>' not supported between instances of 'NoneType' and 'int', causing get_api_meters_aggregates() to fail and return null data.

Fix by guarding with `is not None` before the comparison in all three affected files.