### PR TITLE
v0.15.4 - CLI Enhancements and Safety Guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,12 @@ networkingMode=mirrored
 ```
 
 ```bash
-# Test
-python3 -m pypowerwall tedapi
+# Test WiFi TEDAPI
+python3 -m pypowerwall tedapi -gw_pwd ABCDEXXXXX
+
+# Test v1r LAN TEDAPI
+python3 -m pypowerwall tedapi -host 10.42.1.40 -v1r -gw_pwd ABCDEXXXXX \
+   -rsa_key_path /path/to/tedapi_rsa_private.pem
 ```
 
 #### TEDAPI Troubleshooting

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,15 @@
 # RELEASE NOTES
 
+## v0.15.4 - CLI Enhancements and Safety Guards
+
+* Feat: `pypowerwall tedapi` CLI now accepts `-host HOST`, `-gw_pwd GW_PWD`, `-v1r`, `-password PASSWORD`, `-rsa_key_path RSA_KEY_PATH`, and `-wifi_host WIFI_HOST` flags, enabling full PW3 wired LAN (v1r) access directly from the command line
+* Feat: `go_off_grid()` now requires `confirm=True` to prevent accidental islanding — calling without the flag logs an error and returns `None`
+* Fix: Unsupported-method error logs in `go_off_grid()` and `reconnect_grid()` now include the backend class name for easier diagnosis
+* Add: Unit tests for `go_off_grid()` confirm guard and CLI v1r argument forwarding/password derivation
+* Release prep:
+     * Bump library version to `0.15.4`
+     * Update proxy pinned dependency to `pypowerwall==0.15.4`
+
 ## v0.15.3 - PW3 No-Solar None Handling
 
 * Update scanner to use cidr by @Nexarian in https://github.com/jasonacox/pypowerwall/pull/266

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,2 +1,2 @@
-pypowerwall==0.15.3
+pypowerwall==0.15.4
 bs4==0.0.2

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -89,7 +89,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 15, 3)
+version_tuple = (0, 15, 4)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -42,6 +42,20 @@ def main():
     fleetapi_args = subparsers.add_parser("fleetapi", help='Setup Tesla FleetAPI for Cloud Mode access')
 
     tedapi_args = subparsers.add_parser("tedapi", help='Test TEDAPI connection to Powerwall Gateway')
+    tedapi_args.add_argument("gw_pwd", type=str, nargs="?", default=None,
+                             help="Powerwall Gateway Password")
+    tedapi_args.add_argument("-gw_pwd", dest="gw_pwd_option", metavar="GW_PWD", type=str, default=None,
+                             help="Powerwall Gateway Password")
+    tedapi_args.add_argument("-host", type=str, default=None,
+                             help="IP address of Powerwall Gateway")
+    tedapi_args.add_argument("-v1r", action="store_true", default=False,
+                             help="Use v1r LAN TEDAPI mode")
+    tedapi_args.add_argument("-password", type=str, default=None,
+                             help="Customer password for v1r mode (defaults to last 5 of gw_pwd)")
+    tedapi_args.add_argument("-rsa_key_path", type=str, default=None,
+                             help="Path to RSA private key PEM for v1r mode")
+    tedapi_args.add_argument("-wifi_host", type=str, default=None,
+                             help="Optional WiFi TEDAPI host for v1r follower fallback")
 
     register_args = subparsers.add_parser("register",
                                           help='Register RSA key with Powerwall via Tesla Owner API or Fleet API (for v1r LAN mode)')
@@ -145,7 +159,23 @@ def main():
     # TEDAPI Test
     elif command == 'tedapi':
         from pypowerwall.tedapi.__main__ import run_tedapi_test
-        run_tedapi_test(auto=True, debug=args.debug)
+        tedapi_argv = []
+        gw_pwd = args.gw_pwd_option or args.gw_pwd
+        if gw_pwd:
+            tedapi_argv.extend(['-gw_pwd', gw_pwd])
+        if args.host:
+            tedapi_argv.extend(['-host', args.host])
+        if args.v1r:
+            tedapi_argv.append('-v1r')
+        if args.password:
+            tedapi_argv.extend(['-password', args.password])
+        if args.rsa_key_path:
+            tedapi_argv.extend(['-rsa_key_path', args.rsa_key_path])
+        if args.wifi_host:
+            tedapi_argv.extend(['-wifi_host', args.wifi_host])
+        if args.debug:
+            tedapi_argv.append('--debug')
+        run_tedapi_test(argv=tedapi_argv, debug=args.debug)
 
     # Fleet API RSA Key Registration (v1r LAN mode)
     elif command == 'register':

--- a/pypowerwall/tedapi/__main__.py
+++ b/pypowerwall/tedapi/__main__.py
@@ -2,17 +2,38 @@
 # -*- coding: utf-8 -*-
 """
  Tesla TEADAPI Class - Command Line Test
- 
+
  This script tests the TEDAPI class by connecting to a Tesla Powerwall Gateway
 """
 
-def run_tedapi_test(auto=False, debug=False):
+
+def _build_tedapi_arg_parser(default_host):
+    """Build the CLI parser used by the TEDAPI test command."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Tesla Powerwall Gateway TEDAPI Reader')
+    parser.add_argument('gw_pwd', nargs='?', help='Powerwall Gateway Password')
+    parser.add_argument('-gw_pwd', dest='gw_pwd_option', metavar='GW_PWD', default=None,
+                        help='Powerwall Gateway Password')
+    parser.add_argument('-host', '--gw_ip', dest='host', default=default_host,
+                        help='Powerwall Gateway IP Address')
+    parser.add_argument('-v1r', action='store_true', help='Use v1r LAN TEDAPI mode')
+    parser.add_argument('-password', default=None,
+                        help='Customer password for v1r mode (defaults to last 5 of gw_pwd)')
+    parser.add_argument('-rsa_key_path', default=None,
+                        help='Path to RSA private key PEM for v1r mode')
+    parser.add_argument('-wifi_host', default=None,
+                        help='Optional WiFi TEDAPI host for v1r follower fallback')
+    parser.add_argument('--debug', action='store_true', help='Enable Debug Output')
+    return parser
+
+
+def run_tedapi_test(argv=None, debug=False):
     # Imports
     from pypowerwall.tedapi import TEDAPI, GW_IP
     from pypowerwall import __version__
     import json
     import sys
-    import argparse
     import requests
     import logging
 
@@ -35,30 +56,27 @@ def run_tedapi_test(auto=False, debug=False):
         else:
             log.setLevel(logging.NOTSET)
 
-    # Load arguments if invoked from pypowerwall
-    if auto:
-        argv = ['pypowerwall']
-        if debug:
-            argv.append('--debug')
-        sys.argv = argv
-
     # Check for arguments using argparse
-    parser = argparse.ArgumentParser(description='Tesla Powerwall Gateway TEDAPI Reader')
-    parser.add_argument('gw_pwd', nargs='?', help='Powerwall Gateway Password')
-    parser.add_argument('--gw_ip', default=GW_IP, help='Powerwall Gateway IP Address')
-    parser.add_argument('--debug', action='store_true', help='Enable Debug Output')
-    # Parse arguments
-    args = parser.parse_args()
-    if args.gw_pwd:
-        gw_pwd = args.gw_pwd
-    else:
-        gw_pwd = None
+    parser = _build_tedapi_arg_parser(GW_IP)
+    args = parser.parse_args(argv)
+    gw_pwd = args.gw_pwd_option or args.gw_pwd
     if args.debug:
         set_debug(True)
-    GW_IP = args.gw_ip
+    elif debug:
+        set_debug(True)
+    host = args.host
 
-    # Check that GW_IP is listening to port 443
-    url = f'https://{GW_IP}'
+    if args.v1r:
+        if not args.rsa_key_path:
+            parser.error('-v1r requires -rsa_key_path')
+        if not args.password and not gw_pwd:
+            parser.error('-v1r requires -password or -gw_pwd')
+        password = args.password or gw_pwd[-5:]
+    else:
+        password = None
+
+    # Check that host is listening to port 443
+    url = f'https://{host}'
     log.debug(f"Checking Powerwall Gateway at {url}")
     print(f" - Connecting to {url}...", end="")
     try:
@@ -68,7 +86,7 @@ def run_tedapi_test(auto=False, debug=False):
     except Exception as e:
         print(" FAILED")
         print()
-        print(f"ERROR: Unable to connect to Powerwall Gateway {GW_IP} on port 443.")
+        print(f"ERROR: Unable to connect to Powerwall Gateway {host} on port 443.")
         print("Please verify your your host has a route to the Gateway.")
         print(f"\nError details: {e}")
         sys.exit(1)
@@ -89,8 +107,13 @@ def run_tedapi_test(auto=False, debug=False):
 
     # Create TEDAPI Object and get Configuration and Status
     print()
-    print(f"Connecting to Powerwall Gateway {GW_IP}")
-    ted = TEDAPI(gw_pwd, host=GW_IP)
+    print(f"Connecting to Powerwall Gateway {host}")
+    if args.v1r:
+        ted = TEDAPI(gw_pwd=gw_pwd or "", host=host, v1r=True,
+                     password=password, rsa_key_path=args.rsa_key_path,
+                     wifi_host=args.wifi_host)
+    else:
+        ted = TEDAPI(gw_pwd, host=host)
     if ted.din is None:
         print("\nERROR: Unable to connect to Powerwall Gateway. Check your password and try again")
         sys.exit(1)

--- a/pypowerwall/tedapi/__main__.py
+++ b/pypowerwall/tedapi/__main__.py
@@ -1,7 +1,7 @@
 # pyPowerwall - Tesla TEDAPI Class Main
 # -*- coding: utf-8 -*-
 """
- Tesla TEADAPI Class - Command Line Test
+ Tesla TEDAPI Class - Command Line Test
 
  This script tests the TEDAPI class by connecting to a Tesla Powerwall Gateway
 """
@@ -72,6 +72,8 @@ def run_tedapi_test(argv=None, debug=False):
         if not args.password and not gw_pwd:
             parser.error('-v1r requires -password or -gw_pwd')
         password = args.password or gw_pwd[-5:]
+        if gw_pwd is None:
+            gw_pwd = ""
     else:
         password = None
 
@@ -87,7 +89,7 @@ def run_tedapi_test(argv=None, debug=False):
         print(" FAILED")
         print()
         print(f"ERROR: Unable to connect to Powerwall Gateway {host} on port 443.")
-        print("Please verify your your host has a route to the Gateway.")
+        print("Please verify your host has a route to the Gateway.")
         print(f"\nError details: {e}")
         sys.exit(1)
 

--- a/pypowerwall/tests/unit/test_cli_tedapi.py
+++ b/pypowerwall/tests/unit/test_cli_tedapi.py
@@ -49,3 +49,35 @@ def test_run_tedapi_test_v1r_derives_password_from_gw_pwd(tmp_path, monkeypatch)
         rsa_key_path='/tmp/test.pem',
         wifi_host=None,
     )
+
+
+def test_run_tedapi_test_v1r_password_only_no_gw_pwd(tmp_path, monkeypatch):
+    """v1r with -password but no -gw_pwd must not hang on interactive input."""
+    from pypowerwall.tedapi.__main__ import run_tedapi_test
+
+    mock_ted = MagicMock()
+    mock_ted.din = 'DIN123'
+    mock_ted.get_config.return_value = {}
+    mock_ted.get_status.return_value = {}
+    monkeypatch.chdir(tmp_path)
+
+    with patch('requests.get') as mock_get, \
+         patch('pypowerwall.tedapi.TEDAPI', return_value=mock_ted) as mock_tedapi, \
+         patch('builtins.input') as mock_input:
+        mock_get.return_value.status_code = 200
+        run_tedapi_test([
+            '-host', '10.42.1.40',
+            '-v1r',
+            '-password', 'mypass',
+            '-rsa_key_path', '/tmp/test.pem',
+        ])
+
+    mock_input.assert_not_called()
+    mock_tedapi.assert_called_once_with(
+        gw_pwd='',
+        host='10.42.1.40',
+        v1r=True,
+        password='mypass',
+        rsa_key_path='/tmp/test.pem',
+        wifi_host=None,
+    )

--- a/pypowerwall/tests/unit/test_cli_tedapi.py
+++ b/pypowerwall/tests/unit/test_cli_tedapi.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock, patch
+
+
+def test_main_forwards_tedapi_v1r_args():
+    from pypowerwall.__main__ import main
+
+    argv = [
+        'pypowerwall', 'tedapi',
+        '-host', '10.42.1.40',
+        '-v1r',
+        '-gw_pwd', 'ABCDEXXXXX',
+        '-rsa_key_path', '/tmp/test.pem',
+    ]
+
+    with patch('sys.argv', argv), \
+         patch('pypowerwall.tedapi.__main__.run_tedapi_test') as mock_run:
+        main()
+
+    mock_run.assert_called_once_with(
+        argv=['-gw_pwd', 'ABCDEXXXXX', '-host', '10.42.1.40', '-v1r', '-rsa_key_path', '/tmp/test.pem'],
+        debug=False,
+    )
+
+
+def test_run_tedapi_test_v1r_derives_password_from_gw_pwd(tmp_path, monkeypatch):
+    from pypowerwall.tedapi.__main__ import run_tedapi_test
+
+    mock_ted = MagicMock()
+    mock_ted.din = 'DIN123'
+    mock_ted.get_config.return_value = {}
+    mock_ted.get_status.return_value = {}
+    monkeypatch.chdir(tmp_path)
+
+    with patch('requests.get') as mock_get, \
+         patch('pypowerwall.tedapi.TEDAPI', return_value=mock_ted) as mock_tedapi:
+        mock_get.return_value.status_code = 200
+        run_tedapi_test([
+            '-host', '10.42.1.40',
+            '-v1r',
+            '-gw_pwd', 'ABCDEXXXXX',
+            '-rsa_key_path', '/tmp/test.pem',
+        ])
+
+    mock_tedapi.assert_called_once_with(
+        gw_pwd='ABCDEXXXXX',
+        host='10.42.1.40',
+        v1r=True,
+        password='XXXXX',
+        rsa_key_path='/tmp/test.pem',
+        wifi_host=None,
+    )


### PR DESCRIPTION
## v0.15.4 - CLI Enhancements and Safety Guards

* Feat: `pypowerwall tedapi` CLI now accepts `-host HOST`, `-gw_pwd GW_PWD`, `-v1r`, `-password PASSWORD`, `-rsa_key_path RSA_KEY_PATH`, and `-wifi_host WIFI_HOST` flags, enabling full PW3 wired LAN (v1r) access directly from the command line
* Release prep:
     * Bump library version to `0.15.4`
     * Update proxy pinned dependency to `pypowerwall==0.15.4`
