### PR TITLE
Feature: Native Python Tesla Auth — Cross-Platform Browser Login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,4 +169,4 @@ tools/tesla-history/tesla-history.conf
 tools/tedapi-lan/credentials.json
 fleet_tokens.json
 tedapi_rsa_*
-
+*.bak

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ Step 3 - Run `python3 -m pypowerwall fleetapi` - The credentials and tokens will
 
 The unofficial Tesla Owners API allows FleetAPI access (option 2) without having to set up a website and PEM key. Follow the directions given to you by running `python3 -m pypowerwall setup`. The credentials and site_id will be stored in `.pypowerwall.auth` and `.pypowerwall.site`.
 
+If you need to authenticate on a machine without a display (e.g. a Raspberry Pi or remote server over SSH), use the `authtoken` command on your local machine to obtain a refresh token, then paste it into the remote session:
+
+```bash
+# On your local machine (Mac/Windows/Linux with a display):
+python3 -m pypowerwall authtoken
+
+# Follow the Tesla login flow in the popup window.
+# Copy the token printed to the terminal.
+
+# Then on the remote machine, run setup and paste the token when prompted:
+python3 -m pypowerwall setup
+```
+
 ### TEDAPI Mode - Option 4
 
 With version v0.10.0+, pypowerwall can access the TEDAPI endpoint on the Gateway over **Wi-Fi**. This API offers additional metrics related to string data, voltages, and alerts. You will need the Gateway Wi‑Fi password (found on the QR sticker on the Powerwall Gateway) and network access to `192.168.91.1` (either via the Gateway’s Wi‑Fi AP or a static route from your LAN).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 # RELEASE NOTES
 
+## v0.15.5 - Native Python Tesla Authentication
+
+* Feat: Replace external `tesla-auth` binary dependency with native Python Tesla authentication — no more platform-specific binary downloads
+* Feat: New `setup` command handles authentication and site selection in a single flow using a native WebView popup window (macOS, Windows, Linux)
+* Feat: New `authtoken` command for obtaining a refresh token on a local machine, then using it on a remote/headless server
+* Fix: Cross-platform WebView interception of `tesla://auth/callback` using WKWebView (macOS), WebView2 (Windows), and WebKit2GTK (Linux)
+* Release prep:
+     * Bump library version to `0.15.5`
+
 ## v0.15.4 - CLI Enhancements and Safety Guards
 
 * Feat: `pypowerwall tedapi` CLI now accepts `-host HOST`, `-gw_pwd GW_PWD`, `-v1r`, `-password PASSWORD`, `-rsa_key_path RSA_KEY_PATH`, and `-wifi_host WIFI_HOST` flags, enabling full PW3 wired LAN (v1r) access directly from the command line

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,2 +1,2 @@
-pypowerwall==0.15.4
+pypowerwall==0.15.5
 bs4==0.0.2

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -89,7 +89,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 15, 4)
+version_tuple = (0, 15, 5)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -368,6 +368,7 @@ def main():
             'din': pw.din(),
             'mode': pw.get_mode(),
             'reserve': pw.get_reserve(),
+            'soc': pw.level(),
             'current': pw.level(),
             'grid': pw.grid(),
             'home': pw.home(),

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -172,8 +172,13 @@ def main():
                 debug=getattr(args, 'debug', False),
             )
             auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
-            save_token(refresh_token, path=auth_file, email=args.email or "")
-            print(f"\n✅ Done! Run: python -m pypowerwall setup")
+            from pypowerwall.tesla_auth import _extract_email_from_token
+            email = args.email or _extract_email_from_token(refresh_token)
+            if not email:
+                email = input("Tesla account email: ").strip()
+            save_token(refresh_token, path=auth_file, email=email)
+            print(f"\n✅ Saved to {auth_file}")
+            print(f"\nRun: python -m pypowerwall setup")
         except (KeyboardInterrupt, EOFError):
             print("\nLogin cancelled.")
             sys.exit(1)

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -43,6 +43,8 @@ def main():
     login_args.add_argument("-email", type=str, default=None, help="Tesla account email address")
     login_args.add_argument("-headless", action="store_true", default=False,
                            help="Manual mode — paste URL instead of opening browser")
+    login_args.add_argument("-timeout", type=int, default=120,
+                           help="Seconds to wait for browser login [Default=120]")
     login_args.add_argument("-region", type=str, default="us", choices=["us", "cn"],
                            help="Tesla region: 'us' (default) or 'cn' (China)")
 

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -20,6 +20,17 @@ import json
 from pypowerwall import version, set_debug
 
 
+def _email_from_auth(authpath):
+    """Extract email from .pypowerwall.auth file if it exists."""
+    auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
+    try:
+        with open(auth_file) as f:
+            data = json.load(f)
+        return list(data.keys())[0]
+    except Exception:
+        return None
+
+
 def main():
     """Main entry point for the pypowerwall CLI."""
     # Global Variables
@@ -335,9 +346,11 @@ def main():
             if mode == 'local':
                 pw = pypowerwall.Powerwall(host=args.host, password=args.password, authpath=authpath)
             elif mode == 'cloud':
-                pw = pypowerwall.Powerwall(cloudmode=True, fleetapi=False, authpath=authpath)
+                email = _email_from_auth(authpath)
+                pw = pypowerwall.Powerwall(cloudmode=True, fleetapi=False, authpath=authpath, email=email)
             elif mode == 'fleetapi':
-                pw = pypowerwall.Powerwall(cloudmode=True, fleetapi=True, authpath=authpath)
+                email = _email_from_auth(authpath)
+                pw = pypowerwall.Powerwall(cloudmode=True, fleetapi=True, authpath=authpath, email=email)
             else:
                 print(f"ERROR: Invalid mode '{mode}' - must be one of: local, cloud, fleetapi")
                 sys.exit(1)

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -111,6 +111,8 @@ def main():
                                 help="IP address of Powerwall Gateway")
     get_mode_args.add_argument("-password", type=str, default="",
                                 help="Password for Powerwall Gateway")
+    get_mode_args.add_argument("-mode", type=str, default=None,
+                                help="Force connection mode: local, cloud, fleetapi, or tedapi")
 
     version_args = subparsers.add_parser("version", help='Print version information')
 
@@ -148,45 +150,52 @@ def main():
         set_debug(True)
 
     # Cloud Mode Setup
-    if command == 'setup':
+    elif command == 'setup':
+        from pypowerwall.tesla_auth import login as tesla_login
         from pypowerwall import PyPowerwallCloud
 
         email = args.email
         print("pyPowerwall [%s] - Cloud Mode Setup\n" % version)
-        # Run Setup
-        c = PyPowerwallCloud(None, authpath=authpath)
-        if c.setup(email):
-            print(f"Setup Complete. Auth file {c.authfile} ready to use.")
-        else:
-            print("ERROR: Failed to setup Tesla Cloud Mode")
-            sys.exit(1)
 
-    # Login to get refresh token
-    elif command == 'login':
-        from pypowerwall.tesla_auth import login as tesla_login, save_token
-        try:
-            # Ask for email before launching window (used for token storage)
-            email = args.email
-            if not email:
-                email = input("Tesla account email: ").strip()
-            refresh_token, detected_email = tesla_login(
-                email=email,
+        # Check for existing auth file
+        auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
+        if os.path.isfile(auth_file) and not email:
+            try:
+                with open(auth_file) as f:
+                    data = json.load(f)
+                email = list(data.keys())[0]
+                print("  Found existing auth file: %s" % auth_file)
+                resp = input("  Overwrite existing file? [y/N]: ").strip()
+                if resp.lower() != "y":
+                    email = None  # keep existing, just re-select site
+            except Exception:
+                pass
+
+        token_data = None
+        if email is None or not os.path.isfile(auth_file):
+            # Get token via native browser (macOS) or headless (Linux/Windows/SSH)
+            refresh_token, detected_email, token_data = tesla_login(
                 headless=args.headless,
                 region=args.region,
                 debug=getattr(args, 'debug', False),
             )
-            email = email or detected_email
-            auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
-            save_token(refresh_token, path=auth_file, email=email)
-            print(f"\n✅ Token saved to {auth_file}")
-            print(f"   Email: {email}")
-            print(f"\nRun: python -m pypowerwall setup")
-        except (KeyboardInterrupt, EOFError):
-            print("\nLogin cancelled.")
+            email = detected_email or email
+            if not email:
+                email = input("\nTesla account email: ").strip()
+
+        # Run Setup with token data (or None if using existing file)
+        c = PyPowerwallCloud(None, authpath=authpath, email=email)
+        if c.setup(email=email, token_data=token_data):
+            print(f"\nSetup Complete. Auth file {c.authfile} ready to use.")
+        else:
+            print("\nERROR: Failed to setup Tesla Cloud Mode")
             sys.exit(1)
-        except Exception as e:
-            print(f"\n❌ Login failed: {e}")
-            sys.exit(1)
+
+    # Login to get refresh token (DEPRECATED - use 'setup' instead)
+    elif command == 'login':
+        print("⚠️  'login' command is deprecated. Use 'setup' instead.")
+        print("   python -m pypowerwall setup")
+        sys.exit(1)
 
     # Get auth token (local only, print to stdout)
     elif command == 'authtoken':
@@ -310,9 +319,21 @@ def main():
     # Get Powerwall Mode
     elif command == 'get':
         import pypowerwall
-        # Load email from auth file
-        pw = pypowerwall.Powerwall(auto_select=True, authpath=authpath, password=args.password,
-                                    host=args.host)
+        # Determine connection mode
+        if args.mode:
+            mode = args.mode.lower()
+            if mode == 'local':
+                pw = pypowerwall.Powerwall(host=args.host, password=args.password, authpath=authpath)
+            elif mode == 'cloud':
+                pw = pypowerwall.Powerwall(cloudmode=True, fleetapi=False, authpath=authpath)
+            elif mode == 'fleetapi':
+                pw = pypowerwall.Powerwall(cloudmode=True, fleetapi=True, authpath=authpath)
+            else:
+                print(f"ERROR: Invalid mode '{mode}' - must be one of: local, cloud, fleetapi")
+                sys.exit(1)
+        else:
+            pw = pypowerwall.Powerwall(auto_select=True, authpath=authpath, password=args.password,
+                                        host=args.host)
         if args.format == 'text':
             print(f"pyPowerwall [{version}] - Get Powerwall Mode and Power Levels using {pw.mode} mode.\n")
         if not pw.is_connected():

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -48,6 +48,10 @@ def main():
     login_args.add_argument("-region", type=str, default="us", choices=["us", "cn"],
                            help="Tesla region: 'us' (default) or 'cn' (China)")
 
+    authtoken_args = subparsers.add_parser("authtoken",
+                                            help='Get refresh token via local browser login (prints to stdout)')
+    authtoken_args.add_argument("-region", type=str, default="us", choices=["us", "cn"],
+                                help="Tesla region: 'us' (default) or 'cn' (China)")
 
     fleetapi_args = subparsers.add_parser("fleetapi", help='Setup Tesla FleetAPI for Cloud Mode access')
 
@@ -161,11 +165,30 @@ def main():
                 email=args.email,
                 headless=args.headless,
                 region=args.region,
-                timeout=args.timeout or 120,
             )
             auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
             save_token(refresh_token, path=auth_file, email=args.email or "")
             print(f"\n✅ Done! Run: python -m pypowerwall setup")
+        except (KeyboardInterrupt, EOFError):
+            print("\nLogin cancelled.")
+            sys.exit(1)
+        except Exception as e:
+            print(f"\n❌ Login failed: {e}")
+            sys.exit(1)
+
+    # Get auth token (local only, print to stdout)
+    elif command == 'authtoken':
+        from pypowerwall.tesla_auth import get_authtoken
+        try:
+            print("\n⚡ Tesla Authentication — pypowerwall authtoken")
+            print("=" * 60)
+            token = get_authtoken(region=args.region)
+            print("\n" + "=" * 60)
+            print("Refresh Token:")
+            print("-" * 60)
+            print(token)
+            print("-" * 60)
+            print("\nCopy the token above and use it on your remote machine.")
         except (KeyboardInterrupt, EOFError):
             print("\nLogin cancelled.")
             sys.exit(1)

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -41,6 +41,8 @@ def main():
 
     login_args = subparsers.add_parser("login", help='Authenticate with Tesla and get refresh token')
     login_args.add_argument("-email", type=str, default=None, help="Tesla account email address")
+    login_args.add_argument("-debug", action="store_true", default=False,
+                           help="Enable debug output for auth flow")
     login_args.add_argument("-headless", action="store_true", default=False,
                            help="Manual mode — paste URL instead of opening browser")
     login_args.add_argument("-timeout", type=int, default=120,
@@ -167,6 +169,7 @@ def main():
                 email=args.email,
                 headless=args.headless,
                 region=args.region,
+                debug=getattr(args, 'debug', False),
             )
             auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
             save_token(refresh_token, path=auth_file, email=args.email or "")

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -184,7 +184,7 @@ def main():
                 email = input("\nTesla account email: ").strip()
 
         # Run Setup with token data (or None if using existing file)
-        c = PyPowerwallCloud(None, authpath=authpath, email=email)
+        c = PyPowerwallCloud(email, authpath=authpath)
         if c.setup(email=email, token_data=token_data):
             print(f"\nSetup Complete. Auth file {c.authfile} ready to use.")
         else:

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -50,6 +50,8 @@ def main():
 
     authtoken_args = subparsers.add_parser("authtoken",
                                             help='Get refresh token via local browser login (prints to stdout)')
+    authtoken_args.add_argument("-debug", action="store_true", default=False,
+                               help="Enable debug output for auth flow")
     authtoken_args.add_argument("-region", type=str, default="us", choices=["us", "cn"],
                                 help="Tesla region: 'us' (default) or 'cn' (China)")
 
@@ -182,7 +184,7 @@ def main():
         try:
             print("\n⚡ Tesla Authentication — pypowerwall authtoken")
             print("=" * 60)
-            token = get_authtoken(region=args.region)
+            token = get_authtoken(region=args.region, debug=getattr(args, 'debug', False))
             print("\n" + "=" * 60)
             print("Refresh Token:")
             print("-" * 60)

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -165,15 +165,14 @@ def main():
     elif command == 'login':
         from pypowerwall.tesla_auth import login as tesla_login, save_token
         try:
-            refresh_token = tesla_login(
+            refresh_token, detected_email = tesla_login(
                 email=args.email,
                 headless=args.headless,
                 region=args.region,
                 debug=getattr(args, 'debug', False),
             )
             auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
-            from pypowerwall.tesla_auth import _extract_email_from_token
-            email = args.email or _extract_email_from_token(refresh_token)
+            email = args.email or detected_email
             if not email:
                 email = input("Tesla account email: ").strip()
             save_token(refresh_token, path=auth_file, email=email)

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -203,6 +203,14 @@ def main():
             email = detected_email or email
             if not email:
                 email = input("\nTesla account email: ").strip()
+            # If headless/remote, token_data is empty — write token manually
+            if not token_data:
+                from pypowerwall.tesla_auth import save_token
+                save_token(
+                    {"refresh_token": refresh_token, "token_type": "Bearer", "expires_in": 28800},
+                    path=auth_file, email=email,
+                )
+                token_data = None  # signal setup() to use existing file
 
         # Run Setup with token data (or None if using existing file)
         c = PyPowerwallCloud(email, authpath=authpath)

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -45,8 +45,7 @@ def main():
                            help="Manual mode — paste URL instead of opening browser")
     login_args.add_argument("-region", type=str, default="us", choices=["us", "cn"],
                            help="Tesla region: 'us' (default) or 'cn' (China)")
-    login_args.add_argument("-timeout", type=int, default=300,
-                           help="Seconds to wait for browser redirect (default: 300)")
+
 
     fleetapi_args = subparsers.add_parser("fleetapi", help='Setup Tesla FleetAPI for Cloud Mode access')
 
@@ -160,7 +159,6 @@ def main():
                 email=args.email,
                 headless=args.headless,
                 region=args.region,
-                timeout=args.timeout,
             )
             auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
             save_token(refresh_token, path=auth_file, email=args.email or "")

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -208,7 +208,7 @@ def main():
                 from pypowerwall.tesla_auth import save_token
                 save_token(
                     {"refresh_token": refresh_token, "token_type": "Bearer", "expires_in": 28800},
-                    path=auth_file, email=email,
+                    path=auth_file, email=email, region=args.region,
                 )
                 token_data = None  # signal setup() to use existing file
 

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -39,6 +39,15 @@ def main():
     setup_args = subparsers.add_parser("setup", help='Setup Tesla Login for Cloud Mode access')
     setup_args.add_argument("-email", type=str, default=email, help="Email address for Tesla Login.")
 
+    login_args = subparsers.add_parser("login", help='Authenticate with Tesla and get refresh token')
+    login_args.add_argument("-email", type=str, default=None, help="Tesla account email address")
+    login_args.add_argument("-headless", action="store_true", default=False,
+                           help="Manual mode — paste URL instead of opening browser")
+    login_args.add_argument("-region", type=str, default="us", choices=["us", "cn"],
+                           help="Tesla region: 'us' (default) or 'cn' (China)")
+    login_args.add_argument("-timeout", type=int, default=300,
+                           help="Seconds to wait for browser redirect (default: 300)")
+
     fleetapi_args = subparsers.add_parser("fleetapi", help='Setup Tesla FleetAPI for Cloud Mode access')
 
     tedapi_args = subparsers.add_parser("tedapi", help='Test TEDAPI connection to Powerwall Gateway')
@@ -141,6 +150,26 @@ def main():
             print(f"Setup Complete. Auth file {c.authfile} ready to use.")
         else:
             print("ERROR: Failed to setup Tesla Cloud Mode")
+            sys.exit(1)
+
+    # Login to get refresh token
+    elif command == 'login':
+        from pypowerwall.tesla_auth import login as tesla_login, save_token
+        try:
+            refresh_token = tesla_login(
+                email=args.email,
+                headless=args.headless,
+                region=args.region,
+                timeout=args.timeout,
+            )
+            auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
+            save_token(refresh_token, path=auth_file, email=args.email or "")
+            print(f"\n✅ Done! Run: python -m pypowerwall setup")
+        except (KeyboardInterrupt, EOFError):
+            print("\nLogin cancelled.")
+            sys.exit(1)
+        except Exception as e:
+            print(f"\n❌ Login failed: {e}")
             sys.exit(1)
 
     # FleetAPI Mode Setup

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -159,6 +159,7 @@ def main():
 
         # Check for existing auth file
         auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
+        overwrite = False
         if os.path.isfile(auth_file) and not email:
             try:
                 with open(auth_file) as f:
@@ -166,8 +167,11 @@ def main():
                 email = list(data.keys())[0]
                 print("  Found existing auth file: %s" % auth_file)
                 resp = input("  Overwrite existing file? [y/N]: ").strip()
-                if resp.lower() != "y":
-                    email = None  # keep existing, just re-select site
+                if resp.lower() == "y":
+                    overwrite = True
+                    email = None
+                    os.remove(auth_file)
+                # else: keep existing, just re-select site
             except Exception:
                 pass
 

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -38,6 +38,12 @@ def main():
 
     setup_args = subparsers.add_parser("setup", help='Setup Tesla Login for Cloud Mode access')
     setup_args.add_argument("-email", type=str, default=email, help="Email address for Tesla Login.")
+    setup_args.add_argument("-headless", action="store_true", default=False,
+                           help="Manual mode — paste URL instead of opening browser")
+    setup_args.add_argument("-region", type=str, default="us", choices=["us", "cn"],
+                           help="Tesla region: 'us' (default) or 'cn' (China)")
+    setup_args.add_argument("-debug", action="store_true", default=False,
+                           help="Enable debug output for auth flow")
 
     login_args = subparsers.add_parser("login", help='Authenticate with Tesla and get refresh token')
     login_args.add_argument("-email", type=str, default=None, help="Tesla account email address")

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -159,6 +159,7 @@ def main():
                 email=args.email,
                 headless=args.headless,
                 region=args.region,
+                timeout=args.timeout or 120,
             )
             auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
             save_token(refresh_token, path=auth_file, email=args.email or "")

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -165,18 +165,21 @@ def main():
     elif command == 'login':
         from pypowerwall.tesla_auth import login as tesla_login, save_token
         try:
+            # Ask for email before launching window (used for token storage)
+            email = args.email
+            if not email:
+                email = input("Tesla account email: ").strip()
             refresh_token, detected_email = tesla_login(
-                email=args.email,
+                email=email,
                 headless=args.headless,
                 region=args.region,
                 debug=getattr(args, 'debug', False),
             )
+            email = email or detected_email
             auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
-            email = args.email or detected_email
-            if not email:
-                email = input("Tesla account email: ").strip()
             save_token(refresh_token, path=auth_file, email=email)
-            print(f"\n✅ Saved to {auth_file}")
+            print(f"\n✅ Token saved to {auth_file}")
+            print(f"   Email: {email}")
             print(f"\nRun: python -m pypowerwall setup")
         except (KeyboardInterrupt, EOFError):
             print("\nLogin cancelled.")

--- a/pypowerwall/cloud/pypowerwall_cloud.py
+++ b/pypowerwall/cloud/pypowerwall_cloud.py
@@ -919,7 +919,8 @@ class PyPowerwallCloud(PyPowerwallBase):
         Args:
             email: Tesla account email.
             token_data: Optional dict with full token response from Tesla OAuth.
-                       If provided, skips the browser login flow and uses this token.
+                       If provided, writes token directly. If None and file exists,
+                       skips auth and goes straight to site selection.
         """
         print("Tesla Account Setup")
         print("-" * 60)
@@ -952,69 +953,54 @@ class PyPowerwallCloud(PyPowerwallBase):
                 json.dump(cache, f, indent=2)
             os.chmod(self.authfile, 0o600)
             print(f"  Token saved for {tuser}")
+        elif email and os.path.isfile(self.authfile):
+            # Using existing file — just set email and connect
+            tuser = email.strip()
+            self.email = tuser
+            print(f"  Using existing auth file for {tuser}")
         else:
-            # Check for .pypowerwall.auth file
-            if os.path.isfile(self.authfile):
-                print("  Found existing Tesla Cloud setup file ({})".format(self.authfile))
-                with open(self.authfile) as json_file:
-                    try:
-                        data = json.load(json_file)
-                        tuser = list(data.keys())[0]
-                        print(f"  Using Tesla User: {tuser}")
-                        # Ask user if they want to overwrite the existing file
-                        response = input("\n  Overwrite existing file? [y/N]: ").strip()
-                        if response.lower() == "y":
-                            tuser = ""
-                            os.remove(self.authfile)
-                        else:
-                            self.email = tuser
-                    except Exception as err:
-                        log.debug(f"Unable to use existing authfile {self.authfile}: {err}")
-                        tuser = ""
+            # No token_data, no existing file — manual teslapy flow (fallback)
+            if email not in (None, "") and "@" in email:
+                tuser = email.strip()
+                print(f"\n  Email address: {tuser}")
+            else:
+                while True:
+                    response = input("\n  Email address: ").strip()
+                    if "@" not in response:
+                        print("  - Error: Invalid email address")
+                    else:
+                        tuser = response
+                        break
 
-            if tuser == "":
-                # Create new AUTHFILE
-                if email not in (None, "") and "@" in email:
-                    tuser = email.strip()
-                    print(f"\n  Email address: {tuser}")
-                else:
-                    while True:
-                        response = input("\n  Email address: ").strip()
-                        if "@" not in response:
-                            print("  - Error: Invalid email address")
-                        else:
-                            tuser = response
-                            break
+            # Update the Tesla User
+            self.email = tuser
 
-                # Update the Tesla User
-                self.email = tuser
+            # Create Tesla instance
+            tesla = Tesla(self.email, cache_file=self.authfile)
 
-                # Create Tesla instance
-                tesla = Tesla(self.email, cache_file=self.authfile)
+            if not tesla.authorized:
+                # Login to Tesla account and cache token
+                state = tesla.new_state()
+                code_verifier = tesla.new_code_verifier()
+
+                try:
+                    print("\nOpen the below address in your browser to login.\n")
+                    print(tesla.authorization_url(state=state, code_verifier=code_verifier))
+                except Exception as err:
+                    log.error(f"Connection failure - {repr(err)}")
+
+                print("\nAfter login, paste the URL of the 'Page Not Found' webpage below.\n")
+
+                tesla.close()
+                tesla = Tesla(self.email, state=state, code_verifier=code_verifier, cache_file=self.authfile)
 
                 if not tesla.authorized:
-                    # Login to Tesla account and cache token
-                    state = tesla.new_state()
-                    code_verifier = tesla.new_code_verifier()
-
                     try:
-                        print("\nOpen the below address in your browser to login.\n")
-                        print(tesla.authorization_url(state=state, code_verifier=code_verifier))
+                        tesla.fetch_token(authorization_response=input("Enter URL after login: "))
+                        print("-" * 60)
                     except Exception as err:
                         log.error(f"Connection failure - {repr(err)}")
-
-                    print("\nAfter login, paste the URL of the 'Page Not Found' webpage below.\n")
-
-                    tesla.close()
-                    tesla = Tesla(self.email, state=state, code_verifier=code_verifier, cache_file=self.authfile)
-
-                    if not tesla.authorized:
-                        try:
-                            tesla.fetch_token(authorization_response=input("Enter URL after login: "))
-                            print("-" * 60)
-                        except Exception as err:
-                            log.error(f"Connection failure - {repr(err)}")
-                            return False
+                        return False
 
         # Connect to Tesla Cloud
         self.siteid = None

--- a/pypowerwall/cloud/pypowerwall_cloud.py
+++ b/pypowerwall/cloud/pypowerwall_cloud.py
@@ -912,75 +912,109 @@ class PyPowerwallCloud(PyPowerwallBase):
     def get_api_solar_powerwall(self, **kwargs) -> Optional[Union[dict, list, str, bytes]]:
         return {}
 
-    def setup(self, email=None):
+    def setup(self, email=None, token_data=None):
         """
-        Set up the Tesla Cloud connection
+        Set up the Tesla Cloud connection.
+
+        Args:
+            email: Tesla account email.
+            token_data: Optional dict with full token response from Tesla OAuth.
+                       If provided, skips the browser login flow and uses this token.
         """
         print("Tesla Account Setup")
         print("-" * 60)
         tuser = ""
-        # Check for .pypowerwall.auth file
-        if os.path.isfile(self.authfile):
-            print("  Found existing Tesla Cloud setup file ({})".format(self.authfile))
-            with open(self.authfile) as json_file:
-                try:
-                    data = json.load(json_file)
-                    tuser = list(data.keys())[0]
-                    print(f"  Using Tesla User: {tuser}")
-                    # Ask user if they want to overwrite the existing file
-                    response = input("\n  Overwrite existing file? [y/N]: ").strip()
-                    if response.lower() == "y":
-                        tuser = ""
-                        os.remove(self.authfile)
-                    else:
-                        self.email = tuser
-                except Exception as err:
-                    log.debug(f"Unable to use existing authfile {self.authfile}: {err}")
-                    tuser = ""
 
-        if tuser == "":
-            # Create new AUTHFILE
-            if email not in (None, "") and "@" in email:
-                tuser = email.strip()
-                print(f"\n  Email address: {tuser}")
-            else:
-                while True:
-                    response = input("\n  Email address: ").strip()
-                    if "@" not in response:
-                        print("  - Error: Invalid email address")
-                    else:
-                        tuser = response
-                        break
-
-            # Update the Tesla User
+        # If token_data provided, write it directly and skip manual auth
+        if token_data and email:
+            tuser = email.strip()
             self.email = tuser
+            # Write token in teslapy-compatible format
+            import time
+            expires_in = token_data.get("expires_in", 28800)
+            expires_at = int(time.time() + expires_in)
+            cache = {
+                tuser: {
+                    "url": "https://auth.tesla.com/",
+                    "sso": {
+                        "token_type": token_data.get("token_type", "Bearer"),
+                        "access_token": token_data.get("access_token", ""),
+                        "refresh_token": token_data.get("refresh_token", ""),
+                        "expires_at": expires_at,
+                        "expires_in": expires_in,
+                    }
+                }
+            }
+            dir_name = os.path.dirname(self.authfile)
+            if dir_name:
+                os.makedirs(dir_name, exist_ok=True)
+            with open(self.authfile, "w") as f:
+                json.dump(cache, f, indent=2)
+            os.chmod(self.authfile, 0o600)
+            print(f"  Token saved for {tuser}")
+        else:
+            # Check for .pypowerwall.auth file
+            if os.path.isfile(self.authfile):
+                print("  Found existing Tesla Cloud setup file ({})".format(self.authfile))
+                with open(self.authfile) as json_file:
+                    try:
+                        data = json.load(json_file)
+                        tuser = list(data.keys())[0]
+                        print(f"  Using Tesla User: {tuser}")
+                        # Ask user if they want to overwrite the existing file
+                        response = input("\n  Overwrite existing file? [y/N]: ").strip()
+                        if response.lower() == "y":
+                            tuser = ""
+                            os.remove(self.authfile)
+                        else:
+                            self.email = tuser
+                    except Exception as err:
+                        log.debug(f"Unable to use existing authfile {self.authfile}: {err}")
+                        tuser = ""
 
-            # Create Tesla instance
-            tesla = Tesla(self.email, cache_file=self.authfile)
+            if tuser == "":
+                # Create new AUTHFILE
+                if email not in (None, "") and "@" in email:
+                    tuser = email.strip()
+                    print(f"\n  Email address: {tuser}")
+                else:
+                    while True:
+                        response = input("\n  Email address: ").strip()
+                        if "@" not in response:
+                            print("  - Error: Invalid email address")
+                        else:
+                            tuser = response
+                            break
 
-            if not tesla.authorized:
-                # Login to Tesla account and cache token
-                state = tesla.new_state()
-                code_verifier = tesla.new_code_verifier()
+                # Update the Tesla User
+                self.email = tuser
 
-                try:
-                    print("\nOpen the below address in your browser to login.\n")
-                    print(tesla.authorization_url(state=state, code_verifier=code_verifier))
-                except Exception as err:
-                    log.error(f"Connection failure - {repr(err)}")
-
-                print("\nAfter login, paste the URL of the 'Page Not Found' webpage below.\n")
-
-                tesla.close()
-                tesla = Tesla(self.email, state=state, code_verifier=code_verifier, cache_file=self.authfile)
+                # Create Tesla instance
+                tesla = Tesla(self.email, cache_file=self.authfile)
 
                 if not tesla.authorized:
+                    # Login to Tesla account and cache token
+                    state = tesla.new_state()
+                    code_verifier = tesla.new_code_verifier()
+
                     try:
-                        tesla.fetch_token(authorization_response=input("Enter URL after login: "))
-                        print("-" * 60)
+                        print("\nOpen the below address in your browser to login.\n")
+                        print(tesla.authorization_url(state=state, code_verifier=code_verifier))
                     except Exception as err:
                         log.error(f"Connection failure - {repr(err)}")
-                        return False
+
+                    print("\nAfter login, paste the URL of the 'Page Not Found' webpage below.\n")
+
+                    tesla.close()
+                    tesla = Tesla(self.email, state=state, code_verifier=code_verifier, cache_file=self.authfile)
+
+                    if not tesla.authorized:
+                        try:
+                            tesla.fetch_token(authorization_response=input("Enter URL after login: "))
+                            print("-" * 60)
+                        except Exception as err:
+                            log.error(f"Connection failure - {repr(err)}")
+                            return False
 
         # Connect to Tesla Cloud
         self.siteid = None

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -171,20 +171,10 @@ def _remote_login() -> str:
 # Path 2 — Local login (native WebView with navigation interception)
 # ---------------------------------------------------------------------------
 
-def _local_login(email: str = None, region: str = "us") -> str:
-    """Local login via native WebView, intercepting tesla:// redirect.
-
-    Platform dispatch:
-    - macOS: PyObjC WKWebView with custom WKNavigationDelegate
-    - Windows/Linux: pywebview with monkey-patched navigation handler
-
-    Both approaches use the same technique as tesla_auth (Rust):
-    register a navigation policy handler that intercepts the tesla://
-    custom scheme redirect, extracts the auth code, and cancels the
-    navigation before the WebView rejects it.
-    """
+def _local_login(email: str = None, region: str = "us", debug: bool = False) -> str:
+    """Local login via native WebView, intercepting tesla:// redirect."""
     if sys.platform == "darwin":
-        return _local_login_macos(email, region)
+        return _local_login_macos(email, region, debug=debug)
     else:
         return _local_login_pywebview(email, region)
 
@@ -193,7 +183,7 @@ def _local_login(email: str = None, region: str = "us") -> str:
 # macOS — Native WKWebView via PyObjC
 # ---------------------------------------------------------------------------
 
-def _local_login_macos(email: str = None, region: str = "us") -> str:
+def _local_login_macos(email: str = None, region: str = "us", debug: bool = False) -> str:
     """Native WKWebView on macOS with WKNavigationDelegate to intercept tesla://.
 
     This mirrors exactly what tesla_auth's wry does on macOS:
@@ -215,6 +205,10 @@ def _local_login_macos(email: str = None, region: str = "us") -> str:
 
     result = {"token": None, "error": None}
 
+    def dbg(msg):
+        if debug:
+            print(f"  [debug] {msg}")
+
     class TeslaNavDelegate(AppKit.NSObject):
         """WKNavigationDelegate that intercepts tesla:// redirects."""
 
@@ -223,54 +217,54 @@ def _local_login_macos(email: str = None, region: str = "us") -> str:
         ):
             try:
                 url = str(action.request().URL().absoluteString())
-            except Exception:
-                # If we can't get the URL, allow the navigation
-                handler(1)  # WKNavigationActionPolicyAllow
+            except Exception as e:
+                dbg(f"Could not get URL: {e}")
+                handler(1)
                 return
 
+            dbg(f"Navigation: {url[:100]}")
+
             if url.startswith("tesla://"):
-                # Intercept! Extract auth code from the redirect URL
+                dbg(f"INTERCEPTED tesla:// URL: {url[:120]}")
                 try:
                     parsed = urllib.parse.urlparse(url)
                     params = urllib.parse.parse_qs(parsed.query)
+                    dbg(f"Params: {list(params.keys())}")
 
-                    # Check for error
                     error = params.get("error", [None])[0]
                     if error:
                         result["error"] = f"Tesla auth error: {error}"
-                        handler(0)  # Cancel
-                        AppHelper.stopEventLoop()
-                        return
-
-                    # Check for login cancelled
-                    if params.get("error", [None])[0] == "login_cancelled":
-                        result["error"] = "Login cancelled by user"
+                        dbg(f"Auth error from Tesla: {error}")
                         handler(0)
-                        AppHelper.stopEventLoop()
+                        AppHelper.callAfter(AppHelper.stopEventLoop)
                         return
 
                     code = params.get("code", [None])[0]
                     returned_state = params.get("state", [None])[0]
+                    dbg(f"Code present: {bool(code)}, State match: {returned_state == state}")
 
                     if not code:
                         result["error"] = f"No auth code in redirect: {url}"
                         handler(0)
-                        AppHelper.stopEventLoop()
+                        AppHelper.callAfter(AppHelper.stopEventLoop)
                         return
 
                     if returned_state != state:
-                        result["error"] = "CSRF state mismatch — possible attack"
+                        result["error"] = "CSRF state mismatch"
+                        dbg(f"State mismatch: got {returned_state!r} expected {state!r}")
                         handler(0)
-                        AppHelper.stopEventLoop()
+                        AppHelper.callAfter(AppHelper.stopEventLoop)
                         return
 
-                    # Exchange code for token (in background to not block the delegate)
+                    dbg("Auth code captured — exchanging for token...")
+
                     def do_exchange():
                         try:
-                            # _exchange_code returns a refresh_token string directly
                             result["token"] = _exchange_code(code, code_verifier, region)
+                            dbg(f"Token exchange succeeded, token length: {len(result['token'])}")
                         except Exception as e:
                             result["error"] = f"Token exchange failed: {e}"
+                            dbg(f"Token exchange error: {e}")
                         finally:
                             AppHelper.callAfter(AppHelper.stopEventLoop)
 
@@ -278,12 +272,13 @@ def _local_login_macos(email: str = None, region: str = "us") -> str:
 
                 except Exception as e:
                     result["error"] = f"Failed to parse redirect: {e}"
-                    AppHelper.stopEventLoop()
+                    dbg(f"Parse error: {e}")
+                    AppHelper.callAfter(AppHelper.stopEventLoop)
 
                 handler(0)  # Cancel the tesla:// navigation
             else:
-                # Allow all normal navigation (Tesla login pages, etc.)
-                handler(1)  # WKNavigationActionPolicyAllow
+                # Allow all normal navigation
+                handler(1)
 
     def run_window():
         # Initialize NSApplication on the main thread
@@ -507,34 +502,16 @@ def _patch_pywebview_gtk(result, expected_state):
 # Public API
 # ---------------------------------------------------------------------------
 
-def login(email: str = None, headless: bool = False, region: str = "us") -> str:
-    """Authenticate with Tesla and return a refresh token.
-
-    Auto-detects local vs remote environment. On remote sessions (or if
-    ``headless=True``), uses the paste-token flow. Otherwise opens a
-    native WebView window for login.
-
-    Args:
-        email: Tesla account email (optional, used as login hint).
-        headless: Force remote/paste mode regardless of environment.
-        region: 'us' (default) or 'cn'.
-
-    Returns:
-        refresh_token string.
-    """
+def login(email: str = None, headless: bool = False, region: str = "us", debug: bool = False) -> str:
+    """Authenticate with Tesla and return a refresh token."""
     if headless or _detect_mode() == "remote":
         return _remote_login()
+    return _local_login(email=email, region=region, debug=debug)
 
-    return _local_login(email=email, region=region)
 
-
-def get_authtoken(region: str = "us") -> str:
-    """Get a refresh token for the ``authtoken`` CLI command.
-
-    Always uses the local WebView path (no file saving). The caller
-    is responsible for displaying or using the token.
-    """
-    return _local_login(region=region)
+def get_authtoken(region: str = "us", debug: bool = False) -> str:
+    """Get a refresh token for the authtoken CLI command (no file save)."""
+    return _local_login(region=region, debug=debug)
 
 
 def save_token(refresh_token: str, path: str = None, email: str = None):

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -3,17 +3,21 @@ from __future__ import annotations
 pypowerwall.tesla_auth - Pure Python Tesla OAuth 2.0 PKCE authentication
 
 Replaces the external tesla_auth binary. Users can authenticate with Tesla
-and obtain refresh tokens using only Python — no Rust binary needed.
+and obtain refresh tokens using only Python — no Rust binary or WebView needed.
 
-Tesla requires redirect_uri=tesla://auth/callback for the ownerapi client_id.
-Since this is a custom URI scheme, we cannot use a localhost HTTP server to
-catch the callback automatically. Instead, both interactive and headless modes
-require the user to paste the redirect URL back into the terminal after login.
+How it works:
+  1. Registers tesla:// as a custom URI scheme handler on the OS
+  2. Starts a local HTTP server to catch the forwarded callback
+  3. Opens the browser to Tesla's OAuth login page
+  4. After login, Tesla redirects to tesla://auth/callback?code=...
+  5. The OS calls our handler, which forwards the URL to the local server
+  6. We capture the auth code and exchange it for tokens
+  7. Cleanup: unregister the handler
 
 Supports:
-  - Interactive browser login (opens browser, user pastes redirect URL)
-  - Headless/manual mode (prints URL, user opens on another device, pastes URL)
-  - Cross-platform: Linux, macOS, Windows, headless servers
+  - Interactive browser login (auto-captures callback via URI handler)
+  - Headless/manual mode (prints URL, user pastes redirect URL)
+  - Cross-platform: Linux (xdg), macOS (lsregister), Windows (registry)
   - Region auto-detection from callback issuer parameter
 
 Usage:
@@ -31,10 +35,19 @@ Based on the OAuth 2.0 PKCE flow from tesla_auth (Rust) by Adrian Kumpf.
 
 import base64
 import hashlib
+import http.server
 import json
 import os
+import platform
 import secrets
+import shutil
+import socket
+import struct
+import subprocess
 import sys
+import tempfile
+import threading
+import time
 import urllib.parse
 import webbrowser
 
@@ -56,10 +69,6 @@ TOKEN_URL_US = "https://auth.tesla.com/oauth2/v3/token"
 AUTH_URL_CN = "https://auth.tesla.cn/oauth2/v3/authorize"
 TOKEN_URL_CN = "https://auth.tesla.cn/oauth2/v3/token"
 
-# Tesla only accepts this custom URI scheme for the ownerapi client_id.
-# The native tesla_auth app intercepts this via a WebView navigation handler.
-# We use it in the auth URL; after login, Tesla redirects to this URI with
-# code/state/issuer query params. The user copies the full URL from the browser.
 REDIRECT_URI = "tesla://auth/callback"
 
 SCOPES = ["openid", "email", "offline_access"]
@@ -75,18 +84,18 @@ REGION_CONFIG = {
     },
 }
 
+# Temp files for inter-process communication
+HANDLER_PORT_FILE = os.path.join(tempfile.gettempdir(), "tesla_auth_port.txt")
+HANDLER_SCRIPT_PATH = os.path.join(tempfile.gettempdir(), "tesla_uri_handler.py")
+
 
 # ---------------------------------------------------------------------------
-# PKCE helpers — match tesla_auth's oauth2 crate behavior
+# PKCE helpers
 # ---------------------------------------------------------------------------
 
 def generate_code_verifier() -> str:
-    """Generate a PKCE code_verifier (base64url-encoded random bytes).
-
-    tesla_auth uses oauth2 crate's PkceCodeChallenge::new_random_sha256()
-    which generates 32 random bytes → base64url (43 chars). We match that.
-    """
-    return secrets.token_urlsafe(32)  # 32 bytes → 43 base64url chars
+    """Generate a PKCE code_verifier (base64url-encoded random bytes)."""
+    return secrets.token_urlsafe(32)
 
 
 def generate_code_challenge(code_verifier: str) -> str:
@@ -104,11 +113,7 @@ def generate_state() -> str:
 # URL building
 # ---------------------------------------------------------------------------
 
-def build_auth_url(
-    code_challenge: str,
-    state: str,
-    region: str = "us",
-) -> str:
+def build_auth_url(code_challenge: str, state: str, region: str = "us") -> str:
     """Build the Tesla OAuth authorization URL with tesla:// redirect."""
     cfg = REGION_CONFIG.get(region, REGION_CONFIG["us"])
     params = {
@@ -127,26 +132,8 @@ def build_auth_url(
 # Token exchange
 # ---------------------------------------------------------------------------
 
-def exchange_code(
-    code: str,
-    code_verifier: str,
-    token_url: str,
-) -> dict:
-    """
-    Exchange an authorization code for tokens.
-
-    Args:
-        code: The authorization code from the callback.
-        code_verifier: The PKCE code verifier.
-        token_url: The token endpoint URL (region-specific).
-
-    Returns:
-        dict with: access_token, refresh_token, expires_in, etc.
-
-    Raises:
-        RuntimeError on failure.
-        ImportError if requests is not installed.
-    """
+def exchange_code(code: str, code_verifier: str, token_url: str) -> dict:
+    """Exchange an authorization code for tokens."""
     if requests is None:
         raise ImportError("The 'requests' package is required. Install with: pip install requests")
 
@@ -160,9 +147,7 @@ def exchange_code(
 
     resp = requests.post(token_url, data=data, timeout=30)
     if resp.status_code != 200:
-        raise RuntimeError(
-            f"Token exchange failed (HTTP {resp.status_code}): {resp.text}"
-        )
+        raise RuntimeError(f"Token exchange failed (HTTP {resp.status_code}): {resp.text}")
 
     result = resp.json()
     if "refresh_token" not in result:
@@ -171,20 +156,8 @@ def exchange_code(
     return result
 
 
-def refresh_access_token(
-    refresh_token: str,
-    token_url: str = TOKEN_URL_US,
-) -> dict:
-    """
-    Refresh an access token using a refresh token.
-
-    Args:
-        refresh_token: The Tesla refresh token.
-        token_url: The token endpoint URL (region-specific).
-
-    Returns:
-        dict with: access_token, refresh_token, expires_in, etc.
-    """
+def refresh_access_token(refresh_token: str, token_url: str = TOKEN_URL_US) -> dict:
+    """Refresh an access token using a refresh token."""
     if requests is None:
         raise ImportError("The 'requests' package is required. Install with: pip install requests")
 
@@ -196,9 +169,7 @@ def refresh_access_token(
 
     resp = requests.post(token_url, data=data, timeout=30)
     if resp.status_code != 200:
-        raise RuntimeError(
-            f"Token refresh failed (HTTP {resp.status_code}): {resp.text}"
-        )
+        raise RuntimeError(f"Token refresh failed (HTTP {resp.status_code}): {resp.text}")
 
     return resp.json()
 
@@ -208,14 +179,7 @@ def refresh_access_token(
 # ---------------------------------------------------------------------------
 
 def parse_callback_url(callback_url: str) -> dict:
-    """
-    Parse the redirect callback URL to extract code, state, and issuer.
-
-    The callback URL looks like:
-        tesla://auth/callback?code=...&state=...&issuer=https://auth.tesla.com/...
-
-    Returns dict with: code, state, issuer, token_url
-    """
+    """Parse the redirect callback URL to extract code, state, and issuer."""
     parsed = urllib.parse.urlparse(callback_url)
     params = urllib.parse.parse_qs(parsed.query)
 
@@ -232,8 +196,7 @@ def parse_callback_url(callback_url: str) -> dict:
     if not state:
         raise RuntimeError("No state parameter found in the redirect URL.")
 
-    # Determine token_url from issuer (matching tesla_auth's retrieve_tokens)
-    token_url = TOKEN_URL_US  # default
+    token_url = TOKEN_URL_US
     if issuer and "auth.tesla.cn" in issuer:
         token_url = TOKEN_URL_CN
 
@@ -246,8 +209,306 @@ def parse_callback_url(callback_url: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Main login function
+# Local HTTP callback server
 # ---------------------------------------------------------------------------
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    """HTTP handler that receives the forwarded tesla:// callback."""
+
+    auth_result = None  # type: ignore
+
+    def do_GET(self):
+        if self.path.startswith("/callback"):
+            params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            _CallbackHandler.auth_result = params
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"<html><body><h2>Authentication successful!</h2>"
+                             b"<p>You can close this tab.</p></body></html>")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass  # Suppress request logging
+
+
+class _CallbackServer:
+    """Local HTTP server that waits for the callback from the URI handler."""
+
+    def __init__(self, port: int):
+        _CallbackHandler.auth_result = None
+        self._server = http.server.HTTPServer(("127.0.0.1", port), _CallbackHandler)
+        self._server.timeout = 1
+        self._port = port
+        self._got_it = threading.Event()
+
+    def start_background(self):
+        """Start serving in a background thread."""
+        t = threading.Thread(target=self._serve_loop, daemon=True)
+        t.start()
+
+    def _serve_loop(self):
+        while not self._got_it.is_set():
+            self._server.handle_request()
+
+    def wait_for_code(self, timeout: int = 120) -> dict | None:
+        """Wait for the callback to arrive. Returns the parsed query params."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if _CallbackHandler.auth_result is not None:
+                self._got_it.set()
+                return _CallbackHandler.auth_result
+            time.sleep(0.5)
+        self._got_it.set()
+        return None
+
+    def shutdown(self):
+        self._got_it.set()
+        self._server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# URI handler script (written to /tmp, called by OS when tesla:// is opened)
+# ---------------------------------------------------------------------------
+
+def _write_handler_script():
+    """Write the URI handler script that forwards tesla:// URLs to our server."""
+    # Use stdlib only — no requests dependency for the handler
+    script = f'''#!/usr/bin/env python3
+"""URI handler for tesla:// scheme — forwards to local callback server."""
+import sys
+try:
+    import urllib.request
+    import urllib.parse
+    uri = sys.argv[1] if len(sys.argv) > 1 else ""
+    if not uri:
+        sys.exit(1)
+    try:
+        with open("{HANDLER_PORT_FILE}", "r") as f:
+            port = f.read().strip()
+    except Exception:
+        sys.exit(1)
+    parsed = urllib.parse.urlparse(uri)
+    qs = urllib.parse.urlencode(urllib.parse.parse_qs(parsed.query), doseq=True)
+    url = f"http://127.0.0.1:{{port}}/callback?{{qs}}"
+    try:
+        urllib.request.urlopen(url, timeout=5)
+    except Exception:
+        pass
+except Exception:
+    pass
+'''
+    with open(HANDLER_SCRIPT_PATH, "w") as f:
+        f.write(script)
+    os.chmod(HANDLER_SCRIPT_PATH, 0o755)
+
+
+# ---------------------------------------------------------------------------
+# OS-specific protocol handler registration
+# ---------------------------------------------------------------------------
+
+def _get_python_path() -> str:
+    """Get the current Python interpreter path."""
+    return sys.executable
+
+
+def _register_linux() -> bool:
+    """Register tesla:// URI scheme on Linux via xdg-mime."""
+    apps_dir = os.path.expanduser("~/.local/share/applications")
+    os.makedirs(apps_dir, exist_ok=True)
+
+    desktop_file = os.path.join(apps_dir, "tesla-auth-helper.desktop")
+    python_path = _get_python_path()
+
+    content = (
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        "Name=Tesla Auth Helper\n"
+        f"Exec={python_path} {HANDLER_SCRIPT_PATH} %u\n"
+        "MimeType=x-scheme-handler/tesla\n"
+        "NoDisplay=true\n"
+    )
+
+    with open(desktop_file, "w") as f:
+        f.write(content)
+
+    try:
+        subprocess.run(
+            ["xdg-mime", "default", "tesla-auth-helper.desktop",
+             "x-scheme-handler/tesla"],
+            capture_output=True, timeout=10, check=False,
+        )
+        subprocess.run(
+            ["update-desktop-database", apps_dir],
+            capture_output=True, timeout=10, check=False,
+        )
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def _register_macos() -> bool:
+    """Register tesla:// URI scheme on macOS via a small .app bundle."""
+    # Create a minimal .app bundle
+    app_dir = os.path.expanduser("~/Library/TeslaAuthHelper.app")
+    contents_dir = os.path.join(app_dir, "Contents")
+    macos_dir = os.path.join(contents_dir, "MacOS")
+    os.makedirs(macos_dir, exist_ok=True)
+
+    # Write Info.plist with URI scheme registration
+    plist = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"'
+        ' "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+        '<plist version="1.0"><dict>\n'
+        '  <key>CFBundleIdentifier</key>'
+        '<string>com.pypowerwall.teslaauth</string>\n'
+        '  <key>CFBundleName</key>'
+        '<string>TeslaAuthHelper</string>\n'
+        '  <key>CFBundleURLTypes</key><array><dict>\n'
+        '    <key>CFBundleURLSchemes</key><array>'
+        '<string>tesla</string></array>\n'
+        '    <key>CFBundleURLName</key>'
+        '<string>Tesla Auth</string>\n'
+        '  </dict></array>\n'
+        '</dict></plist>\n'
+    )
+    with open(os.path.join(contents_dir, "Info.plist"), "w") as f:
+        f.write(plist)
+
+    # Write the launcher script
+    launcher = os.path.join(macos_dir, "TeslaAuthHelper")
+    python_path = _get_python_path()
+    with open(launcher, "w") as f:
+        f.write(f"#!/bin/bash\nexec {python_path} {HANDLER_SCRIPT_PATH} \"$1\"\n")
+    os.chmod(launcher, 0o755)
+
+    # Register with LaunchServices
+    try:
+        subprocess.run(
+            ["/System/Library/Frameworks/CoreServices.framework/Frameworks/"
+             "LaunchServices.framework/Support/lsregister",
+             "-f", app_dir],
+            capture_output=True, timeout=15, check=False,
+        )
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def _register_windows() -> bool:
+    """Register tesla:// URI scheme on Windows via Registry."""
+    try:
+        import winreg
+    except ImportError:
+        return False
+
+    python_path = _get_python_path()
+    try:
+        key = winreg.CreateKey(winreg.HKEY_CURRENT_USER, r"Software\Classes\tesla")
+        winreg.SetValue(key, "", winreg.REG_SZ, "URL:Tesla Auth Protocol")
+        winreg.SetValueEx(key, "URL Protocol", 0, winreg.REG_SZ, "")
+        cmd_key = winreg.CreateKey(key, r"shell\open\command")
+        winreg.SetValue(
+            cmd_key, "",
+            winreg.REG_SZ,
+            f'"{python_path}" "{HANDLER_SCRIPT_PATH}" "%1"',
+        )
+        winreg.CloseKey(cmd_key)
+        winreg.CloseKey(key)
+        return True
+    except Exception:
+        return False
+
+
+def _register_protocol_handler() -> bool:
+    """Register the tesla:// URI scheme handler for the current OS."""
+    system = sys.platform
+    if system == "linux":
+        return _register_linux()
+    elif system == "darwin":
+        return _register_macos()
+    elif system == "win32":
+        return _register_windows()
+    return False
+
+
+def _unregister_protocol_handler():
+    """Remove the tesla:// URI scheme registration."""
+    system = sys.platform
+
+    if system == "linux":
+        desktop_file = os.path.expanduser(
+            "~/.local/share/applications/tesla-auth-helper.desktop"
+        )
+        try:
+            if os.path.exists(desktop_file):
+                os.remove(desktop_file)
+            apps_dir = os.path.expanduser("~/.local/share/applications")
+            subprocess.run(
+                ["update-desktop-database", apps_dir],
+                capture_output=True, timeout=10, check=False,
+            )
+        except Exception:
+            pass
+
+    elif system == "darwin":
+        app_dir = os.path.expanduser("~/Library/TeslaAuthHelper.app")
+        try:
+            if os.path.exists(app_dir):
+                shutil.rmtree(app_dir, ignore_errors=True)
+            subprocess.run(
+                ["/System/Library/Frameworks/CoreServices.framework/Frameworks/"
+                 "LaunchServices.framework/Support/lsregister",
+                 "-u", app_dir],
+                capture_output=True, timeout=10, check=False,
+            )
+        except Exception:
+            pass
+
+    elif system == "win32":
+        try:
+            import winreg
+            winreg.DeleteKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Classes\tesla\shell\open\command",
+            )
+            winreg.DeleteKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Classes\tesla\shell\open",
+            )
+            winreg.DeleteKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Classes\tesla\shell",
+            )
+            winreg.DeleteKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Classes\tesla",
+            )
+        except Exception:
+            pass
+
+    # Clean up handler script and port file
+    for f in [HANDLER_SCRIPT_PATH, HANDLER_PORT_FILE]:
+        try:
+            if os.path.exists(f):
+                os.remove(f)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _find_free_port() -> int:
+    """Find a free TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
 
 def _has_display() -> bool:
     """Check if a display is available for opening a browser."""
@@ -256,30 +517,38 @@ def _has_display() -> bool:
     return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
 
 
+# ---------------------------------------------------------------------------
+# Main login function
+# ---------------------------------------------------------------------------
+
 def login(
     email: str = None,
     headless: bool = False,
     region: str = "us",
+    timeout: int = 120,
 ) -> str:
     """
     Authenticate with Tesla and return a refresh token.
 
-    Uses the OAuth 2.0 PKCE flow matching tesla_auth. The redirect URI is
-    tesla://auth/callback — Tesla's only accepted redirect for ownerapi.
-    After login, the browser redirects to this custom URI. The user must
-    copy the full URL from the browser's address bar and paste it back.
+    Uses OAuth 2.0 PKCE flow. When a display is available:
+      1. Registers tesla:// URI handler on the OS
+      2. Starts a local HTTP server
+      3. Opens browser → user logs in → Tesla redirects to tesla://...
+      4. OS handler forwards to local server → captures auth code
+      5. Exchanges code for tokens
+      6. Cleans up URI registration
+
+    In headless mode or when handler registration fails, falls back to
+    manual paste mode (user copies URL from browser address bar).
 
     Args:
         email: Tesla account email (optional, will prompt if needed).
-        headless: If True, don't open browser (just print URL).
-        region: 'us' (default) or 'cn' for China. Overridden by issuer in callback.
-        timeout: Removed — no server to timeout.
+        headless: If True, skip browser and use manual paste mode.
+        region: 'us' (default) or 'cn' for China.
+        timeout: Seconds to wait for automatic callback (default: 120).
 
     Returns:
         refresh_token string.
-
-    Raises:
-        RuntimeError: On authentication failure.
     """
     # Generate PKCE parameters
     code_verifier = generate_code_verifier()
@@ -298,26 +567,108 @@ def login(
     # Build auth URL
     auth_url = build_auth_url(code_challenge, state, region)
 
-    # Open browser if not headless and display available
-    if not headless and _has_display():
-        print("Opening browser for Tesla login...")
-        webbrowser.open(auth_url)
+    # Determine mode: try automatic capture if display available and not headless
+    use_auto = not headless and _has_display()
+
+    callback_url = None
+    server = None
+
+    if use_auto:
+        try:
+            port = _find_free_port()
+
+            # Write port file for handler script
+            with open(HANDLER_PORT_FILE, "w") as f:
+                f.write(str(port))
+
+            # Write handler script
+            _write_handler_script()
+
+            # Register protocol handler
+            registered = _register_protocol_handler()
+
+            if registered:
+                # Start local HTTP server
+                server = _CallbackServer(port)
+                server.start_background()
+
+                # Open browser
+                print("Opening browser for Tesla login...")
+                print(
+                    "\nAfter logging in, the browser will redirect automatically.\n"
+                    "If the redirect fails, copy the FULL URL from the address bar\n"
+                    "and paste it below.\n"
+                )
+                webbrowser.open(auth_url)
+
+                # Wait for automatic callback
+                print(f"Waiting for redirect (up to {timeout}s)...")
+                result = server.wait_for_code(timeout=timeout)
+
+                if result and "code" in result:
+                    codes = result["code"]
+                    states = result.get("state", [None])
+                    issuers = result.get("issuer", [None])
+
+                    if codes and states and states[0] == state:
+                        # Build a fake callback URL to parse consistently
+                        issuer = issuers[0] if issuers else None
+                        token_url = TOKEN_URL_US
+                        if issuer and "auth.tesla.cn" in issuer:
+                            token_url = TOKEN_URL_CN
+
+                        print("  ✅ Auth code captured automatically!")
+                        tokens = exchange_code(codes[0], code_verifier, token_url)
+                        refresh_token = tokens["refresh_token"]
+                        print(f"  ✅ Refresh token obtained (expires in {tokens.get('expires_in', '?')}s)")
+                        return refresh_token
+                    else:
+                        print("  ⚠️ State mismatch or empty code, falling back to manual mode.")
+                else:
+                    print("  ⚠️ Timed out waiting for automatic redirect.")
+                    print("  Falling back to manual paste mode.\n")
+            else:
+                print("  ⚠️ Could not register URI handler, using manual paste mode.\n")
+
+        except Exception as e:
+            print(f"  ⚠️ Auto-capture failed ({e}), falling back to manual paste mode.\n")
+        finally:
+            # Always clean up
+            if server:
+                try:
+                    server.shutdown()
+                except Exception:
+                    pass
+            _unregister_protocol_handler()
+
+    # Manual paste mode (headless, fallback, or auto-capture failed)
+    if not headless and _has_display() and callback_url is None:
+        # Already opened browser above in auto attempt
+        print("Open the following URL if the browser didn't open:")
+        print(f"  {auth_url}\n")
         print(
-            "\nAfter logging in, your browser will show an error or blank page.\n"
-            "This is expected — the URL in the address bar contains your auth code.\n"
-            "Copy the FULL URL from the address bar and paste it below.\n"
+            "After logging in, copy the FULL URL from the address bar\n"
+            "(it will start with tesla://) and paste it below.\n"
         )
-    else:
+    elif callback_url is None:
         print(
             "\nOpen the following URL in your browser to log into your Tesla account:\n"
         )
         print(f"  {auth_url}\n")
         print(
-            "After logging in, you will be redirected to a tesla:// URL.\n"
-            "Copy the FULL URL from your browser's address bar and paste it below.\n"
+            "After logging in, copy the FULL redirect URL from your browser\n"
+            "(it will start with tesla://) and paste it below.\n"
         )
 
-    callback_url = input("Paste the redirect URL: ").strip()
+    # In auto mode, we may have already opened the browser — offer to open again
+    if use_auto and callback_url is None:
+        if not headless and _has_display():
+            # Browser was already opened; just prompt for paste
+            pass
+        else:
+            webbrowser.open(auth_url)
+
+    callback_url = input("Paste the redirect URL (or press Enter to retry): ").strip()
 
     if not callback_url:
         raise RuntimeError("No callback URL provided.")
@@ -329,7 +680,7 @@ def login(
     if callback["state"] != state:
         raise RuntimeError("CSRF state mismatch — possible tampering.")
 
-    # Exchange code for tokens (use issuer-detected token_url)
+    # Exchange code for tokens
     print("  Exchanging authorization code for tokens...")
     tokens = exchange_code(callback["code"], code_verifier, callback["token_url"])
 
@@ -339,35 +690,17 @@ def login(
 
 
 # ---------------------------------------------------------------------------
-# Token storage — compatible with pypowerwall's existing auth format
+# Token storage
 # ---------------------------------------------------------------------------
 
 def save_token(refresh_token: str, path: str = None, email: str = None):
-    """
-    Save a refresh token to pypowerwall's auth file.
-
-    The file format is a JSON dict keyed by email, compatible with teslapy's
-    cache format:
-        {
-            "user@example.com": {
-                "refresh_token": "...",
-                "access_token": "",
-                "expires_at": 0
-            }
-        }
-
-    Args:
-        refresh_token: The Tesla refresh token string.
-        path: Path to the auth file. Defaults to .pypowerwall.auth in current dir.
-        email: Email to key the token under. If None, prompts for input.
-    """
+    """Save a refresh token to pypowerwall's auth file."""
     if not path:
         path = os.path.join(os.getcwd(), ".pypowerwall.auth")
 
     if not email:
         email = input("Tesla account email: ").strip()
 
-    # Load existing data or start fresh
     data = {}
     if os.path.isfile(path):
         try:
@@ -376,14 +709,12 @@ def save_token(refresh_token: str, path: str = None, email: str = None):
         except (json.JSONDecodeError, IOError):
             data = {}
 
-    # Update with new token
     data[email] = {
         "refresh_token": refresh_token,
         "access_token": "",
         "expires_at": 0,
     }
 
-    # Ensure directory exists
     dir_name = os.path.dirname(path)
     if dir_name:
         os.makedirs(dir_name, exist_ok=True)
@@ -417,6 +748,10 @@ def main():
         help="Tesla region: 'us' (default) or 'cn' (China)",
     )
     parser.add_argument(
+        "--timeout", "-t", type=int, default=120,
+        help="Seconds to wait for automatic redirect (default: 120)",
+    )
+    parser.add_argument(
         "--output", "-o", type=str, default=None,
         help="Path to save the auth file (default: .pypowerwall.auth in current dir)",
     )
@@ -431,6 +766,7 @@ def main():
             email=args.email,
             headless=args.headless,
             region=args.region,
+            timeout=args.timeout,
         )
     except (KeyboardInterrupt, EOFError):
         print("\n\nLogin cancelled.")
@@ -439,7 +775,6 @@ def main():
         print(f"\n❌ Login failed: {e}")
         sys.exit(1)
 
-    # Save the token
     email = args.email or ""
     save_token(refresh_token, path=args.output, email=email)
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -266,13 +266,24 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                             token = data["refresh_token"] if isinstance(data, dict) else data
                             dbg(f"Token exchange succeeded, token length: {len(token)}")
                             result["token"] = token
+                            # Copy to macOS clipboard via NSPasteboard
+                            try:
+                                pb = AppKit.NSPasteboard.generalPasteboard()
+                                pb.clearContents()
+                                pb.setString_forType_(token, AppKit.NSPasteboardTypeString)
+                                clipboard_ok = True
+                            except Exception:
+                                clipboard_ok = False
                             # Print immediately to terminal
                             print("\n" + "=" * 60)
                             print("\u2705 Tesla Refresh Token:")
                             print("-" * 60)
                             print(token)
                             print("-" * 60)
-                            print("Copy the token above. You can now close the window.")
+                            if clipboard_ok:
+                                print("Token copied to clipboard! You can now close the window.")
+                            else:
+                                print("Copy the token above. You can now close the window.")
                             # Load success page in the WebView
                             success_html = f"""<!DOCTYPE html><html><head>
 <meta charset='utf-8'>
@@ -288,35 +299,10 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
   p {{ color: #6e6e73; font-size: 13px; }}
 </style></head><body>
 <h2>\u2705 Authentication Successful</h2>
-<p>Your Tesla refresh token is ready. Copy it and paste it into your remote pypowerwall session.</p>
+<p>Your Tesla refresh token is ready. It has been <strong>copied to your clipboard</strong> automatically.</p>
 <div class='token-box' id='tokenText'>{token}</div>
-<button class='copy-btn' id='copyBtn' onclick="
-  var btn = document.getElementById('copyBtn');
-  var txt = document.getElementById('tokenText').innerText;
-  try {{
-    navigator.clipboard.writeText(txt).then(function() {{
-      btn.textContent = '\u2705 Copied!';
-      btn.style.background = '#34c759';
-      setTimeout(function() {{ btn.textContent = 'Copy Token'; btn.style.background = '#0071e3'; }}, 3000);
-    }}).catch(function() {{
-      // Fallback: select text
-      var r = document.createRange(); r.selectNode(document.getElementById('tokenText'));
-      window.getSelection().removeAllRanges(); window.getSelection().addRange(r);
-      btn.textContent = '\u2705 Text Selected — Cmd+C to copy';
-      btn.style.background = '#34c759';
-      setTimeout(function() {{ btn.textContent = 'Copy Token'; btn.style.background = '#0071e3'; }}, 4000);
-    }});
-  }} catch(e) {{
-    var r = document.createRange(); r.selectNode(document.getElementById('tokenText'));
-    window.getSelection().removeAllRanges(); window.getSelection().addRange(r);
-    btn.textContent = '\u2705 Text Selected — Cmd+C to copy';
-    btn.style.background = '#34c759';
-    setTimeout(function() {{ btn.textContent = 'Copy Token'; btn.style.background = '#0071e3'; }}, 4000);
-  }}
-">
-  Copy Token
-</button>
-<p style='margin-top:20px'>You can close this window when done.</p>
+<p style='color:#34c759; font-weight:bold; font-size:15px'>\u2705 Token copied to clipboard!</p>
+<p style='margin-top:10px'>You can close this window when done.</p>
 </body></html>"""
                             def load_success():
                                 webview_ref[0].loadHTMLString_baseURL_(success_html, None)

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -204,9 +204,10 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
     if email:
         auth_url += f"&login_hint={urllib.parse.quote(email)}"
 
-    result = {"token": None, "error": None}
+    result = {"token": None, "error": None, "email": "", "token_data": {}}
     exchange_done = threading.Event()
     webview_ref = [None]  # mutable container so closure can access it
+    window_ref = [None]   # mutable container for the NSWindow
 
 
     def dbg(msg):
@@ -243,7 +244,11 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                     except Exception as e:
                         dbg(f"Clipboard error: {e}")
                 elif action == "close":
-                    AppKit.NSApplication.sharedApplication().stop_(None)
+                    # Close window explicitly — triggers windowWillClose_ → stop_()
+                    if window_ref[0]:
+                        window_ref[0].close()
+                    else:
+                        AppKit.NSApplication.sharedApplication().stop_(None)
                 handler(0)
                 return
 
@@ -396,6 +401,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
         ns_window.setDelegate_(win_delegate)
         ns_window.makeKeyAndOrderFront_(None)
         ns_window.retain()
+        window_ref[0] = ns_window
         req = Foundation.NSURLRequest.requestWithURL_(
             Foundation.NSURL.URLWithString_(auth_url)
         )
@@ -483,7 +489,7 @@ def _local_login_pywebview(email: str = None, region: str = "us") -> str:
         raise RuntimeError("Login cancelled or timed out — no token received.")
 
     print("  ✅ Refresh token captured!")
-    return result["token"]
+    return result["token"], "", {}
 
 
 def _patch_pywebview_navigation(result, expected_state):

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -5,16 +5,21 @@ pypowerwall.tesla_auth - Pure Python Tesla OAuth 2.0 PKCE authentication
 Replaces the external tesla_auth binary. Users can authenticate with Tesla
 and obtain refresh tokens using only Python — no Rust binary needed.
 
+Tesla requires redirect_uri=tesla://auth/callback for the ownerapi client_id.
+Since this is a custom URI scheme, we cannot use a localhost HTTP server to
+catch the callback automatically. Instead, both interactive and headless modes
+require the user to paste the redirect URL back into the terminal after login.
+
 Supports:
-  - Interactive browser login (opens browser, catches redirect via localhost)
-  - Headless/manual mode (prints URL, user pastes redirect URL back)
+  - Interactive browser login (opens browser, user pastes redirect URL)
+  - Headless/manual mode (prints URL, user opens on another device, pastes URL)
   - Cross-platform: Linux, macOS, Windows, headless servers
+  - Region auto-detection from callback issuer parameter
 
 Usage:
     python -m pypowerwall login
     python -m pypowerwall login --headless
     python -m pypowerwall login --email user@example.com
-    python -m pypowerwall login --region cn
 
 Or programmatically:
     from pypowerwall.tesla_auth import login, save_token
@@ -26,13 +31,10 @@ Based on the OAuth 2.0 PKCE flow from tesla_auth (Rust) by Adrian Kumpf.
 
 import base64
 import hashlib
-import http.server
 import json
 import os
 import secrets
-import socket
 import sys
-import threading
 import urllib.parse
 import webbrowser
 
@@ -54,13 +56,11 @@ TOKEN_URL_US = "https://auth.tesla.com/oauth2/v3/token"
 AUTH_URL_CN = "https://auth.tesla.cn/oauth2/v3/authorize"
 TOKEN_URL_CN = "https://auth.tesla.cn/oauth2/v3/token"
 
-# Tesla's custom URI scheme — used by the native tesla_auth app via WebView interception.
-# We do NOT use this directly; instead we try localhost or fall back to void/callback.
-REDIRECT_URL_CUSTOM = "tesla://auth/callback"
-
-# Tesla's void callback — shows "Page Not Found" but the URL contains the auth code.
-# This is what teslapy uses for the manual paste flow.
-REDIRECT_URL_VOID = "https://auth.tesla.com/void/callback"
+# Tesla only accepts this custom URI scheme for the ownerapi client_id.
+# The native tesla_auth app intercepts this via a WebView navigation handler.
+# We use it in the auth URL; after login, Tesla redirects to this URI with
+# code/state/issuer query params. The user copies the full URL from the browser.
+REDIRECT_URI = "tesla://auth/callback"
 
 SCOPES = ["openid", "email", "offline_access"]
 
@@ -68,27 +68,29 @@ REGION_CONFIG = {
     "us": {
         "auth_url": AUTH_URL_US,
         "token_url": TOKEN_URL_US,
-        "void_redirect": "https://auth.tesla.com/void/callback",
     },
     "cn": {
         "auth_url": AUTH_URL_CN,
         "token_url": TOKEN_URL_CN,
-        "void_redirect": "https://auth.tesla.cn/void/callback",
     },
 }
 
 
 # ---------------------------------------------------------------------------
-# PKCE helpers
+# PKCE helpers — match tesla_auth's oauth2 crate behavior
 # ---------------------------------------------------------------------------
 
 def generate_code_verifier() -> str:
-    """Generate a PKCE code_verifier (43-128 chars, base64url-encoded random bytes)."""
-    return secrets.token_urlsafe(86)  # 86 bytes → ~115 base64url chars
+    """Generate a PKCE code_verifier (base64url-encoded random bytes).
+
+    tesla_auth uses oauth2 crate's PkceCodeChallenge::new_random_sha256()
+    which generates 32 random bytes → base64url (43 chars). We match that.
+    """
+    return secrets.token_urlsafe(32)  # 32 bytes → 43 base64url chars
 
 
 def generate_code_challenge(code_verifier: str) -> str:
-    """Generate S256 code_challenge from code_verifier."""
+    """Generate S256 code_challenge from code_verifier (RFC 7636 §4.2)."""
     digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
@@ -106,15 +108,14 @@ def build_auth_url(
     code_challenge: str,
     state: str,
     region: str = "us",
-    redirect_uri: str = REDIRECT_URL_VOID,
 ) -> str:
-    """Build the Tesla OAuth authorization URL."""
+    """Build the Tesla OAuth authorization URL with tesla:// redirect."""
     cfg = REGION_CONFIG.get(region, REGION_CONFIG["us"])
     params = {
         "client_id": CLIENT_ID,
         "code_challenge": code_challenge,
         "code_challenge_method": "S256",
-        "redirect_uri": redirect_uri,
+        "redirect_uri": REDIRECT_URI,
         "response_type": "code",
         "scope": " ".join(SCOPES),
         "state": state,
@@ -129,28 +130,35 @@ def build_auth_url(
 def exchange_code(
     code: str,
     code_verifier: str,
-    redirect_uri: str,
-    region: str = "us",
+    token_url: str,
 ) -> dict:
     """
     Exchange an authorization code for tokens.
 
-    Returns dict with: access_token, refresh_token, expires_in, token_type, etc.
-    Raises RuntimeError on failure.
+    Args:
+        code: The authorization code from the callback.
+        code_verifier: The PKCE code verifier.
+        token_url: The token endpoint URL (region-specific).
+
+    Returns:
+        dict with: access_token, refresh_token, expires_in, etc.
+
+    Raises:
+        RuntimeError on failure.
+        ImportError if requests is not installed.
     """
     if requests is None:
         raise ImportError("The 'requests' package is required. Install with: pip install requests")
 
-    cfg = REGION_CONFIG.get(region, REGION_CONFIG["us"])
     data = {
         "grant_type": "authorization_code",
         "client_id": CLIENT_ID,
         "code": code,
         "code_verifier": code_verifier,
-        "redirect_uri": redirect_uri,
+        "redirect_uri": REDIRECT_URI,
     }
 
-    resp = requests.post(cfg["token_url"], data=data, timeout=30)
+    resp = requests.post(token_url, data=data, timeout=30)
     if resp.status_code != 200:
         raise RuntimeError(
             f"Token exchange failed (HTTP {resp.status_code}): {resp.text}"
@@ -163,116 +171,115 @@ def exchange_code(
     return result
 
 
-# ---------------------------------------------------------------------------
-# Localhost redirect catcher
-# ---------------------------------------------------------------------------
+def refresh_access_token(
+    refresh_token: str,
+    token_url: str = TOKEN_URL_US,
+) -> dict:
+    """
+    Refresh an access token using a refresh token.
 
-def _find_free_port() -> int:
-    """Find a free TCP port on localhost."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+    Args:
+        refresh_token: The Tesla refresh token.
+        token_url: The token endpoint URL (region-specific).
 
+    Returns:
+        dict with: access_token, refresh_token, expires_in, etc.
+    """
+    if requests is None:
+        raise ImportError("The 'requests' package is required. Install with: pip install requests")
 
-class _RedirectHandler(http.server.BaseHTTPRequestHandler):
-    """HTTP handler that captures the OAuth redirect."""
+    data = {
+        "grant_type": "refresh_token",
+        "client_id": CLIENT_ID,
+        "refresh_token": refresh_token,
+    }
 
-    auth_result = None  # type: ignore  # set by the handler
-    auth_event = None  # type: ignore  # threading.Event
-
-    def do_GET(self):
-        parsed = urllib.parse.urlparse(self.path)
-        params = urllib.parse.parse_qs(parsed.query)
-
-        code = params.get("code", [None])[0]
-        state = params.get("state", [None])[0]
-        error = params.get("error", [None])[0]
-
-        if error:
-            self._respond(
-                400,
-                "<h1>Authentication Failed</h1>"
-                f"<p>Error: {error}</p>"
-                f"<p>You can close this window.</p>",
-            )
-            _RedirectHandler.auth_result = {"error": error}
-        elif code:
-            self._respond(
-                200,
-                "<h1>&#x2705; Authentication Successful!</h1>"
-                "<p>You can close this window and return to the terminal.</p>",
-            )
-            _RedirectHandler.auth_result = {"code": code, "state": state}
-        else:
-            self._respond(
-                400,
-                "<h1>Invalid Response</h1><p>No authorization code received.</p>",
-            )
-            _RedirectHandler.auth_result = {"error": "no_code"}
-
-        if _RedirectHandler.auth_event:
-            _RedirectHandler.auth_event.set()
-
-    def _respond(self, status: int, html: str):
-        self.send_response(status)
-        self.send_header("Content-Type", "text/html")
-        self.end_headers()
-        self.wfile.write(html.encode())
-
-    def log_message(self, format, *args):
-        """Suppress default stderr logging."""
-        pass
-
-
-def _catch_redirect_on_localhost(port: int, timeout: int = 300) -> dict[str, str]:
-    """Start a localhost HTTP server and wait for the OAuth redirect."""
-    _RedirectHandler.auth_result = None
-    _RedirectHandler.auth_event = threading.Event()
-
-    server = http.server.HTTPServer(("127.0.0.1", port), _RedirectHandler)
-    server.timeout = timeout
-
-    # Run server in a thread
-    server_thread = threading.Thread(target=server.handle_request, daemon=True)
-    server_thread.start()
-
-    # Wait for the redirect or timeout
-    if not _RedirectHandler.auth_event.wait(timeout=timeout):
-        server.server_close()
-        raise TimeoutError(
-            f"Timed out waiting for redirect after {timeout} seconds. "
-            "Try running with --headless instead."
+    resp = requests.post(token_url, data=data, timeout=30)
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Token refresh failed (HTTP {resp.status_code}): {resp.text}"
         )
 
-    server.server_close()
-    return _RedirectHandler.auth_result
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Callback URL parsing
+# ---------------------------------------------------------------------------
+
+def parse_callback_url(callback_url: str) -> dict:
+    """
+    Parse the redirect callback URL to extract code, state, and issuer.
+
+    The callback URL looks like:
+        tesla://auth/callback?code=...&state=...&issuer=https://auth.tesla.com/...
+
+    Returns dict with: code, state, issuer, token_url
+    """
+    parsed = urllib.parse.urlparse(callback_url)
+    params = urllib.parse.parse_qs(parsed.query)
+
+    error = params.get("error", [None])[0]
+    if error:
+        raise RuntimeError(f"Tesla authentication error: {error}")
+
+    code = params.get("code", [None])[0]
+    state = params.get("state", [None])[0]
+    issuer = params.get("issuer", [None])[0]
+
+    if not code:
+        raise RuntimeError("No authorization code found in the redirect URL.")
+    if not state:
+        raise RuntimeError("No state parameter found in the redirect URL.")
+
+    # Determine token_url from issuer (matching tesla_auth's retrieve_tokens)
+    token_url = TOKEN_URL_US  # default
+    if issuer and "auth.tesla.cn" in issuer:
+        token_url = TOKEN_URL_CN
+
+    return {
+        "code": code,
+        "state": state,
+        "issuer": issuer,
+        "token_url": token_url,
+    }
 
 
 # ---------------------------------------------------------------------------
 # Main login function
 # ---------------------------------------------------------------------------
 
+def _has_display() -> bool:
+    """Check if a display is available for opening a browser."""
+    if sys.platform == "win32":
+        return True
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
 def login(
     email: str = None,
     headless: bool = False,
     region: str = "us",
-    timeout: int = 300,
 ) -> str:
     """
     Authenticate with Tesla and return a refresh token.
 
+    Uses the OAuth 2.0 PKCE flow matching tesla_auth. The redirect URI is
+    tesla://auth/callback — Tesla's only accepted redirect for ownerapi.
+    After login, the browser redirects to this custom URI. The user must
+    copy the full URL from the browser's address bar and paste it back.
+
     Args:
         email: Tesla account email (optional, will prompt if needed).
-        headless: If True, skip browser and use manual URL paste mode.
-        region: 'us' (default) or 'cn' for China.
-        timeout: Seconds to wait for browser redirect (default 300).
+        headless: If True, don't open browser (just print URL).
+        region: 'us' (default) or 'cn' for China. Overridden by issuer in callback.
+        timeout: Removed — no server to timeout.
 
     Returns:
         refresh_token string.
 
     Raises:
         RuntimeError: On authentication failure.
-        TimeoutError: If redirect not received within timeout.
     """
     # Generate PKCE parameters
     code_verifier = generate_code_verifier()
@@ -288,118 +295,43 @@ def login(
     print(f"\nTesla login for: {email}")
     print("-" * 60)
 
-    # Try localhost redirect first (unless headless)
+    # Build auth URL
+    auth_url = build_auth_url(code_challenge, state, region)
+
+    # Open browser if not headless and display available
     if not headless and _has_display():
-        refresh_token = _login_interactive(
-            code_verifier, code_challenge, state, region, email, timeout
+        print("Opening browser for Tesla login...")
+        webbrowser.open(auth_url)
+        print(
+            "\nAfter logging in, your browser will show an error or blank page.\n"
+            "This is expected — the URL in the address bar contains your auth code.\n"
+            "Copy the FULL URL from the address bar and paste it below.\n"
         )
-        if refresh_token:
-            return refresh_token
-        # Interactive failed — fall through to manual mode
-        print("\nFalling back to manual mode...")
+    else:
+        print(
+            "\nOpen the following URL in your browser to log into your Tesla account:\n"
+        )
+        print(f"  {auth_url}\n")
+        print(
+            "After logging in, you will be redirected to a tesla:// URL.\n"
+            "Copy the FULL URL from your browser's address bar and paste it below.\n"
+        )
 
-    # Headless / manual mode — use void/callback redirect
-    return _login_manual(code_verifier, code_challenge, state, region, email)
+    callback_url = input("Paste the redirect URL: ").strip()
 
+    if not callback_url:
+        raise RuntimeError("No callback URL provided.")
 
-def _has_display() -> bool:
-    """Check if a display is available for opening a browser."""
-    if sys.platform == "win32":
-        return True
-    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+    # Parse callback
+    callback = parse_callback_url(callback_url)
 
-
-def _login_interactive(
-    code_verifier: str,
-    code_challenge: str,
-    state: str,
-    region: str,
-    email: str,
-    timeout: int,
-) -> str | None:
-    """Try interactive browser login with localhost redirect."""
-    port = _find_free_port()
-    redirect_uri = f"http://localhost:{port}/callback"
-
-    auth_url = build_auth_url(code_challenge, state, region, redirect_uri=redirect_uri)
-
-    print(f"Opening browser for Tesla login...")
-    print(f"If the browser doesn't open, visit:\n\n  {auth_url}\n")
-
-    # Open browser
-    webbrowser.open(auth_url)
-
-    # Wait for redirect
-    try:
-        result = _catch_redirect_on_localhost(port, timeout=timeout)
-    except TimeoutError:
-        return None
-
-    if result is None:
-        return None
-
-    # pylint: disable=unsupported-membership-test,unsubscriptable-object
-    if "error" in result:
-        print(f"  Error from Tesla: {result['error']}")
-        return None
-
-    # Validate state
-    if result.get("state") != state:
-        print("  Error: CSRF state mismatch — possible tampering.")
-        return None
-
-    # Exchange code for tokens
-    print("  Exchanging authorization code for tokens...")
-    try:
-        tokens = exchange_code(result["code"], code_verifier, redirect_uri, region)
-    except Exception as e:
-        print(f"  Token exchange failed: {e}")
-        return None
-
-    refresh_token = tokens["refresh_token"]
-    print(f"  ✅ Refresh token obtained (expires in {tokens.get('expires_in', '?')}s)")
-    return refresh_token
-
-
-def _login_manual(
-    code_verifier: str,
-    code_challenge: str,
-    state: str,
-    region: str,
-    email: str,
-) -> str:
-    """Manual mode — user pastes the redirect URL from the browser."""
-    redirect_uri = REDIRECT_URL_VOID
-    auth_url = build_auth_url(code_challenge, state, region, redirect_uri=redirect_uri)
-
-    print("\nOpen the following URL in your browser to log into your Tesla account:\n")
-    print(f"  {auth_url}\n")
-    print(
-        "After logging in, you will be redirected to a 'Page Not Found' page.\n"
-        "Copy the FULL URL from your browser's address bar and paste it below.\n"
-    )
-
-    redirect_response = input("Enter the URL after login: ").strip()
-
-    # Parse the code and state from the redirect URL
-    parsed = urllib.parse.urlparse(redirect_response)
-    params = urllib.parse.parse_qs(parsed.query)
-
-    error = params.get("error", [None])[0]
-    if error:
-        raise RuntimeError(f"Tesla authentication error: {error}")
-
-    code = params.get("code", [None])[0]
-    returned_state = params.get("state", [None])[0]
-
-    if not code:
-        raise RuntimeError("No authorization code found in the redirect URL.")
-
-    if returned_state != state:
+    # Validate state (CSRF protection)
+    if callback["state"] != state:
         raise RuntimeError("CSRF state mismatch — possible tampering.")
 
+    # Exchange code for tokens (use issuer-detected token_url)
     print("  Exchanging authorization code for tokens...")
-    tokens = exchange_code(code, code_verifier, redirect_uri, region)
+    tokens = exchange_code(callback["code"], code_verifier, callback["token_url"])
 
     refresh_token = tokens["refresh_token"]
     print(f"  ✅ Refresh token obtained (expires in {tokens.get('expires_in', '?')}s)")
@@ -452,7 +384,9 @@ def save_token(refresh_token: str, path: str = None, email: str = None):
     }
 
     # Ensure directory exists
-    os.makedirs(os.path.dirname(path) if os.path.dirname(path) else ".", exist_ok=True)
+    dir_name = os.path.dirname(path)
+    if dir_name:
+        os.makedirs(dir_name, exist_ok=True)
 
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
@@ -486,10 +420,6 @@ def main():
         "--output", "-o", type=str, default=None,
         help="Path to save the auth file (default: .pypowerwall.auth in current dir)",
     )
-    parser.add_argument(
-        "--timeout", "-t", type=int, default=300,
-        help="Seconds to wait for browser redirect (default: 300)",
-    )
 
     args = parser.parse_args()
 
@@ -501,7 +431,6 @@ def main():
             email=args.email,
             headless=args.headless,
             region=args.region,
-            timeout=args.timeout,
         )
     except (KeyboardInterrupt, EOFError):
         print("\n\nLogin cancelled.")
@@ -515,7 +444,7 @@ def main():
     save_token(refresh_token, path=args.output, email=email)
 
     print("\n✅ Done! You can now use pypowerwall with cloud mode.")
-    print(f"   Run: python -m pypowerwall setup")
+    print("   Run: python -m pypowerwall setup")
 
 
 if __name__ == "__main__":

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -151,12 +151,13 @@ def _remote_login() -> str:
 # ---------------------------------------------------------------------------
 
 def _local_login(email: str = None, region: str = "us") -> str:
-    """Local login via pywebview using before_load event to intercept tesla:// redirect.
+    """Local login via pywebview, intercepting Tesla's fetch() token exchange.
 
-    window.events.before_load fires inside WKNavigationDelegate before WKWebView
-    processes any navigation, including custom URI schemes. This is the correct
-    native interception point — equivalent to what the Rust tesla_auth tool uses.
+    Instead of fighting the tesla:// custom URI scheme (which WKWebView blocks),
+    we intercept the fetch()/XHR call Tesla's JS makes to /oauth2/v3/token after
+    login. The response contains the refresh_token directly — no redirect needed.
     """
+    import threading, time
     try:
         import webview
     except ImportError:
@@ -171,70 +172,87 @@ def _local_login(email: str = None, region: str = "us") -> str:
 
     result = {}
 
+    # Inject JS that wraps fetch() and XHR to intercept the token exchange response.
+    # Tesla's completion page calls POST /oauth2/v3/token after the user logs in.
+    # We clone the response body and store refresh_token in window.__teslaRefreshToken.
+    # We poll this global from Python every 500ms.
+    INTERCEPT_JS = """
+(function() {
+    if (window.__teslaFetchPatched) return window.__teslaRefreshToken || '';
+    window.__teslaFetchPatched = true;
+    window.__teslaRefreshToken = null;
+    var _fetch = window.fetch;
+    window.fetch = function(url, opts) {
+        var p = _fetch.apply(this, arguments);
+        var urlStr = (typeof url === 'string') ? url : ((url && url.url) || '');
+        if (urlStr.indexOf('/oauth2/v3/token') !== -1 || urlStr.indexOf('auth.tesla') !== -1) {
+            p.then(function(resp) {
+                resp.clone().text().then(function(txt) {
+                    try {
+                        var d = JSON.parse(txt);
+                        if (d && d.refresh_token) window.__teslaRefreshToken = d.refresh_token;
+                    } catch(e) {}
+                });
+            }).catch(function() {});
+        }
+        return p;
+    };
+    var _xOpen = XMLHttpRequest.prototype.open;
+    var _xSend = XMLHttpRequest.prototype.send;
+    XMLHttpRequest.prototype.open = function(m, u) { this.__u = u; return _xOpen.apply(this, arguments); };
+    XMLHttpRequest.prototype.send = function() {
+        if (this.__u && (this.__u.indexOf('/oauth2/v3/token') !== -1 || this.__u.indexOf('auth.tesla') !== -1)) {
+            this.addEventListener('load', function() {
+                try {
+                    var d = JSON.parse(this.responseText);
+                    if (d && d.refresh_token) window.__teslaRefreshToken = d.refresh_token;
+                } catch(e) {}
+            });
+        }
+        return _xSend.apply(this, arguments);
+    };
+    return window.__teslaRefreshToken || '';
+})();
+"""
+
+    POLL_JS = "window.__teslaRefreshToken || '';"
+
+    def on_loaded():
+        def poll():
+            for _ in range(240):  # 2 min
+                try:
+                    # First inject the patch, then poll
+                    window.evaluate_js(INTERCEPT_JS)
+                    token = window.evaluate_js(POLL_JS)
+                    if token and isinstance(token, str) and len(token) > 20:
+                        result['refresh_token'] = token
+                        try:
+                            window.destroy()
+                        except Exception:
+                            pass
+                        return
+                except Exception:
+                    pass
+                time.sleep(0.5)
+        t = threading.Thread(target=poll, daemon=True)
+        t.start()
+
     print("Opening Tesla login window...")
     window = webview.create_window(
-        "Tesla Login — pypowerwall",
+        "Tesla Login \u2014 pypowerwall",
         auth_url,
         width=500,
         height=750,
     )
-
-    # Use a JS polling approach: inject a MutationObserver that watches for
-    # Tesla's redirect attempt by overriding XMLHttpRequest and fetch,
-    # then poll evaluate_js every 300ms to read window.__teslaCode
-    js_inject = """
-    if (!window.__teslaPatch) {
-        window.__teslaPatch = true;
-        window.__teslaCode = null;
-        var _origOpen = XMLHttpRequest.prototype.open;
-        // Patch fetch to intercept token responses
-        var _origFetch = window.fetch;
-        window.fetch = function(url, opts) {
-            var p = _origFetch.apply(this, arguments);
-            if (url && url.indexOf('/oauth2/v3/token') > -1) {
-                p.then(function(r) {
-                    r.clone().json().then(function(d) {
-                        if (d && d.refresh_token) window.__teslaRefresh = d.refresh_token;
-                    });
-                });
-            }
-            return p;
-        };
-    }
-    window.__teslaCode || window.__teslaRefresh || '';
-    """
-
-    import threading, time
-
-    def poll():
-        for _ in range(600):
-            try:
-                val = window.evaluate_js(js_inject)
-                if val and val not in ('', 'null', None):
-                    result['value'] = val
-                    try:
-                        window.destroy()
-                    except Exception:
-                        pass
-                    return
-            except Exception:
-                pass
-            time.sleep(0.3)
-
-    def on_loaded():
-        t = threading.Thread(target=poll, daemon=True)
-        t.start()
-
     window.events.loaded += on_loaded
     webview.start()
 
-    auth_code = result.get("code")
-    if not auth_code:
-        raise RuntimeError("Login cancelled or timed out.")
+    refresh_token = result.get('refresh_token')
+    if not refresh_token:
+        raise RuntimeError("Login cancelled or timed out — no token received.")
 
-    print("  ✅ Authorization code captured!")
-    print("  Exchanging for refresh token...")
-    return _exchange_code(auth_code, code_verifier, region)
+    print("  \u2705 Refresh token captured!")
+    return refresh_token
 
 
 # ---------------------------------------------------------------------------

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -350,46 +350,42 @@ def _register_linux() -> bool:
 
 
 def _register_macos() -> bool:
-    """Register tesla:// URI scheme on macOS via a small .app bundle."""
-    # Create a minimal .app bundle
+    """Register tesla:// URI scheme on macOS via a small .app bundle + lsregister."""
+    import plistlib
+
     app_dir = os.path.expanduser("~/Library/TeslaAuthHelper.app")
-    contents_dir = os.path.join(app_dir, "Contents")
-    macos_dir = os.path.join(contents_dir, "MacOS")
+    contents = os.path.join(app_dir, "Contents")
+    macos_dir = os.path.join(contents, "MacOS")
     os.makedirs(macos_dir, exist_ok=True)
 
-    # Write Info.plist with URI scheme registration
-    plist = (
-        '<?xml version="1.0" encoding="UTF-8"?>\n'
-        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"'
-        ' "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
-        '<plist version="1.0"><dict>\n'
-        '  <key>CFBundleIdentifier</key>'
-        '<string>com.pypowerwall.teslaauth</string>\n'
-        '  <key>CFBundleName</key>'
-        '<string>TeslaAuthHelper</string>\n'
-        '  <key>CFBundleURLTypes</key><array><dict>\n'
-        '    <key>CFBundleURLSchemes</key><array>'
-        '<string>tesla</string></array>\n'
-        '    <key>CFBundleURLName</key>'
-        '<string>Tesla Auth</string>\n'
-        '  </dict></array>\n'
-        '</dict></plist>\n'
-    )
-    with open(os.path.join(contents_dir, "Info.plist"), "w") as f:
-        f.write(plist)
-
-    # Write the launcher script
-    launcher = os.path.join(macos_dir, "TeslaAuthHelper")
+    # Handler script
     python_path = _get_python_path()
-    with open(launcher, "w") as f:
+    handler_script = os.path.join(macos_dir, "TeslaAuthHelper")
+    with open(handler_script, "w") as f:
         f.write(f"#!/bin/bash\nexec {python_path} {HANDLER_SCRIPT_PATH} \"$1\"\n")
-    os.chmod(launcher, 0o755)
+    os.chmod(handler_script, 0o755)
+
+    # Info.plist using plistlib for correctness
+    plist_path = os.path.join(contents, "Info.plist")
+    plist_data = {
+        "CFBundleIdentifier": "com.pypowerwall.teslaauth",
+        "CFBundleName": "TeslaAuthHelper",
+        "CFBundleExecutable": "TeslaAuthHelper",
+        "CFBundleVersion": "1.0",
+        "LSUIElement": True,
+        "CFBundleURLTypes": [{
+            "CFBundleURLSchemes": ["tesla"],
+            "CFBundleURLName": "Tesla Auth Callback",
+        }],
+    }
+    with open(plist_path, "wb") as f:
+        plistlib.dump(plist_data, f)
 
     # Register with LaunchServices
     try:
         subprocess.run(
-            ["/System/Library/Frameworks/CoreServices.framework/Frameworks/"
-             "LaunchServices.framework/Support/lsregister",
+            ["/System/Library/Frameworks/CoreServices.framework/Versions/A/"
+             "Frameworks/LaunchServices.framework/Versions/A/Support/lsregister",
              "-f", app_dir],
             capture_output=True, timeout=15, check=False,
         )
@@ -460,8 +456,8 @@ def _unregister_protocol_handler():
             if os.path.exists(app_dir):
                 shutil.rmtree(app_dir, ignore_errors=True)
             subprocess.run(
-                ["/System/Library/Frameworks/CoreServices.framework/Frameworks/"
-                 "LaunchServices.framework/Support/lsregister",
+                ["/System/Library/Frameworks/CoreServices.framework/Versions/A/"
+                 "Frameworks/LaunchServices.framework/Versions/A/Support/lsregister",
                  "-u", app_dir],
                 capture_output=True, timeout=10, check=False,
             )
@@ -497,6 +493,46 @@ def _unregister_protocol_handler():
                 os.remove(f)
         except Exception:
             pass
+
+
+# ---------------------------------------------------------------------------
+# Headless login — pure manual paste, no OS handler or HTTP server needed
+# ---------------------------------------------------------------------------
+
+def _headless_login(auth_url: str) -> str:
+    """
+    Headless login flow: print URL, user logs in via browser,
+    copies tesla:// callback URL from Chrome DevTools, and pastes it.
+
+    Returns the parsed auth code.
+    """
+    print("\n" + "=" * 60)
+    print("Tesla Authentication — Headless Mode")
+    print("=" * 60)
+    print("\n1. Open this URL in your browser:\n")
+    print(f"   {auth_url}\n")
+    print("2. Complete the Tesla login (enter credentials + MFA if required).")
+    print("\n3. After login, the browser will show an error like:")
+    print('   "Failed to launch tesla://auth/callback?code=..."')
+    print("\n4. Open Chrome DevTools (F12 \u2192 Console tab) and find the")
+    print('   line starting with "Failed to launch tesla://..."')
+    print("\n5. Copy the FULL tesla:// URL from that line and paste it below.\n")
+
+    while True:
+        callback_url = input("Paste the tesla:// URL here: ").strip()
+        if callback_url.startswith("tesla://"):
+            break
+        print("   \u26a0\ufe0f  Must start with 'tesla://' — try again.")
+
+    # Parse code from the pasted URL
+    parsed = urllib.parse.urlparse(callback_url)
+    params = urllib.parse.parse_qs(parsed.query)
+    auth_code = params.get("code", [None])[0]
+
+    if not auth_code:
+        raise ValueError("No auth code found in pasted URL")
+
+    return auth_code
 
 
 # ---------------------------------------------------------------------------
@@ -538,8 +574,11 @@ def login(
       5. Exchanges code for tokens
       6. Cleans up URI registration
 
-    In headless mode or when handler registration fails, falls back to
-    manual paste mode (user copies URL from browser address bar).
+    In headless mode, uses manual paste: user copies the tesla:// URL from
+    Chrome DevTools console after login and pastes it into the terminal.
+
+    If OS handler registration fails on any platform, automatically falls
+    back to headless-style manual paste mode.
 
     Args:
         email: Tesla account email (optional, will prompt if needed).
@@ -567,8 +606,25 @@ def login(
     # Build auth URL
     auth_url = build_auth_url(code_challenge, state, region)
 
-    # Determine mode: try automatic capture if display available and not headless
-    use_auto = not headless and _has_display()
+    # --- Headless mode: pure manual paste, no browser/server needed ---
+    if headless:
+        auth_code = _headless_login(auth_url)
+
+        # Detect region from issuer if present in the pasted URL
+        parsed_url = urllib.parse.urlparse(input) if False else None
+        # Re-parse from the callback to get issuer for region detection
+        # _headless_login only returns the code, so we use US as default
+        # (the token exchange will fail if wrong region, and user can retry)
+        token_url = TOKEN_URL_US
+
+        print("  Exchanging authorization code for tokens...")
+        tokens = exchange_code(auth_code, code_verifier, token_url)
+        refresh_token = tokens["refresh_token"]
+        print(f"  \u2705 Refresh token obtained (expires in {tokens.get('expires_in', '?')}s)")
+        return refresh_token
+
+    # --- Interactive mode: try automatic callback, fall back to manual ---
+    use_auto = _has_display()
 
     callback_url = None
     server = None
@@ -586,6 +642,11 @@ def login(
 
             # Register protocol handler
             registered = _register_protocol_handler()
+
+            if not registered:
+                print(f"  \u26a0\ufe0f  Could not register tesla:// handler automatically "
+                      f"(platform: {sys.platform})")
+                print("     Falling back to manual paste mode...\n")
 
             if registered:
                 # Start local HTTP server
@@ -611,27 +672,27 @@ def login(
                     issuers = result.get("issuer", [None])
 
                     if codes and states and states[0] == state:
-                        # Build a fake callback URL to parse consistently
                         issuer = issuers[0] if issuers else None
                         token_url = TOKEN_URL_US
                         if issuer and "auth.tesla.cn" in issuer:
                             token_url = TOKEN_URL_CN
 
-                        print("  ✅ Auth code captured automatically!")
+                        print("  \u2705 Auth code captured automatically!")
                         tokens = exchange_code(codes[0], code_verifier, token_url)
                         refresh_token = tokens["refresh_token"]
-                        print(f"  ✅ Refresh token obtained (expires in {tokens.get('expires_in', '?')}s)")
+                        print(f"  \u2705 Refresh token obtained "
+                              f"(expires in {tokens.get('expires_in', '?')}s)")
                         return refresh_token
                     else:
-                        print("  ⚠️ State mismatch or empty code, falling back to manual mode.")
+                        print("  \u26a0\ufe0f State mismatch or empty code, "
+                              "falling back to manual mode.")
                 else:
-                    print("  ⚠️ Timed out waiting for automatic redirect.")
+                    print("  \u26a0\ufe0f Timed out waiting for automatic redirect.")
                     print("  Falling back to manual paste mode.\n")
-            else:
-                print("  ⚠️ Could not register URI handler, using manual paste mode.\n")
 
         except Exception as e:
-            print(f"  ⚠️ Auto-capture failed ({e}), falling back to manual paste mode.\n")
+            print(f"  \u26a0\ufe0f Auto-capture failed ({e}), "
+                  "falling back to manual paste mode.\n")
         finally:
             # Always clean up
             if server:
@@ -641,37 +702,27 @@ def login(
                     pass
             _unregister_protocol_handler()
 
-    # Manual paste mode (headless, fallback, or auto-capture failed)
-    if not headless and _has_display() and callback_url is None:
-        # Already opened browser above in auto attempt
-        print("Open the following URL if the browser didn't open:")
-        print(f"  {auth_url}\n")
-        print(
-            "After logging in, copy the FULL URL from the address bar\n"
-            "(it will start with tesla://) and paste it below.\n"
-        )
-    elif callback_url is None:
-        print(
-            "\nOpen the following URL in your browser to log into your Tesla account:\n"
-        )
-        print(f"  {auth_url}\n")
-        print(
-            "After logging in, copy the FULL redirect URL from your browser\n"
-            "(it will start with tesla://) and paste it below.\n"
-        )
+    # --- Manual paste mode (headless-style fallback) ---
+    # This is reached when:
+    #   - headless=False but auto capture failed or wasn't available
+    #   - No display detected
+    print("\n" + "-" * 60)
+    print("Manual Authentication Required")
+    print("-" * 60)
+    print("\n1. Open this URL in your browser:\n")
+    print(f"   {auth_url}\n")
+    print("2. Complete the Tesla login (enter credentials + MFA if required).")
+    print("\n3. After login, the browser will show an error like:")
+    print('   "Failed to launch tesla://auth/callback?code=..."')
+    print("\n4. Open Chrome DevTools (F12 \u2192 Console tab) and find the")
+    print('   line starting with "Failed to launch tesla://..."')
+    print("\n5. Copy the FULL tesla:// URL from that line and paste it below.\n")
 
-    # In auto mode, we may have already opened the browser — offer to open again
-    if use_auto and callback_url is None:
-        if not headless and _has_display():
-            # Browser was already opened; just prompt for paste
-            pass
-        else:
-            webbrowser.open(auth_url)
-
-    callback_url = input("Paste the redirect URL (or press Enter to retry): ").strip()
-
-    if not callback_url:
-        raise RuntimeError("No callback URL provided.")
+    while True:
+        callback_url = input("Paste the tesla:// URL here: ").strip()
+        if callback_url.startswith("tesla://"):
+            break
+        print("   \u26a0\ufe0f  Must start with 'tesla://' — try again.")
 
     # Parse callback
     callback = parse_callback_url(callback_url)
@@ -685,7 +736,7 @@ def login(
     tokens = exchange_code(callback["code"], code_verifier, callback["token_url"])
 
     refresh_token = tokens["refresh_token"]
-    print(f"  ✅ Refresh token obtained (expires in {tokens.get('expires_in', '?')}s)")
+    print(f"  \u2705 Refresh token obtained (expires in {tokens.get('expires_in', '?')}s)")
     return refresh_token
 
 
@@ -758,7 +809,7 @@ def main():
 
     args = parser.parse_args()
 
-    print("⚡ Tesla Authentication — pypowerwall")
+    print("\u26a1 Tesla Authentication — pypowerwall")
     print("=" * 60)
 
     try:
@@ -772,13 +823,13 @@ def main():
         print("\n\nLogin cancelled.")
         sys.exit(1)
     except Exception as e:
-        print(f"\n❌ Login failed: {e}")
+        print(f"\n\u274c Login failed: {e}")
         sys.exit(1)
 
     email = args.email or ""
     save_token(refresh_token, path=args.output, email=email)
 
-    print("\n✅ Done! You can now use pypowerwall with cloud mode.")
+    print("\n\u2705 Done! You can now use pypowerwall with cloud mode.")
     print("   Run: python -m pypowerwall setup")
 
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -1,55 +1,31 @@
-from __future__ import annotations
 """
 pypowerwall.tesla_auth - Pure Python Tesla OAuth 2.0 PKCE authentication
 
-Replaces the external tesla_auth binary. Users can authenticate with Tesla
-and obtain refresh tokens using only Python — no Rust binary or WebView needed.
+Two login paths, auto-detected:
 
-How it works:
-  1. Registers tesla:// as a custom URI scheme handler on the OS
-  2. Starts a local HTTP server to catch the forwarded callback
-  3. Opens the browser to Tesla's OAuth login page
-  4. After login, Tesla redirects to tesla://auth/callback?code=...
-  5. The OS calls our handler, which forwards the URL to the local server
-  6. We capture the auth code and exchange it for tokens
-  7. Cleanup: unregister the handler
+  Path 1 — Remote/Headless (no display):
+    Detects SSH session or missing DISPLAY. Prompts user to run
+    ``python -m pypowerwall authtoken`` on their local machine, then
+    paste the resulting refresh token.
 
-Supports:
-  - Interactive browser login (auto-captures callback via URI handler)
-  - Headless/manual mode (prints URL, user pastes redirect URL)
-  - Cross-platform: Linux (xdg), macOS (lsregister), Windows (registry)
-  - Region auto-detection from callback issuer parameter
+  Path 2 — Local machine (display available):
+    Opens a native pywebview window for Tesla login. Captures the
+    tesla:// callback, exchanges the auth code for a refresh token.
 
-Usage:
-    python -m pypowerwall login
-    python -m pypowerwall login --headless
-    python -m pypowerwall login --email user@example.com
-
-Or programmatically:
-    from pypowerwall.tesla_auth import login, save_token
-    refresh_token = login(email="user@example.com")
-    save_token(refresh_token)
+CLI commands:
+    python -m pypowerwall login       # auto-detect, save token to file
+    python -m pypowerwall authtoken   # local-only, print token to stdout
 
 Based on the OAuth 2.0 PKCE flow from tesla_auth (Rust) by Adrian Kumpf.
 """
 
 import base64
 import hashlib
-import http.server
 import json
 import os
-import platform
 import secrets
-import shutil
-import socket
-import struct
-import subprocess
 import sys
-import tempfile
-import threading
-import time
 import urllib.parse
-import webbrowser
 
 try:
     import requests
@@ -58,694 +34,214 @@ except ImportError:
 
 
 # ---------------------------------------------------------------------------
-# Constants — match tesla_auth exactly
+# Constants — match tesla_auth Rust exactly
 # ---------------------------------------------------------------------------
 
+AUTH_HOST = "https://auth.tesla.com"
 CLIENT_ID = "ownerapi"
-
-AUTH_URL_US = "https://auth.tesla.com/oauth2/v3/authorize"
-TOKEN_URL_US = "https://auth.tesla.com/oauth2/v3/token"
-
-AUTH_URL_CN = "https://auth.tesla.cn/oauth2/v3/authorize"
-TOKEN_URL_CN = "https://auth.tesla.cn/oauth2/v3/token"
-
 REDIRECT_URI = "tesla://auth/callback"
 
-SCOPES = ["openid", "email", "offline_access"]
-
-REGION_CONFIG = {
-    "us": {
-        "auth_url": AUTH_URL_US,
-        "token_url": TOKEN_URL_US,
-    },
-    "cn": {
-        "auth_url": AUTH_URL_CN,
-        "token_url": TOKEN_URL_CN,
-    },
+REGION_HOSTS = {
+    "us": "https://auth.tesla.com",
+    "cn": "https://auth.tesla.cn",
 }
-
-# Temp files for inter-process communication
-HANDLER_PORT_FILE = os.path.join(tempfile.gettempdir(), "tesla_auth_port.txt")
-HANDLER_SCRIPT_PATH = os.path.join(tempfile.gettempdir(), "tesla_uri_handler.py")
 
 
 # ---------------------------------------------------------------------------
 # PKCE helpers
 # ---------------------------------------------------------------------------
 
-def generate_code_verifier() -> str:
-    """Generate a PKCE code_verifier (base64url-encoded random bytes)."""
-    return secrets.token_urlsafe(32)
+def _build_auth_url(region: str = "us"):
+    """Build Tesla OAuth URL with PKCE parameters. Returns (url, code_verifier, state)."""
+    auth_host = REGION_HOSTS.get(region, REGION_HOSTS["us"])
 
+    code_verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    code_challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(code_verifier.encode()).digest()
+    ).rstrip(b"=").decode()
+    state = secrets.token_urlsafe(16)
 
-def generate_code_challenge(code_verifier: str) -> str:
-    """Generate S256 code_challenge from code_verifier (RFC 7636 §4.2)."""
-    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
-    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-
-
-def generate_state() -> str:
-    """Generate a random state parameter for CSRF protection."""
-    return secrets.token_urlsafe(16)
-
-
-# ---------------------------------------------------------------------------
-# URL building
-# ---------------------------------------------------------------------------
-
-def build_auth_url(code_challenge: str, state: str, region: str = "us") -> str:
-    """Build the Tesla OAuth authorization URL with tesla:// redirect."""
-    cfg = REGION_CONFIG.get(region, REGION_CONFIG["us"])
     params = {
         "client_id": CLIENT_ID,
         "code_challenge": code_challenge,
         "code_challenge_method": "S256",
         "redirect_uri": REDIRECT_URI,
         "response_type": "code",
-        "scope": " ".join(SCOPES),
+        "scope": "openid email offline_access",
         "state": state,
     }
-    return f"{cfg['auth_url']}?{urllib.parse.urlencode(params)}"
+    auth_url = f"{auth_host}/oauth2/v3/authorize?" + urllib.parse.urlencode(params)
+    return auth_url, code_verifier, state
 
 
-# ---------------------------------------------------------------------------
-# Token exchange
-# ---------------------------------------------------------------------------
-
-def exchange_code(code: str, code_verifier: str, token_url: str) -> dict:
-    """Exchange an authorization code for tokens."""
+def _exchange_code(auth_code: str, code_verifier: str, region: str = "us") -> str:
+    """Exchange authorization code for a refresh token. Returns refresh_token string."""
     if requests is None:
         raise ImportError("The 'requests' package is required. Install with: pip install requests")
 
-    data = {
-        "grant_type": "authorization_code",
-        "client_id": CLIENT_ID,
-        "code": code,
-        "code_verifier": code_verifier,
-        "redirect_uri": REDIRECT_URI,
-    }
-
-    resp = requests.post(token_url, data=data, timeout=30)
+    auth_host = REGION_HOSTS.get(region, REGION_HOSTS["us"])
+    resp = requests.post(
+        f"{auth_host}/oauth2/v3/token",
+        json={
+            "grant_type": "authorization_code",
+            "client_id": CLIENT_ID,
+            "code": auth_code,
+            "code_verifier": code_verifier,
+            "redirect_uri": REDIRECT_URI,
+        },
+        timeout=30,
+    )
     if resp.status_code != 200:
         raise RuntimeError(f"Token exchange failed (HTTP {resp.status_code}): {resp.text}")
 
-    result = resp.json()
-    if "refresh_token" not in result:
-        raise RuntimeError(f"No refresh_token in response: {result}")
+    data = resp.json()
+    if "refresh_token" not in data:
+        raise RuntimeError(f"No refresh_token in response: {data}")
 
-    return result
-
-
-def refresh_access_token(refresh_token: str, token_url: str = TOKEN_URL_US) -> dict:
-    """Refresh an access token using a refresh token."""
-    if requests is None:
-        raise ImportError("The 'requests' package is required. Install with: pip install requests")
-
-    data = {
-        "grant_type": "refresh_token",
-        "client_id": CLIENT_ID,
-        "refresh_token": refresh_token,
-    }
-
-    resp = requests.post(token_url, data=data, timeout=30)
-    if resp.status_code != 200:
-        raise RuntimeError(f"Token refresh failed (HTTP {resp.status_code}): {resp.text}")
-
-    return resp.json()
+    return data["refresh_token"]
 
 
 # ---------------------------------------------------------------------------
-# Callback URL parsing
+# Environment detection
 # ---------------------------------------------------------------------------
 
-def parse_callback_url(callback_url: str) -> dict:
-    """Parse the redirect callback URL to extract code, state, and issuer."""
-    parsed = urllib.parse.urlparse(callback_url)
-    params = urllib.parse.parse_qs(parsed.query)
+def _detect_mode() -> str:
+    """Detect whether we're in a local or remote session.
 
-    error = params.get("error", [None])[0]
-    if error:
-        raise RuntimeError(f"Tesla authentication error: {error}")
-
-    code = params.get("code", [None])[0]
-    state = params.get("state", [None])[0]
-    issuer = params.get("issuer", [None])[0]
-
-    if not code:
-        raise RuntimeError("No authorization code found in the redirect URL.")
-    if not state:
-        raise RuntimeError("No state parameter found in the redirect URL.")
-
-    token_url = TOKEN_URL_US
-    if issuer and "auth.tesla.cn" in issuer:
-        token_url = TOKEN_URL_CN
-
-    return {
-        "code": code,
-        "state": state,
-        "issuer": issuer,
-        "token_url": token_url,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Local HTTP callback server
-# ---------------------------------------------------------------------------
-
-class _CallbackHandler(http.server.BaseHTTPRequestHandler):
-    """HTTP handler that receives the forwarded tesla:// callback."""
-
-    auth_result = None  # type: ignore
-
-    def do_GET(self):
-        if self.path.startswith("/callback"):
-            params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
-            _CallbackHandler.auth_result = params
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html")
-            self.end_headers()
-            self.wfile.write(b"<html><body><h2>Authentication successful!</h2>"
-                             b"<p>You can close this tab.</p></body></html>")
-        else:
-            self.send_response(404)
-            self.end_headers()
-
-    def log_message(self, format, *args):
-        pass  # Suppress request logging
-
-
-class _CallbackServer:
-    """Local HTTP server that waits for the callback from the URI handler."""
-
-    def __init__(self, port: int):
-        _CallbackHandler.auth_result = None
-        self._server = http.server.HTTPServer(("127.0.0.1", port), _CallbackHandler)
-        self._server.timeout = 1
-        self._port = port
-        self._got_it = threading.Event()
-
-    def start_background(self):
-        """Start serving in a background thread."""
-        t = threading.Thread(target=self._serve_loop, daemon=True)
-        t.start()
-
-    def _serve_loop(self):
-        while not self._got_it.is_set():
-            self._server.handle_request()
-
-    def wait_for_code(self, timeout: int = 120) -> dict | None:
-        """Wait for the callback to arrive. Returns the parsed query params."""
-        deadline = time.time() + timeout
-        while time.time() < deadline:
-            if _CallbackHandler.auth_result is not None:
-                self._got_it.set()
-                return _CallbackHandler.auth_result
-            time.sleep(0.5)
-        self._got_it.set()
-        return None
-
-    def shutdown(self):
-        self._got_it.set()
-        self._server.server_close()
-
-
-# ---------------------------------------------------------------------------
-# URI handler script (written to /tmp, called by OS when tesla:// is opened)
-# ---------------------------------------------------------------------------
-
-def _write_handler_script():
-    """Write the URI handler script that forwards tesla:// URLs to our server."""
-    # Use stdlib only — no requests dependency for the handler
-    script = f'''#!/usr/bin/env python3
-"""URI handler for tesla:// scheme — forwards to local callback server."""
-import sys
-try:
-    import urllib.request
-    import urllib.parse
-    uri = sys.argv[1] if len(sys.argv) > 1 else ""
-    if not uri:
-        sys.exit(1)
-    try:
-        with open("{HANDLER_PORT_FILE}", "r") as f:
-            port = f.read().strip()
-    except Exception:
-        sys.exit(1)
-    parsed = urllib.parse.urlparse(uri)
-    qs = urllib.parse.urlencode(urllib.parse.parse_qs(parsed.query), doseq=True)
-    url = f"http://127.0.0.1:{{port}}/callback?{{qs}}"
-    try:
-        urllib.request.urlopen(url, timeout=5)
-    except Exception:
-        pass
-except Exception:
-    pass
-'''
-    with open(HANDLER_SCRIPT_PATH, "w") as f:
-        f.write(script)
-    os.chmod(HANDLER_SCRIPT_PATH, 0o755)
-
-
-# ---------------------------------------------------------------------------
-# OS-specific protocol handler registration
-# ---------------------------------------------------------------------------
-
-def _get_python_path() -> str:
-    """Get the current Python interpreter path."""
-    return sys.executable
-
-
-def _register_linux() -> bool:
-    """Register tesla:// URI scheme on Linux via xdg-mime."""
-    apps_dir = os.path.expanduser("~/.local/share/applications")
-    os.makedirs(apps_dir, exist_ok=True)
-
-    desktop_file = os.path.join(apps_dir, "tesla-auth-helper.desktop")
-    python_path = _get_python_path()
-
-    content = (
-        "[Desktop Entry]\n"
-        "Type=Application\n"
-        "Name=Tesla Auth Helper\n"
-        f"Exec={python_path} {HANDLER_SCRIPT_PATH} %u\n"
-        "MimeType=x-scheme-handler/tesla\n"
-        "NoDisplay=true\n"
-    )
-
-    with open(desktop_file, "w") as f:
-        f.write(content)
-
-    try:
-        subprocess.run(
-            ["xdg-mime", "default", "tesla-auth-helper.desktop",
-             "x-scheme-handler/tesla"],
-            capture_output=True, timeout=10, check=False,
-        )
-        subprocess.run(
-            ["update-desktop-database", apps_dir],
-            capture_output=True, timeout=10, check=False,
-        )
-        return True
-    except FileNotFoundError:
-        return False
-
-
-def _register_macos() -> bool:
-    """Register tesla:// URI scheme on macOS via a small .app bundle + lsregister."""
-    import plistlib
-
-    app_dir = os.path.expanduser("~/Library/TeslaAuthHelper.app")
-    contents = os.path.join(app_dir, "Contents")
-    macos_dir = os.path.join(contents, "MacOS")
-    os.makedirs(macos_dir, exist_ok=True)
-
-    # Handler script
-    python_path = _get_python_path()
-    handler_script = os.path.join(macos_dir, "TeslaAuthHelper")
-    with open(handler_script, "w") as f:
-        f.write(f"#!/bin/bash\nexec {python_path} {HANDLER_SCRIPT_PATH} \"$1\"\n")
-    os.chmod(handler_script, 0o755)
-
-    # Info.plist using plistlib for correctness
-    plist_path = os.path.join(contents, "Info.plist")
-    plist_data = {
-        "CFBundleIdentifier": "com.pypowerwall.teslaauth",
-        "CFBundleName": "TeslaAuthHelper",
-        "CFBundleExecutable": "TeslaAuthHelper",
-        "CFBundleVersion": "1.0",
-        "LSUIElement": True,
-        "CFBundleURLTypes": [{
-            "CFBundleURLSchemes": ["tesla"],
-            "CFBundleURLName": "Tesla Auth Callback",
-        }],
-    }
-    with open(plist_path, "wb") as f:
-        plistlib.dump(plist_data, f)
-
-    # Register with LaunchServices
-    try:
-        subprocess.run(
-            ["/System/Library/Frameworks/CoreServices.framework/Versions/A/"
-             "Frameworks/LaunchServices.framework/Versions/A/Support/lsregister",
-             "-f", app_dir],
-            capture_output=True, timeout=15, check=False,
-        )
-        return True
-    except FileNotFoundError:
-        return False
-
-
-def _register_windows() -> bool:
-    """Register tesla:// URI scheme on Windows via Registry."""
-    try:
-        import winreg
-    except ImportError:
-        return False
-
-    python_path = _get_python_path()
-    try:
-        key = winreg.CreateKey(winreg.HKEY_CURRENT_USER, r"Software\Classes\tesla")
-        winreg.SetValue(key, "", winreg.REG_SZ, "URL:Tesla Auth Protocol")
-        winreg.SetValueEx(key, "URL Protocol", 0, winreg.REG_SZ, "")
-        cmd_key = winreg.CreateKey(key, r"shell\open\command")
-        winreg.SetValue(
-            cmd_key, "",
-            winreg.REG_SZ,
-            f'"{python_path}" "{HANDLER_SCRIPT_PATH}" "%1"',
-        )
-        winreg.CloseKey(cmd_key)
-        winreg.CloseKey(key)
-        return True
-    except Exception:
-        return False
-
-
-def _register_protocol_handler() -> bool:
-    """Register the tesla:// URI scheme handler for the current OS."""
-    system = sys.platform
-    if system == "linux":
-        return _register_linux()
-    elif system == "darwin":
-        return _register_macos()
-    elif system == "win32":
-        return _register_windows()
-    return False
-
-
-def _unregister_protocol_handler():
-    """Remove the tesla:// URI scheme registration."""
-    system = sys.platform
-
-    if system == "linux":
-        desktop_file = os.path.expanduser(
-            "~/.local/share/applications/tesla-auth-helper.desktop"
-        )
-        try:
-            if os.path.exists(desktop_file):
-                os.remove(desktop_file)
-            apps_dir = os.path.expanduser("~/.local/share/applications")
-            subprocess.run(
-                ["update-desktop-database", apps_dir],
-                capture_output=True, timeout=10, check=False,
-            )
-        except Exception:
-            pass
-
-    elif system == "darwin":
-        app_dir = os.path.expanduser("~/Library/TeslaAuthHelper.app")
-        try:
-            if os.path.exists(app_dir):
-                shutil.rmtree(app_dir, ignore_errors=True)
-            subprocess.run(
-                ["/System/Library/Frameworks/CoreServices.framework/Versions/A/"
-                 "Frameworks/LaunchServices.framework/Versions/A/Support/lsregister",
-                 "-u", app_dir],
-                capture_output=True, timeout=10, check=False,
-            )
-        except Exception:
-            pass
-
-    elif system == "win32":
-        try:
-            import winreg
-            winreg.DeleteKey(
-                winreg.HKEY_CURRENT_USER,
-                r"Software\Classes\tesla\shell\open\command",
-            )
-            winreg.DeleteKey(
-                winreg.HKEY_CURRENT_USER,
-                r"Software\Classes\tesla\shell\open",
-            )
-            winreg.DeleteKey(
-                winreg.HKEY_CURRENT_USER,
-                r"Software\Classes\tesla\shell",
-            )
-            winreg.DeleteKey(
-                winreg.HKEY_CURRENT_USER,
-                r"Software\Classes\tesla",
-            )
-        except Exception:
-            pass
-
-    # Clean up handler script and port file
-    for f in [HANDLER_SCRIPT_PATH, HANDLER_PORT_FILE]:
-        try:
-            if os.path.exists(f):
-                os.remove(f)
-        except Exception:
-            pass
-
-
-# ---------------------------------------------------------------------------
-# Headless login — pure manual paste, no OS handler or HTTP server needed
-# ---------------------------------------------------------------------------
-
-def _headless_login(auth_url: str) -> str:
+    Returns 'remote' if SSH env vars are set or DISPLAY is empty on Linux,
+    otherwise 'local'.
     """
-    Headless login flow: print URL, user logs in via browser,
-    copies tesla:// callback URL from Chrome DevTools, and pastes it.
+    if os.environ.get("SSH_CLIENT") or os.environ.get("SSH_TTY"):
+        return "remote"
+    if sys.platform == "linux" and not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+        return "remote"
+    return "local"
 
-    Returns the parsed auth code.
-    """
+
+# ---------------------------------------------------------------------------
+# Path 1 — Remote/Headless login (paste token)
+# ---------------------------------------------------------------------------
+
+def _remote_login() -> str:
+    """Remote login: instruct user to run authtoken locally, then paste token."""
     print("\n" + "=" * 60)
-    print("Tesla Authentication — Headless Mode")
+    print("Tesla Authentication — Remote Session Detected")
     print("=" * 60)
-    print("\n1. Open this URL in your browser:\n")
-    print(f"   {auth_url}\n")
-    print("2. Complete the Tesla login (enter credentials + MFA if required).")
-    print("\n3. After login, the browser will show an error like:")
-    print('   "Failed to launch tesla://auth/callback?code=..."')
-    print("\n4. Open Chrome DevTools (F12 \u2192 Console tab) and find the")
-    print('   line starting with "Failed to launch tesla://..."')
-    print("\n5. Copy the FULL tesla:// URL from that line and paste it below.\n")
+    print()
+    print("You're on a remote session. On your local Mac/PC with")
+    print("pypowerwall installed, run:")
+    print()
+    print("    python -m pypowerwall authtoken")
+    print()
+    print("That will open a browser window, log you in, and print")
+    print("your refresh token.")
+    print()
+    print("Paste the token here when ready:")
+    print()
 
     while True:
-        callback_url = input("Paste the tesla:// URL here: ").strip()
-        if callback_url.startswith("tesla://"):
-            break
-        print("   \u26a0\ufe0f  Must start with 'tesla://' — try again.")
+        token = input("Token: ").strip()
+        if token:
+            return token
+        print("   ⚠️  Token cannot be empty — try again.")
 
-    # Parse code from the pasted URL
-    parsed = urllib.parse.urlparse(callback_url)
-    params = urllib.parse.parse_qs(parsed.query)
-    auth_code = params.get("code", [None])[0]
 
+# ---------------------------------------------------------------------------
+# Path 2 — Local login (pywebview)
+# ---------------------------------------------------------------------------
+
+def _local_login(email: str = None, region: str = "us") -> str:
+    """Local login: open pywebview window, capture callback, exchange for token.
+
+    Returns refresh_token string.
+    """
+    try:
+        import webview  # noqa: F401
+    except ImportError:
+        print("⚠️  pywebview is not installed.")
+        print("   Installing pywebview for native browser login...")
+        import subprocess
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "pywebview", "--quiet"]
+        )
+        print("   ✅ pywebview installed.\n")
+        # Re-import after install
+        import webview
+
+    auth_url, code_verifier, state = _build_auth_url(region)
+
+    if email:
+        # Append login_hint for a smoother UX
+        auth_url += f"&login_hint={urllib.parse.quote(email)}"
+
+    result = {}
+
+    def on_navigated(window, url):
+        if url and url.startswith("tesla://"):
+            parsed = urllib.parse.urlparse(url)
+            params = urllib.parse.parse_qs(parsed.query)
+            result["code"] = params.get("code", [None])[0]
+            window.destroy()
+
+    print("Opening Tesla login window...")
+    window = webview.create_window(
+        "Tesla Login — pypowerwall", auth_url, width=500, height=750
+    )
+    window.events.navigated += on_navigated
+    webview.start()
+
+    auth_code = result.get("code")
     if not auth_code:
-        raise ValueError("No auth code found in pasted URL")
+        raise RuntimeError("Login cancelled or timed out — no authorization code received.")
 
-    return auth_code
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _find_free_port() -> int:
-    """Find a free TCP port."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-def _has_display() -> bool:
-    """Check if a display is available for opening a browser."""
-    if sys.platform == "win32":
-        return True
-    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
-
-
-# ---------------------------------------------------------------------------
-# Main login function
-# ---------------------------------------------------------------------------
-
-def login(
-    email: str = None,
-    headless: bool = False,
-    region: str = "us",
-    timeout: int = 120,
-) -> str:
-    """
-    Authenticate with Tesla and return a refresh token.
-
-    Uses OAuth 2.0 PKCE flow. When a display is available:
-      1. Registers tesla:// URI handler on the OS
-      2. Starts a local HTTP server
-      3. Opens browser → user logs in → Tesla redirects to tesla://...
-      4. OS handler forwards to local server → captures auth code
-      5. Exchanges code for tokens
-      6. Cleans up URI registration
-
-    In headless mode, uses manual paste: user copies the tesla:// URL from
-    Chrome DevTools console after login and pastes it into the terminal.
-
-    If OS handler registration fails on any platform, automatically falls
-    back to headless-style manual paste mode.
-
-    Args:
-        email: Tesla account email (optional, will prompt if needed).
-        headless: If True, skip browser and use manual paste mode.
-        region: 'us' (default) or 'cn' for China.
-        timeout: Seconds to wait for automatic callback (default: 120).
-
-    Returns:
-        refresh_token string.
-    """
-    # Generate PKCE parameters
-    code_verifier = generate_code_verifier()
-    code_challenge = generate_code_challenge(code_verifier)
-    state = generate_state()
-
-    # Prompt for email if not provided
-    if not email:
-        email = input("Tesla account email: ").strip()
-        if not email or "@" not in email:
-            raise ValueError("A valid email address is required.")
-
-    print(f"\nTesla login for: {email}")
-    print("-" * 60)
-
-    # Build auth URL
-    auth_url = build_auth_url(code_challenge, state, region)
-
-    # --- Headless mode: pure manual paste, no browser/server needed ---
-    if headless:
-        auth_code = _headless_login(auth_url)
-
-        # Detect region from issuer if present in the pasted URL
-        parsed_url = urllib.parse.urlparse(input) if False else None
-        # Re-parse from the callback to get issuer for region detection
-        # _headless_login only returns the code, so we use US as default
-        # (the token exchange will fail if wrong region, and user can retry)
-        token_url = TOKEN_URL_US
-
-        print("  Exchanging authorization code for tokens...")
-        tokens = exchange_code(auth_code, code_verifier, token_url)
-        refresh_token = tokens["refresh_token"]
-        print(f"  \u2705 Refresh token obtained (expires in {tokens.get('expires_in', '?')}s)")
-        return refresh_token
-
-    # --- Interactive mode: try automatic callback, fall back to manual ---
-    use_auto = _has_display()
-
-    callback_url = None
-    server = None
-
-    if use_auto:
-        try:
-            port = _find_free_port()
-
-            # Write port file for handler script
-            with open(HANDLER_PORT_FILE, "w") as f:
-                f.write(str(port))
-
-            # Write handler script
-            _write_handler_script()
-
-            # Register protocol handler
-            registered = _register_protocol_handler()
-
-            if not registered:
-                print(f"  \u26a0\ufe0f  Could not register tesla:// handler automatically "
-                      f"(platform: {sys.platform})")
-                print("     Falling back to manual paste mode...\n")
-
-            if registered:
-                # Start local HTTP server
-                server = _CallbackServer(port)
-                server.start_background()
-
-                # Open browser
-                print("Opening browser for Tesla login...")
-                print(
-                    "\nAfter logging in, the browser will redirect automatically.\n"
-                    "If the redirect fails, copy the FULL URL from the address bar\n"
-                    "and paste it below.\n"
-                )
-                webbrowser.open(auth_url)
-
-                # Wait for automatic callback
-                print(f"Waiting for redirect (up to {timeout}s)...")
-                result = server.wait_for_code(timeout=timeout)
-
-                if result and "code" in result:
-                    codes = result["code"]
-                    states = result.get("state", [None])
-                    issuers = result.get("issuer", [None])
-
-                    if codes and states and states[0] == state:
-                        issuer = issuers[0] if issuers else None
-                        token_url = TOKEN_URL_US
-                        if issuer and "auth.tesla.cn" in issuer:
-                            token_url = TOKEN_URL_CN
-
-                        print("  \u2705 Auth code captured automatically!")
-                        tokens = exchange_code(codes[0], code_verifier, token_url)
-                        refresh_token = tokens["refresh_token"]
-                        print(f"  \u2705 Refresh token obtained "
-                              f"(expires in {tokens.get('expires_in', '?')}s)")
-                        return refresh_token
-                    else:
-                        print("  \u26a0\ufe0f State mismatch or empty code, "
-                              "falling back to manual mode.")
-                else:
-                    print("  \u26a0\ufe0f Timed out waiting for automatic redirect.")
-                    print("  Falling back to manual paste mode.\n")
-
-        except Exception as e:
-            print(f"  \u26a0\ufe0f Auto-capture failed ({e}), "
-                  "falling back to manual paste mode.\n")
-        finally:
-            # Always clean up
-            if server:
-                try:
-                    server.shutdown()
-                except Exception:
-                    pass
-            _unregister_protocol_handler()
-
-    # --- Manual paste mode (headless-style fallback) ---
-    # This is reached when:
-    #   - headless=False but auto capture failed or wasn't available
-    #   - No display detected
-    print("\n" + "-" * 60)
-    print("Manual Authentication Required")
-    print("-" * 60)
-    print("\n1. Open this URL in your browser:\n")
-    print(f"   {auth_url}\n")
-    print("2. Complete the Tesla login (enter credentials + MFA if required).")
-    print("\n3. After login, the browser will show an error like:")
-    print('   "Failed to launch tesla://auth/callback?code=..."')
-    print("\n4. Open Chrome DevTools (F12 \u2192 Console tab) and find the")
-    print('   line starting with "Failed to launch tesla://..."')
-    print("\n5. Copy the FULL tesla:// URL from that line and paste it below.\n")
-
-    while True:
-        callback_url = input("Paste the tesla:// URL here: ").strip()
-        if callback_url.startswith("tesla://"):
-            break
-        print("   \u26a0\ufe0f  Must start with 'tesla://' — try again.")
-
-    # Parse callback
-    callback = parse_callback_url(callback_url)
-
-    # Validate state (CSRF protection)
-    if callback["state"] != state:
-        raise RuntimeError("CSRF state mismatch — possible tampering.")
-
-    # Exchange code for tokens
-    print("  Exchanging authorization code for tokens...")
-    tokens = exchange_code(callback["code"], code_verifier, callback["token_url"])
-
-    refresh_token = tokens["refresh_token"]
-    print(f"  \u2705 Refresh token obtained (expires in {tokens.get('expires_in', '?')}s)")
+    print("  ✅ Authorization code captured!")
+    print("  Exchanging for refresh token...")
+    refresh_token = _exchange_code(auth_code, code_verifier, region)
     return refresh_token
 
 
 # ---------------------------------------------------------------------------
-# Token storage
+# Public API
 # ---------------------------------------------------------------------------
 
+def login(email: str = None, headless: bool = False, region: str = "us") -> str:
+    """Authenticate with Tesla and return a refresh token.
+
+    Auto-detects local vs remote environment. On remote sessions (or if
+    ``headless=True``), uses the paste-token flow. Otherwise opens a
+    pywebview window for browser login.
+
+    Args:
+        email: Tesla account email (optional, used as login hint).
+        headless: Force remote/paste mode regardless of environment.
+        region: 'us' (default) or 'cn'.
+
+    Returns:
+        refresh_token string.
+    """
+    if headless or _detect_mode() == "remote":
+        return _remote_login()
+
+    return _local_login(email=email, region=region)
+
+
+def get_authtoken(region: str = "us") -> str:
+    """Get a refresh token for the ``authtoken`` CLI command.
+
+    Always uses the local pywebview path (no file saving). The caller
+    is responsible for displaying or using the token.
+    """
+    return _local_login(region=region)
+
+
 def save_token(refresh_token: str, path: str = None, email: str = None):
-    """Save a refresh token to pypowerwall's auth file."""
+    """Save a refresh token to the pypowerwall auth file (.pypowerwall.auth).
+
+    Args:
+        refresh_token: The token to save.
+        path: File path (default: .pypowerwall.auth in current directory).
+        email: Email address to associate with the token.
+    """
     if not path:
         path = os.path.join(os.getcwd(), ".pypowerwall.auth")
 
@@ -775,63 +271,3 @@ def save_token(refresh_token: str, path: str = None, email: str = None):
 
     print(f"  Token saved to {path}")
     return path
-
-
-# ---------------------------------------------------------------------------
-# CLI entry point
-# ---------------------------------------------------------------------------
-
-def main():
-    """CLI entry point for `python -m pypowerwall login`."""
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        prog="pypowerwall login",
-        description="Authenticate with Tesla and obtain a refresh token",
-    )
-    parser.add_argument("--email", "-e", type=str, help="Tesla account email address")
-    parser.add_argument(
-        "--headless", "-H", action="store_true",
-        help="Manual mode — don't open browser, paste URL instead",
-    )
-    parser.add_argument(
-        "--region", "-r", type=str, default="us", choices=["us", "cn"],
-        help="Tesla region: 'us' (default) or 'cn' (China)",
-    )
-    parser.add_argument(
-        "--timeout", "-t", type=int, default=120,
-        help="Seconds to wait for automatic redirect (default: 120)",
-    )
-    parser.add_argument(
-        "--output", "-o", type=str, default=None,
-        help="Path to save the auth file (default: .pypowerwall.auth in current dir)",
-    )
-
-    args = parser.parse_args()
-
-    print("\u26a1 Tesla Authentication — pypowerwall")
-    print("=" * 60)
-
-    try:
-        refresh_token = login(
-            email=args.email,
-            headless=args.headless,
-            region=args.region,
-            timeout=args.timeout,
-        )
-    except (KeyboardInterrupt, EOFError):
-        print("\n\nLogin cancelled.")
-        sys.exit(1)
-    except Exception as e:
-        print(f"\n\u274c Login failed: {e}")
-        sys.exit(1)
-
-    email = args.email or ""
-    save_token(refresh_token, path=args.output, email=email)
-
-    print("\n\u2705 Done! You can now use pypowerwall with cloud mode.")
-    print("   Run: python -m pypowerwall setup")
-
-
-if __name__ == "__main__":
-    main()

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -151,13 +151,13 @@ def _remote_login() -> str:
 # ---------------------------------------------------------------------------
 
 def _local_login(email: str = None, region: str = "us") -> str:
-    """Local login: open pywebview window, capture callback, exchange for token."""
+    """Local login via pywebview native window. Requires pywebview >= 4.0."""
     try:
         import webview
     except ImportError:
         print("Installing pywebview...")
-        import subprocess, sys
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "pywebview", "-q"])
+        import subprocess
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "pywebview>=4.0", "-q"])
         import webview
 
     auth_url, code_verifier, state = _build_auth_url(region)
@@ -167,114 +167,56 @@ def _local_login(email: str = None, region: str = "us") -> str:
     result = {}
     window_holder = {}
 
-    # Use localStorage instead of a global — persists across page reloads/navigations
-    intercept_js = """
-    (function() {
-        if (window.__teslaAuthPatched) return;
-        window.__teslaAuthPatched = true;
-        
-        function capture(url) {
-            try {
-                window.localStorage.setItem('__teslaUrl', url);
-            } catch(e) {}
-        }
-        
-        try {
-            var desc = Object.getOwnPropertyDescriptor(Location.prototype, 'href');
-            if (desc && desc.set) {
-                Object.defineProperty(Location.prototype, 'href', {
-                    get: desc.get,
-                    set: function(val) {
-                        if (val && val.indexOf('tesla://') === 0) { capture(val); return; }
-                        desc.set.call(this, val);
-                    },
-                    configurable: true
-                });
-            }
-        } catch(e) {}
-        
-        try {
-            var _assign = Location.prototype.assign;
-            Location.prototype.assign = function(url) {
-                if (url && url.indexOf('tesla://') === 0) { capture(url); return; }
-                return _assign.call(this, url);
-            };
-            var _replace = Location.prototype.replace;
-            Location.prototype.replace = function(url) {
-                if (url && url.indexOf('tesla://') === 0) { capture(url); return; }
-                return _replace.call(this, url);
-            };
-        } catch(e) {}
-        
-        try {
-            var _open = window.open;
-            window.open = function(url, t, f) {
-                if (url && url.indexOf('tesla://') === 0) { capture(url); return; }
-                return _open.apply(this, arguments);
-            };
-        } catch(e) {}
-    })();
-    """
-
-    def inject():
-        try:
-            window_holder["window"].evaluate_js(intercept_js)
-            print("  [debug] JS injected successfully")
-        except Exception as e:
-            print(f"  [debug] JS inject error: {e}")
-
     def poll():
-        """Poll localStorage for the tesla:// URL."""
+        """Poll window URL every 200ms — works in pywebview 4.x+ via get_current_url()."""
         import time
-        for i in range(1200):  # 120 seconds max
-            if not window_holder.get("window"):
-                time.sleep(0.1)
+        print("  Waiting for Tesla login to complete...")
+        for _ in range(600):  # 120 seconds
+            win = window_holder.get("window")
+            if not win:
+                time.sleep(0.2)
                 continue
             try:
-                url = window_holder["window"].evaluate_js(
-                    'window.localStorage.getItem("__teslaUrl") || ""'
-                )
+                # pywebview 4.x+: get_current_url() returns the current URL
+                url = win.get_current_url()
                 if url and url.startswith("tesla://"):
-                    print(f"  [debug] Got tesla:// URL at poll {i}: {url[:80]}...")
                     parsed = urllib.parse.urlparse(url)
                     params = urllib.parse.parse_qs(parsed.query)
                     code = params.get("code", [None])[0]
                     if code:
                         result["code"] = code
                         try:
-                            window_holder["window"].destroy()
+                            win.destroy()
                         except Exception:
                             pass
                         return
-            except Exception as e:
-                print(f"  [debug] Poll error: {e}")
-            time.sleep(0.1)
-        print("  [debug] Poll timed out after 120s")
+            except Exception:
+                pass
+            time.sleep(0.2)
 
     print("Opening Tesla login window...")
-    print("  [debug] Creating window...")
     window = webview.create_window(
-        "Tesla Login — pypowerwall", auth_url, width=500, height=750
+        "Tesla Login — pypowerwall",
+        auth_url,
+        width=500,
+        height=750,
     )
     window_holder["window"] = window
-    window.events.loaded += inject
-    
+
     import threading
     t = threading.Thread(target=poll, daemon=True)
     t.start()
-    
-    print("  [debug] Starting webview...")
+
     webview.start()
-    print(f"  [debug] webview.start() returned, result code present: {bool(result.get('code'))}")
 
     auth_code = result.get("code")
     if not auth_code:
-        raise RuntimeError("Login cancelled or timed out — no authorization code received.")
+        raise RuntimeError("Login cancelled or timed out.")
 
     print("  Authorization code captured!")
     print("  Exchanging for refresh token...")
-    refresh_token = _exchange_code(auth_code, code_verifier, region)
-    return refresh_token
+    return _exchange_code(auth_code, code_verifier, region)
+
 
 # ---------------------------------------------------------------------------
 # Public API

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -151,7 +151,12 @@ def _remote_login() -> str:
 # ---------------------------------------------------------------------------
 
 def _local_login(email: str = None, region: str = "us") -> str:
-    """Local login via pywebview native window. Requires pywebview >= 4.0."""
+    """Local login via pywebview native window.
+
+    Uses window.events.request_sent which fires inside WKNavigationDelegate
+    decidePolicyForNavigationAction BEFORE WKWebView rejects the tesla:// scheme.
+    This is the correct interception point — same layer as the Rust tesla_auth tool.
+    """
     try:
         import webview
     except ImportError:
@@ -165,34 +170,6 @@ def _local_login(email: str = None, region: str = "us") -> str:
         auth_url += f"&login_hint={urllib.parse.quote(email)}"
 
     result = {}
-    window_holder = {}
-
-    def poll():
-        """Poll window URL every 200ms — works in pywebview 4.x+ via get_current_url()."""
-        import time
-        print("  Waiting for Tesla login to complete...")
-        for _ in range(600):  # 120 seconds
-            win = window_holder.get("window")
-            if not win:
-                time.sleep(0.2)
-                continue
-            try:
-                # pywebview 4.x+: get_current_url() returns the current URL
-                url = win.get_current_url()
-                if url and url.startswith("tesla://"):
-                    parsed = urllib.parse.urlparse(url)
-                    params = urllib.parse.parse_qs(parsed.query)
-                    code = params.get("code", [None])[0]
-                    if code:
-                        result["code"] = code
-                        try:
-                            win.destroy()
-                        except Exception:
-                            pass
-                        return
-            except Exception:
-                pass
-            time.sleep(0.2)
 
     print("Opening Tesla login window...")
     window = webview.create_window(
@@ -201,11 +178,24 @@ def _local_login(email: str = None, region: str = "us") -> str:
         width=500,
         height=750,
     )
-    window_holder["window"] = window
 
-    import threading
-    t = threading.Thread(target=poll, daemon=True)
-    t.start()
+    def on_request(request):
+        """Fires inside WKNavigationDelegate before any navigation decision.
+        Intercepts the tesla:// callback URL before WKWebView can reject it.
+        """
+        url = getattr(request, "url", None) or str(request)
+        if url and url.startswith("tesla://"):
+            parsed = urllib.parse.urlparse(url)
+            params = urllib.parse.parse_qs(parsed.query)
+            code = params.get("code", [None])[0]
+            if code:
+                result["code"] = code
+                try:
+                    window.destroy()
+                except Exception:
+                    pass
+
+    window.events.request_sent += on_request
 
     webview.start()
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -172,11 +172,12 @@ def _remote_login() -> str:
 # ---------------------------------------------------------------------------
 
 def _local_login(email: str = None, region: str = "us", debug: bool = False):
-    """Local login via native WebView. Returns (refresh_token, email) tuple."""
+    """Local login via native WebView. Returns (refresh_token, email, token_data) tuple."""
     if sys.platform == "darwin":
         return _local_login_macos(email, region, debug=debug)
     else:
-        return _local_login_pywebview(email, region), ""
+        token = _local_login_pywebview(email, region)
+        return token, "", {}
 
 
 # ---------------------------------------------------------------------------
@@ -286,6 +287,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                             token = data["refresh_token"] if isinstance(data, dict) else data
                             dbg(f"Token exchange succeeded, token length: {len(token)}")
                             result["token"] = token
+                            result["token_data"] = data if isinstance(data, dict) else {}
                             # Extract email from id_token if available
                             if isinstance(data, dict) and data.get("id_token"):
                                 result["email"] = _extract_email_from_token(data["id_token"])
@@ -409,7 +411,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
         raise RuntimeError(result["error"])
     if not result["token"]:
         raise RuntimeError("Login cancelled - no token received.")
-    return result["token"], result.get("email", "")
+    return result["token"], result.get("email", ""), result.get("token_data", {})
 
 
 def _local_login_pywebview(email: str = None, region: str = "us") -> str:
@@ -572,15 +574,15 @@ def _patch_pywebview_gtk(result, expected_state):
 # ---------------------------------------------------------------------------
 
 def login(email: str = None, headless: bool = False, region: str = "us", debug: bool = False):
-    """Authenticate with Tesla. Returns (refresh_token, email) tuple."""
+    """Authenticate with Tesla. Returns (refresh_token, email, token_data) tuple."""
     if headless or _detect_mode() == "remote":
-        return _remote_login(), ""
+        return _remote_login(), "", {}
     return _local_login(email=email, region=region, debug=debug)
 
 
 def get_authtoken(region: str = "us", debug: bool = False) -> str:
     """Get a refresh token for the authtoken CLI command (no file save)."""
-    token, _ = _local_login(region=region, debug=debug)
+    token, _, _ = _local_login(region=region, debug=debug)
     return token
 
 
@@ -601,32 +603,50 @@ def _extract_email_from_token(token: str) -> str:
 ''
 
 
-def save_token(refresh_token: str, path: str = None, email: str = None):
-    """Save a refresh token to the pypowerwall auth file (.pypowerwall.auth).
+def save_token(token_data: dict, path: str = None, email: str = None):
+    """Save token data to the pypowerwall auth file (.pypowerwall.auth).
+
+    Writes in teslapy-compatible format so PyPowerwallCloud can read it.
 
     Args:
-        refresh_token: The token to save.
+        token_data: Full token response dict from Tesla (contains access_token,
+                    refresh_token, expires_in, token_type, id_token).
         path: File path (default: .pypowerwall.auth in current directory).
         email: Email address to associate with the token.
     """
+    import time
+
     if not path:
         path = os.path.join(os.getcwd(), ".pypowerwall.auth")
 
     if not email:
         email = input("Tesla account email: ").strip()
 
-    data = {}
+    # Build teslapy-compatible cache entry
+    expires_in = token_data.get("expires_in", 28800)
+    expires_at = int(time.time() + expires_in)
+
+    sso = {
+        "token_type": token_data.get("token_type", "Bearer"),
+        "access_token": token_data.get("access_token", ""),
+        "refresh_token": token_data.get("refresh_token", ""),
+        "expires_at": expires_at,
+        "expires_in": expires_in,
+    }
+    if token_data.get("id_token"):
+        sso["id_token"] = token_data["id_token"]
+
+    cache = {}
     if os.path.isfile(path):
         try:
             with open(path, "r") as f:
-                data = json.load(f)
+                cache = json.load(f)
         except (json.JSONDecodeError, IOError):
-            data = {}
+            cache = {}
 
-    data[email] = {
-        "refresh_token": refresh_token,
-        "access_token": "",
-        "expires_at": 0,
+    cache[email] = {
+        "url": "https://auth.tesla.com/",
+        "sso": sso,
     }
 
     dir_name = os.path.dirname(path)
@@ -634,7 +654,8 @@ def save_token(refresh_token: str, path: str = None, email: str = None):
         os.makedirs(dir_name, exist_ok=True)
 
     with open(path, "w") as f:
-        json.dump(data, f, indent=2)
+        json.dump(cache, f, indent=2)
+    os.chmod(path, 0o600)
 
     print(f"  Token saved to {path}")
     return path

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -151,11 +151,11 @@ def _remote_login() -> str:
 # ---------------------------------------------------------------------------
 
 def _local_login(email: str = None, region: str = "us") -> str:
-    """Local login via pywebview native window.
+    """Local login via pywebview using before_load event to intercept tesla:// redirect.
 
-    Uses window.events.request_sent which fires inside WKNavigationDelegate
-    decidePolicyForNavigationAction BEFORE WKWebView rejects the tesla:// scheme.
-    This is the correct interception point — same layer as the Rust tesla_auth tool.
+    window.events.before_load fires inside WKNavigationDelegate before WKWebView
+    processes any navigation, including custom URI schemes. This is the correct
+    native interception point — equivalent to what the Rust tesla_auth tool uses.
     """
     try:
         import webview
@@ -179,11 +179,11 @@ def _local_login(email: str = None, region: str = "us") -> str:
         height=750,
     )
 
-    def on_request(request):
-        """Fires inside WKNavigationDelegate before any navigation decision.
-        Intercepts the tesla:// callback URL before WKWebView can reject it.
+    def on_before_load(url):
+        """Fires before WKWebView navigates to any URL.
+        When Tesla redirects to tesla://auth/callback, we capture the code here
+        and cancel navigation by returning False.
         """
-        url = getattr(request, "url", None) or str(request)
         if url and url.startswith("tesla://"):
             parsed = urllib.parse.urlparse(url)
             params = urllib.parse.parse_qs(parsed.query)
@@ -194,16 +194,17 @@ def _local_login(email: str = None, region: str = "us") -> str:
                     window.destroy()
                 except Exception:
                     pass
+            return False  # cancel navigation
+        return True  # allow all other navigation
 
-    window.events.request_sent += on_request
-
+    window.events.before_load += on_before_load
     webview.start()
 
     auth_code = result.get("code")
     if not auth_code:
         raise RuntimeError("Login cancelled or timed out.")
 
-    print("  Authorization code captured!")
+    print("  ✅ Authorization code captured!")
     print("  Exchanging for refresh token...")
     return _exchange_code(auth_code, code_verifier, region)
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -376,6 +376,8 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
         app = AppKit.NSApplication.sharedApplication()
         app.setActivationPolicy_(AppKit.NSApplicationActivationPolicyRegular)
         config = WebKit.WKWebViewConfiguration.alloc().init()
+        # Use non-persistent data store so every run starts with no cookies/cache
+        config.setWebsiteDataStore_(WebKit.WKWebsiteDataStore.nonPersistentDataStore())
         webview_obj = WebKit.WKWebView.alloc().initWithFrame_configuration_(
             Foundation.NSMakeRect(0, 0, 500, 750), config,
         )

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -350,9 +350,8 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                             dbg(f"Token exchange error: {e}")
                         finally:
                             exchange_done.set()
-                            # Stop event loop so run_window() returns and token is saved
-                            # The success page will already be loaded at this point
-                            AppKit.NSApplication.sharedApplication().stop_(None)
+                            # Window stays open for user to click Close button
+                            # DO NOT stop event loop here
 
                     threading.Thread(target=do_exchange, daemon=True).start()
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -95,6 +95,35 @@ def _build_auth_url(region: str = "us"):
     return auth_url, code_verifier, state
 
 
+def _refresh_access_token(refresh_token: str, region: str = "us") -> dict:
+    """Exchange a refresh token for a fresh access token.
+
+    Tesla OAuth refresh: POST /oauth2/v3/token with grant_type=refresh_token,
+    client_id=ownerapi, refresh_token.
+    """
+    if requests is None:
+        raise ImportError("The 'requests' package is required.")
+
+    auth_host = REGION_HOSTS.get(region, REGION_HOSTS["us"])
+    resp = requests.post(
+        f"{auth_host}{TOKEN_URL_PATH}",
+        json={
+            "grant_type": "refresh_token",
+            "client_id": CLIENT_ID,
+            "refresh_token": refresh_token,
+        },
+        timeout=30,
+    )
+    if resp.status_code != 200:
+        raise RuntimeError(f"Token refresh failed (HTTP {resp.status_code}): {resp.text}")
+
+    data = resp.json()
+    if "access_token" not in data:
+        raise RuntimeError(f"No access_token in refresh response: {data}")
+
+    return data
+
+
 def _exchange_code(auth_code: str, code_verifier: str, region: str = "us") -> dict:
     """Exchange authorization code for tokens.
 
@@ -628,7 +657,7 @@ def _extract_email_from_token(token: str) -> str:
 ''
 
 
-def save_token(token_data: dict, path: str = None, email: str = None):
+def save_token(token_data: dict, path: str = None, email: str = None, region: str = "us"):
     """Save token data to the pypowerwall auth file (.pypowerwall.auth).
 
     Writes in teslapy-compatible format so PyPowerwallCloud can read it.
@@ -638,6 +667,7 @@ def save_token(token_data: dict, path: str = None, email: str = None):
                     refresh_token, expires_in, token_type, id_token).
         path: File path (default: .pypowerwall.auth in current directory).
         email: Email address to associate with the token.
+        region: Tesla region for token refresh if access_token is missing.
     """
     import time
 
@@ -646,6 +676,15 @@ def save_token(token_data: dict, path: str = None, email: str = None):
 
     if not email:
         email = input("Tesla account email: ").strip()
+
+    # If access_token is missing, refresh it from the refresh_token
+    if not token_data.get("access_token") and token_data.get("refresh_token"):
+        try:
+            refreshed = _refresh_access_token(token_data["refresh_token"], region=region)
+            token_data.update(refreshed)
+            print("  Access token refreshed successfully.")
+        except Exception as e:
+            print(f"  Warning: Could not refresh access token: {e}")
 
     # Build teslapy-compatible cache entry
     expires_in = token_data.get("expires_in", 28800)

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -409,6 +409,19 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
         )
         webview_obj.loadRequest_(req)
         app.activateIgnoringOtherApps_(True)
+
+        # Add Edit menu so Cmd+V (paste) and other shortcuts work in WKWebView
+        edit_menu = AppKit.NSMenu.alloc().initWithTitle_("Edit")
+        edit_menu.addItemWithTitle_action_keyEquivalent_("Cut", "cut:", "x")
+        edit_menu.addItemWithTitle_action_keyEquivalent_("Copy", "copy:", "c")
+        edit_menu.addItemWithTitle_action_keyEquivalent_("Paste", "paste:", "v")
+        edit_menu.addItemWithTitle_action_keyEquivalent_("Select All", "selectAll:", "a")
+        edit_item = AppKit.NSMenuItem.alloc().initWithTitle_action_keyEquivalent_("Edit", None, "")
+        edit_item.setSubmenu_(edit_menu)
+        main_menu = AppKit.NSMenu.alloc().init()
+        main_menu.addItem_(edit_item)
+        app.setMainMenu_(main_menu)
+
         AppHelper.runEventLoop()
 
     print("Opening Tesla login window...")

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -204,6 +204,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
         auth_url += f"&login_hint={urllib.parse.quote(email)}"
 
     result = {"token": None, "error": None}
+    exchange_done = threading.Event()
 
     def dbg(msg):
         if debug:
@@ -261,7 +262,6 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                     def do_exchange():
                         try:
                             data = _exchange_code(code, code_verifier, region)
-                            # _exchange_code returns the full token dict
                             token = data["refresh_token"] if isinstance(data, dict) else data
                             dbg(f"Token exchange succeeded, token length: {len(token)}")
                             dbg(f"Token preview: {token[:20]}...")
@@ -270,6 +270,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                             result["error"] = f"Token exchange failed: {e}"
                             dbg(f"Token exchange error: {e}")
                         finally:
+                            exchange_done.set()
                             AppHelper.callAfter(AppHelper.stopEventLoop)
 
                     threading.Thread(target=do_exchange, daemon=True).start()
@@ -333,6 +334,9 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
 
     print("Opening Tesla login window...")
     run_window()
+
+    # Wait up to 15s for background token exchange thread to finish
+    exchange_done.wait(timeout=15)
 
     if result["error"]:
         raise RuntimeError(result["error"])

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -600,27 +600,130 @@ def _patch_pywebview_cocoa(result, expected_state):
 
 
 def _patch_pywebview_win32(result, expected_state):
-    """Patch pywebview's Windows WebView2 handler to intercept tesla:// URLs."""
+    """Patch pywebview's Windows EdgeChrome/WebView2 handler to intercept tesla:// URLs.
+
+    pywebview on Windows uses EdgeChromium (WebView2). The EdgeChrome class connects
+    NavigationStarting to self.on_navigation_start. We monkey-patch that method to
+    intercept tesla:// URLs before the browser tries to navigate to them.
+    """
     try:
-        from webview.platforms import winforms
-        # WebView2 fires a SourceChanged event or we can use the
-        # CoreWebView2.NavigationStarting event.
-        # For now, we'll use a JS-based approach as fallback on Windows,
-        # since the winforms backend may not expose navigation policy directly.
-        # TODO: Implement WebView2 navigation interception for Windows.
+        from webview.platforms import edgechromium as chromium_mod
     except ImportError:
-        pass
+        try:
+            from webview.platforms import winforms
+            chromium_mod = getattr(winforms, 'Chromium', None)
+            if chromium_mod is None:
+                return
+        except ImportError:
+            return
+
+    EdgeChrome = getattr(chromium_mod, 'EdgeChrome', None)
+    if EdgeChrome is None:
+        return
+
+    original_on_navigation_start = EdgeChrome.on_navigation_start
+
+    def patched_on_navigation_start(self, sender, args):
+        try:
+            uri = str(args.get_Uri())
+            if uri and uri.startswith("tesla://"):
+                # Cancel the navigation — tesla:// is not a real scheme
+                args.set_Cancel(True)
+
+                parsed = urllib.parse.urlparse(uri)
+                params = urllib.parse.parse_qs(parsed.query)
+
+                error = params.get("error", [None])[0]
+                if error:
+                    result["error"] = f"Tesla auth error: {error}"
+                    return
+
+                code = params.get("code", [None])[0]
+                returned_state = params.get("state", [None])[0]
+
+                if not code:
+                    result["error"] = "No auth code in redirect"
+                    return
+
+                if returned_state != expected_state:
+                    result["error"] = "CSRF state mismatch"
+                    return
+
+                result["code"] = code
+                return
+        except Exception:
+            pass
+
+        # Fall through to original handler for non-tesla:// URLs
+        original_on_navigation_start(self, sender, args)
+
+    EdgeChrome.on_navigation_start = patched_on_navigation_start
 
 
 def _patch_pywebview_gtk(result, expected_state):
-    """Patch pywebview's Linux WebKit2GTK handler to intercept tesla:// URLs."""
+    """Patch pywebview's Linux WebKit2GTK BrowserView to intercept tesla:// URLs.
+
+    pywebview on Linux uses WebKit2GTK. BrowserView connects the 'decide-policy' signal
+    to self.on_navigation. We monkey-patch on_navigation to intercept tesla:// URLs
+    before the browser tries to navigate (which would fail since tesla:// is not real).
+
+    The on_navigation signature is: on_navigation(self, webview, decision, decision_type)
+    where decision_type is a WebKit2.PolicyDecisionType enum and decision is a
+    NavigationPolicyDecision (for NAVIGATION_ACTION) or ResponsePolicyDecision.
+    """
     try:
-        from webview.platforms import gtk
-        # WebKit2GTK uses "decide-policy" signal on the WebView.
-        # pywebview's BrowserView connects this signal.
-        # TODO: Implement WebKit2GTK navigation interception for Linux.
+        from webview.platforms import gtk as gtk_mod
     except ImportError:
-        pass
+        return
+
+    BrowserView = getattr(gtk_mod, 'BrowserView', None)
+    if BrowserView is None:
+        return
+
+    original_on_navigation = BrowserView.on_navigation
+
+    def patched_on_navigation(self, webview, decision, decision_type):
+        try:
+            # WebKit2.PolicyDecisionType.NAVIGATION_ACTION = 0
+            if decision_type == 0:
+                import gi
+                from gi.repository import WebKit2 as webkit
+                nav_decision = decision
+                request = nav_decision.get_request()
+                uri = request.get_uri() if request else None
+
+                if uri and uri.startswith("tesla://"):
+                    # Ignore the request — tesla:// is not a real scheme
+                    nav_decision.ignore()
+
+                    parsed = urllib.parse.urlparse(uri)
+                    params = urllib.parse.parse_qs(parsed.query)
+
+                    error = params.get("error", [None])[0]
+                    if error:
+                        result["error"] = f"Tesla auth error: {error}"
+                        return
+
+                    code = params.get("code", [None])[0]
+                    returned_state = params.get("state", [None])[0]
+
+                    if not code:
+                        result["error"] = "No auth code in redirect"
+                        return
+
+                    if returned_state != expected_state:
+                        result["error"] = "CSRF state mismatch"
+                        return
+
+                    result["code"] = code
+                    return
+        except Exception:
+            pass
+
+        # Fall through to original handler for non-tesla:// URLs
+        original_on_navigation(self, webview, decision, decision_type)
+
+    BrowserView.on_navigation = patched_on_navigation
 
 
 # ---------------------------------------------------------------------------

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -226,6 +226,25 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
 
             dbg(f"Navigation: {url[:100]}")
 
+            # Handle our own action URLs
+            if url.startswith("pypowerwall://"):
+                action = url.split("pypowerwall://")[1].split("?")[0]
+                dbg(f"pypowerwall action: {action}")
+                if action == "copy":
+                    try:
+                        token = result.get("token", "")
+                        if token:
+                            pb = AppKit.NSPasteboard.generalPasteboard()
+                            pb.clearContents()
+                            pb.setString_forType_(token, AppKit.NSPasteboardTypeString)
+                            dbg("Token copied to clipboard via button")
+                    except Exception as e:
+                        dbg(f"Clipboard error: {e}")
+                elif action == "close":
+                    AppHelper.callAfter(AppHelper.stopEventLoop)
+                handler(0)
+                return
+
             if url.startswith("tesla://"):
                 dbg(f"INTERCEPTED tesla:// URL: {url[:120]}")
                 try:
@@ -301,8 +320,22 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
 <h2>\u2705 Authentication Successful</h2>
 <p>Your Tesla refresh token is ready. It has been <strong>copied to your clipboard</strong> automatically.</p>
 <div class='token-box' id='tokenText'>{token}</div>
-<p style='color:#34c759; font-weight:bold; font-size:15px'>\u2705 Token copied to clipboard!</p>
-<p style='margin-top:10px'>You can close this window when done.</p>
+<div style='display:flex; gap:10px; margin-top:5px'>
+  <a href='pypowerwall://copy' style='flex:1; text-decoration:none'>
+    <button class='copy-btn' id='copyBtn' style='width:100%' onclick="
+      document.getElementById('copyBtn').textContent = '\u2705 Copied!';
+      document.getElementById('copyBtn').style.background = '#34c759';
+      setTimeout(function(){{
+        document.getElementById('copyBtn').textContent = 'Copy Token';
+        document.getElementById('copyBtn').style.background = '#0071e3';
+      }}, 2500);
+    ">Copy Token</button>
+  </a>
+  <a href='pypowerwall://close' style='flex:1; text-decoration:none'>
+    <button style='width:100%; background:#636366; color:white; border:none; border-radius:8px;
+      padding:10px 20px; font-size:15px; cursor:pointer'>Close Window</button>
+  </a>
+</div>
 </body></html>"""
                             def load_success():
                                 webview_ref[0].loadHTMLString_baseURL_(success_html, None)

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -171,12 +171,12 @@ def _remote_login() -> str:
 # Path 2 — Local login (native WebView with navigation interception)
 # ---------------------------------------------------------------------------
 
-def _local_login(email: str = None, region: str = "us", debug: bool = False) -> str:
-    """Local login via native WebView, intercepting tesla:// redirect."""
+def _local_login(email: str = None, region: str = "us", debug: bool = False):
+    """Local login via native WebView. Returns (refresh_token, email) tuple."""
     if sys.platform == "darwin":
         return _local_login_macos(email, region, debug=debug)
     else:
-        return _local_login_pywebview(email, region)
+        return _local_login_pywebview(email, region), ""
 
 
 # ---------------------------------------------------------------------------
@@ -285,6 +285,10 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                             token = data["refresh_token"] if isinstance(data, dict) else data
                             dbg(f"Token exchange succeeded, token length: {len(token)}")
                             result["token"] = token
+                            # Extract email from id_token if available
+                            if isinstance(data, dict) and data.get("id_token"):
+                                result["email"] = _extract_email_from_token(data["id_token"])
+                                dbg(f"Email from id_token: {result['email']}")
                             # Copy to macOS clipboard via NSPasteboard
                             try:
                                 pb = AppKit.NSPasteboard.generalPasteboard()
@@ -403,7 +407,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
         raise RuntimeError(result["error"])
     if not result["token"]:
         raise RuntimeError("Login cancelled - no token received.")
-    return result["token"]
+    return result["token"], result.get("email", "")
 
 
 def _local_login_pywebview(email: str = None, region: str = "us") -> str:
@@ -565,33 +569,34 @@ def _patch_pywebview_gtk(result, expected_state):
 # Public API
 # ---------------------------------------------------------------------------
 
-def login(email: str = None, headless: bool = False, region: str = "us", debug: bool = False) -> str:
-    """Authenticate with Tesla and return a refresh token."""
+def login(email: str = None, headless: bool = False, region: str = "us", debug: bool = False):
+    """Authenticate with Tesla. Returns (refresh_token, email) tuple."""
     if headless or _detect_mode() == "remote":
-        return _remote_login()
+        return _remote_login(), ""
     return _local_login(email=email, region=region, debug=debug)
 
 
 def get_authtoken(region: str = "us", debug: bool = False) -> str:
     """Get a refresh token for the authtoken CLI command (no file save)."""
-    return _local_login(region=region, debug=debug)
+    token, _ = _local_login(region=region, debug=debug)
+    return token
 
 
 def _extract_email_from_token(token: str) -> str:
-    """Try to extract email from the JWT refresh token payload."""
+    """Extract email from a JWT id_token payload."""
     try:
         import base64, json
         parts = token.split('.')
         if len(parts) >= 2:
-            payload = parts[1] + '=='  # pad
-            data = json.loads(base64.urlsafe_b64decode(payload))
-            # Check nested data.sub or email fields
-            return (data.get('data', {}).get('email') or
-                    data.get('email') or
-                    data.get('data', {}).get('sub', '') or '')
+            # Add padding
+            padded = parts[1] + '=' * (4 - len(parts[1]) % 4)
+            data = json.loads(base64.urlsafe_b64decode(padded))
+            return (data.get('email') or
+                    data.get('data', {}).get('email') or '')
     except Exception:
         pass
     return ''
+''
 
 
 def save_token(refresh_token: str, path: str = None, email: str = None):

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -241,7 +241,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                     except Exception as e:
                         dbg(f"Clipboard error: {e}")
                 elif action == "close":
-                    AppHelper.callAfter(AppHelper.stopEventLoop)
+                    AppHelper.callAfter(_stop_runloop)
                 handler(0)
                 return
 
@@ -257,7 +257,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                         result["error"] = f"Tesla auth error: {error}"
                         dbg(f"Auth error from Tesla: {error}")
                         handler(0)
-                        AppHelper.callAfter(AppHelper.stopEventLoop)
+                        AppHelper.callAfter(_stop_runloop)
                         return
 
                     code = params.get("code", [None])[0]
@@ -267,14 +267,14 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                     if not code:
                         result["error"] = f"No auth code in redirect: {url}"
                         handler(0)
-                        AppHelper.callAfter(AppHelper.stopEventLoop)
+                        AppHelper.callAfter(_stop_runloop)
                         return
 
                     if returned_state != state:
                         result["error"] = "CSRF state mismatch"
                         dbg(f"State mismatch: got {returned_state!r} expected {state!r}")
                         handler(0)
-                        AppHelper.callAfter(AppHelper.stopEventLoop)
+                        AppHelper.callAfter(_stop_runloop)
                         return
 
                     dbg("Auth code captured — exchanging for token...")
@@ -351,14 +351,14 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                             exchange_done.set()
                             # Stop event loop so run_window() returns and token is saved
                             # The success page will already be loaded at this point
-                            AppHelper.callAfter(AppHelper.stopEventLoop)
+                            AppHelper.callAfter(_stop_runloop)
 
                     threading.Thread(target=do_exchange, daemon=True).start()
 
                 except Exception as e:
                     result["error"] = f"Failed to parse redirect: {e}"
                     dbg(f"Parse error: {e}")
-                    AppHelper.callAfter(AppHelper.stopEventLoop)
+                    AppHelper.callAfter(_stop_runloop)
 
                 handler(0)  # Cancel the tesla:// navigation
             else:
@@ -377,9 +377,18 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
         delegate.retain()
         webview_obj.setNavigationDelegate_(delegate)
 
+        def _stop_runloop():
+            AppKit.NSApplication.sharedApplication().stop_(None)
+            # Post dummy event to wake the run loop so stop_ takes effect
+            import Foundation
+            event = AppKit.NSEvent.otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2_(
+                15, Foundation.NSPoint(0, 0), 0, 0, 0, None, 0, 0, 0
+            )
+            AppKit.NSApplication.sharedApplication().postEvent_atStart_(event, True)
+
         class WindowDelegate(AppKit.NSObject):
             def windowWillClose_(self, notification):
-                AppHelper.stopEventLoop()
+                _stop_runloop()
         win_delegate = WindowDelegate.alloc().init()
         win_delegate.retain()
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -207,6 +207,19 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
     exchange_done = threading.Event()
     webview_ref = [None]  # mutable container so closure can access it
 
+    def _stop_runloop():
+        """Stop the NSApp run loop cleanly without terminating the process."""
+        app = AppKit.NSApplication.sharedApplication()
+        app.stop_(None)
+        # Post a dummy event to wake the run loop immediately
+        try:
+            dummy = AppKit.NSEvent.otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2_(
+                15, Foundation.NSPoint(0, 0), 0, 0, 0, None, 0, 0, 0
+            )
+            app.postEvent_atStart_(dummy, True)
+        except Exception:
+            pass
+
     def dbg(msg):
         if debug:
             print(f"  [debug] {msg}")
@@ -376,15 +389,6 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
         delegate = TeslaNavDelegate.alloc().init()
         delegate.retain()
         webview_obj.setNavigationDelegate_(delegate)
-
-        def _stop_runloop():
-            AppKit.NSApplication.sharedApplication().stop_(None)
-            # Post dummy event to wake the run loop so stop_ takes effect
-            import Foundation
-            event = AppKit.NSEvent.otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2_(
-                15, Foundation.NSPoint(0, 0), 0, 0, 0, None, 0, 0, 0
-            )
-            AppKit.NSApplication.sharedApplication().postEvent_atStart_(event, True)
 
         class WindowDelegate(AppKit.NSObject):
             def windowWillClose_(self, notification):

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -577,6 +577,23 @@ def get_authtoken(region: str = "us", debug: bool = False) -> str:
     return _local_login(region=region, debug=debug)
 
 
+def _extract_email_from_token(token: str) -> str:
+    """Try to extract email from the JWT refresh token payload."""
+    try:
+        import base64, json
+        parts = token.split('.')
+        if len(parts) >= 2:
+            payload = parts[1] + '=='  # pad
+            data = json.loads(base64.urlsafe_b64decode(payload))
+            # Check nested data.sub or email fields
+            return (data.get('data', {}).get('email') or
+                    data.get('email') or
+                    data.get('data', {}).get('sub', '') or '')
+    except Exception:
+        pass
+    return ''
+
+
 def save_token(refresh_token: str, path: str = None, email: str = None):
     """Save a refresh token to the pypowerwall auth file (.pypowerwall.auth).
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -1,6 +1,10 @@
 """
 pypowerwall.tesla_auth - Pure Python Tesla OAuth 2.0 PKCE authentication
 
+Uses a native WebView window (not a browser) to load Tesla's login page.
+Intercepts the tesla://auth/callback redirect via the WebView's navigation
+policy handler — the same technique used by tesla_auth (Rust/wry).
+
 Two login paths, auto-detected:
 
   Path 1 — Remote/Headless (no display):
@@ -9,7 +13,9 @@ Two login paths, auto-detected:
     paste the resulting refresh token.
 
   Path 2 — Local machine (display available):
-    Opens a native pywebview window for Tesla login. Captures the
+    Opens a native WebView window for Tesla login. On macOS, uses PyObjC
+    directly (WKWebView + WKNavigationDelegate). On Windows/Linux, uses
+    pywebview with a monkey-patched navigation handler. Captures the
     tesla:// callback, exchanges the auth code for a refresh token.
 
 CLI commands:
@@ -17,6 +23,7 @@ CLI commands:
     python -m pypowerwall authtoken   # local-only, print token to stdout
 
 Based on the OAuth 2.0 PKCE flow from tesla_auth (Rust) by Adrian Kumpf.
+https://github.com/adriankumpf/tesla_auth
 """
 
 import base64
@@ -35,11 +42,14 @@ except ImportError:
 
 # ---------------------------------------------------------------------------
 # Constants — match tesla_auth Rust exactly
+# See: https://github.com/adriankumpf/tesla_auth/blob/master/src/auth.rs
 # ---------------------------------------------------------------------------
 
-AUTH_HOST = "https://auth.tesla.com"
 CLIENT_ID = "ownerapi"
+AUTH_URL_PATH = "/oauth2/v3/authorize"
+TOKEN_URL_PATH = "/oauth2/v3/token"
 REDIRECT_URI = "tesla://auth/callback"
+SCOPES = "openid email offline_access"
 
 REGION_HOSTS = {
     "us": "https://auth.tesla.com",
@@ -52,7 +62,18 @@ REGION_HOSTS = {
 # ---------------------------------------------------------------------------
 
 def _build_auth_url(region: str = "us"):
-    """Build Tesla OAuth URL with PKCE parameters. Returns (url, code_verifier, state)."""
+    """Build Tesla OAuth URL with PKCE parameters.
+
+    Returns (url, code_verifier, state).
+
+    Matches tesla_auth exactly:
+    - client_id = "ownerapi"
+    - code_challenge_method = "S256"
+    - PKCE code_verifier = urlsafe_b64encode(random 32 bytes, no padding)
+    - code_challenge = urlsafe_b64encode(sha256(verifier), no padding)
+    - scopes: openid email offline_access
+    - redirect_uri: tesla://auth/callback
+    """
     auth_host = REGION_HOSTS.get(region, REGION_HOSTS["us"])
 
     code_verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
@@ -67,21 +88,27 @@ def _build_auth_url(region: str = "us"):
         "code_challenge_method": "S256",
         "redirect_uri": REDIRECT_URI,
         "response_type": "code",
-        "scope": "openid email offline_access",
+        "scope": SCOPES,
         "state": state,
     }
-    auth_url = f"{auth_host}/oauth2/v3/authorize?" + urllib.parse.urlencode(params)
+    auth_url = f"{auth_host}{AUTH_URL_PATH}?" + urllib.parse.urlencode(params)
     return auth_url, code_verifier, state
 
 
-def _exchange_code(auth_code: str, code_verifier: str, region: str = "us") -> str:
-    """Exchange authorization code for a refresh token. Returns refresh_token string."""
+def _exchange_code(auth_code: str, code_verifier: str, region: str = "us") -> dict:
+    """Exchange authorization code for tokens.
+
+    Returns the full token response dict (contains access_token, refresh_token, etc.).
+
+    Matches tesla_auth: POST to /oauth2/v3/token with grant_type=authorization_code,
+    client_id=ownerapi, code, code_verifier, redirect_uri.
+    """
     if requests is None:
         raise ImportError("The 'requests' package is required. Install with: pip install requests")
 
     auth_host = REGION_HOSTS.get(region, REGION_HOSTS["us"])
     resp = requests.post(
-        f"{auth_host}/oauth2/v3/token",
+        f"{auth_host}{TOKEN_URL_PATH}",
         json={
             "grant_type": "authorization_code",
             "client_id": CLIENT_ID,
@@ -98,7 +125,7 @@ def _exchange_code(auth_code: str, code_verifier: str, region: str = "us") -> st
     if "refresh_token" not in data:
         raise RuntimeError(f"No refresh_token in response: {data}")
 
-    return data["refresh_token"]
+    return data
 
 
 # ---------------------------------------------------------------------------
@@ -106,11 +133,7 @@ def _exchange_code(auth_code: str, code_verifier: str, region: str = "us") -> st
 # ---------------------------------------------------------------------------
 
 def _detect_mode() -> str:
-    """Detect whether we're in a local or remote session.
-
-    Returns 'remote' if SSH env vars are set or DISPLAY is empty on Linux,
-    otherwise 'local'.
-    """
+    """Detect whether we're in a local or remote session."""
     if os.environ.get("SSH_CLIENT") or os.environ.get("SSH_TTY"):
         return "remote"
     if sys.platform == "linux" and not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
@@ -133,126 +156,343 @@ def _remote_login() -> str:
     print()
     print("    python -m pypowerwall authtoken")
     print()
-    print("That will open a browser window, log you in, and print")
-    print("your refresh token.")
-    print()
-    print("Paste the token here when ready:")
+    print("That will open a login window. After authentication,")
+    print("copy the refresh token and paste it here.")
     print()
 
     while True:
-        token = input("Token: ").strip()
+        token = input("Refresh token: ").strip()
         if token:
             return token
         print("   ⚠️  Token cannot be empty — try again.")
 
 
 # ---------------------------------------------------------------------------
-# Path 2 — Local login (pywebview)
+# Path 2 — Local login (native WebView with navigation interception)
 # ---------------------------------------------------------------------------
 
 def _local_login(email: str = None, region: str = "us") -> str:
-    """Local login via pywebview, intercepting Tesla's fetch() token exchange.
+    """Local login via native WebView, intercepting tesla:// redirect.
 
-    Instead of fighting the tesla:// custom URI scheme (which WKWebView blocks),
-    we intercept the fetch()/XHR call Tesla's JS makes to /oauth2/v3/token after
-    login. The response contains the refresh_token directly — no redirect needed.
+    Platform dispatch:
+    - macOS: PyObjC WKWebView with custom WKNavigationDelegate
+    - Windows/Linux: pywebview with monkey-patched navigation handler
+
+    Both approaches use the same technique as tesla_auth (Rust):
+    register a navigation policy handler that intercepts the tesla://
+    custom scheme redirect, extracts the auth code, and cancels the
+    navigation before the WebView rejects it.
     """
-    import threading, time
+    if sys.platform == "darwin":
+        return _local_login_macos(email, region)
+    else:
+        return _local_login_pywebview(email, region)
+
+
+# ---------------------------------------------------------------------------
+# macOS — Native WKWebView via PyObjC
+# ---------------------------------------------------------------------------
+
+def _local_login_macos(email: str = None, region: str = "us") -> str:
+    """Native WKWebView on macOS with WKNavigationDelegate to intercept tesla://.
+
+    This mirrors exactly what tesla_auth's wry does on macOS:
+    1. Create a WKWebView in an NSWindow
+    2. Set a WKNavigationDelegate with webView:decidePolicyForNavigationAction:decisionHandler:
+    3. When the URL starts with "tesla://", capture it and cancel navigation
+    4. Extract the auth code from the URL
+    5. Exchange it for a refresh token
+    """
+    import threading
+    import AppKit
+    import WebKit
+    import Foundation
+    from PyObjCTools import AppHelper
+
+    auth_url, code_verifier, state = _build_auth_url(region)
+    if email:
+        auth_url += f"&login_hint={urllib.parse.quote(email)}"
+
+    result = {"token": None, "error": None}
+
+    class TeslaNavDelegate(AppKit.NSObject):
+        """WKNavigationDelegate that intercepts tesla:// redirects."""
+
+        def webView_decidePolicyForNavigationAction_decisionHandler_(
+            self, webview, action, handler
+        ):
+            try:
+                url = str(action.request().URL().absoluteString())
+            except Exception:
+                # If we can't get the URL, allow the navigation
+                handler(1)  # WKNavigationActionPolicyAllow
+                return
+
+            if url.startswith("tesla://"):
+                # Intercept! Extract auth code from the redirect URL
+                try:
+                    parsed = urllib.parse.urlparse(url)
+                    params = urllib.parse.parse_qs(parsed.query)
+
+                    # Check for error
+                    error = params.get("error", [None])[0]
+                    if error:
+                        result["error"] = f"Tesla auth error: {error}"
+                        handler(0)  # Cancel
+                        AppHelper.stopEventLoop()
+                        return
+
+                    # Check for login cancelled
+                    if params.get("error", [None])[0] == "login_cancelled":
+                        result["error"] = "Login cancelled by user"
+                        handler(0)
+                        AppHelper.stopEventLoop()
+                        return
+
+                    code = params.get("code", [None])[0]
+                    returned_state = params.get("state", [None])[0]
+
+                    if not code:
+                        result["error"] = f"No auth code in redirect: {url}"
+                        handler(0)
+                        AppHelper.stopEventLoop()
+                        return
+
+                    if returned_state != state:
+                        result["error"] = "CSRF state mismatch — possible attack"
+                        handler(0)
+                        AppHelper.stopEventLoop()
+                        return
+
+                    # Exchange code for token (in background to not block the delegate)
+                    def do_exchange():
+                        try:
+                            token_data = _exchange_code(code, code_verifier, region)
+                            result["token"] = token_data["refresh_token"]
+                        except Exception as e:
+                            result["error"] = f"Token exchange failed: {e}"
+                        finally:
+                            # Close the window
+                            AppHelper.stopEventLoop()
+
+                    threading.Thread(target=do_exchange, daemon=True).start()
+
+                except Exception as e:
+                    result["error"] = f"Failed to parse redirect: {e}"
+                    AppHelper.stopEventLoop()
+
+                handler(0)  # Cancel the tesla:// navigation
+            else:
+                # Allow all normal navigation (Tesla login pages, etc.)
+                handler(1)  # WKNavigationActionPolicyAllow
+
+    def run_window():
+        # Create WebView configuration
+        config = WebKit.WKWebViewConfiguration.alloc().init()
+
+        # Create WebView
+        webview = WebKit.WKWebView.alloc().initWithFrame_configuration_(
+            Foundation.NSMakeRect(0, 0, 500, 750),
+            config,
+        )
+
+        # Set navigation delegate
+        delegate = TeslaNavDelegate.alloc().init()
+        webview.setNavigationDelegate_(delegate)
+
+        # Create window
+        window = AppKit.NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
+            Foundation.NSMakeRect(100, 100, 500, 750),
+            (
+                AppKit.NSWindowStyleMaskTitled
+                | AppKit.NSWindowStyleMaskClosable
+                | AppKit.NSWindowStyleMaskResizable
+            ),
+            AppKit.NSBackingStoreBuffered,
+            False,
+        )
+        window.setContentView_(webview)
+        window.setTitle_("Tesla Login — pypowerwall")
+        window.makeKeyAndOrderFront_(None)
+
+        # Load the auth URL
+        req = Foundation.NSURLRequest.requestWithURL_(
+            Foundation.NSURL.URLWithString_(auth_url)
+        )
+        webview.loadRequest_(req)
+
+        # Run the event loop (blocks until stopEventLoop is called)
+        AppHelper.runEventLoop()
+
+    print("Opening Tesla login window...")
+    run_window()
+
+    if result["error"]:
+        raise RuntimeError(result["error"])
+    if not result["token"]:
+        raise RuntimeError("Login cancelled or timed out — no token received.")
+
+    print("  ✅ Refresh token captured!")
+    return result["token"]
+
+
+# ---------------------------------------------------------------------------
+# Windows/Linux — pywebview with monkey-patched navigation handler
+# ---------------------------------------------------------------------------
+
+def _local_login_pywebview(email: str = None, region: str = "us") -> str:
+    """pywebview login with navigation handler monkey-patch.
+
+    On Windows (WebView2) and Linux (WebKit2GTK), we use pywebview but
+    monkey-patch the platform-specific BrowserDelegate to intercept
+    tesla:// URLs in the navigation policy handler.
+
+    The monkey-patch wraps the original webView_decidePolicyForNavigationAction_decisionHandler_
+    (macOS) or the equivalent handler on other platforms, checking for tesla://
+    before delegating to the original logic.
+    """
+    import time
     try:
         import webview
     except ImportError:
         print("Installing pywebview...")
         import subprocess
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "pywebview>=4.0", "-q"])
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "pywebview>=4.0", "-q"]
+        )
         import webview
 
     auth_url, code_verifier, state = _build_auth_url(region)
     if email:
         auth_url += f"&login_hint={urllib.parse.quote(email)}"
 
-    result = {}
+    result = {"token": None, "error": None, "code": None}
 
-    # Inject JS that wraps fetch() and XHR to intercept the token exchange response.
-    # Tesla's completion page calls POST /oauth2/v3/token after the user logs in.
-    # We clone the response body and store refresh_token in window.__teslaRefreshToken.
-    # We poll this global from Python every 500ms.
-    INTERCEPT_JS = """
-(function() {
-    if (window.__teslaFetchPatched) return window.__teslaRefreshToken || '';
-    window.__teslaFetchPatched = true;
-    window.__teslaRefreshToken = null;
-    var _fetch = window.fetch;
-    window.fetch = function(url, opts) {
-        var p = _fetch.apply(this, arguments);
-        var urlStr = (typeof url === 'string') ? url : ((url && url.url) || '');
-        if (urlStr.indexOf('/oauth2/v3/token') !== -1 || urlStr.indexOf('auth.tesla') !== -1) {
-            p.then(function(resp) {
-                resp.clone().text().then(function(txt) {
-                    try {
-                        var d = JSON.parse(txt);
-                        if (d && d.refresh_token) window.__teslaRefreshToken = d.refresh_token;
-                    } catch(e) {}
-                });
-            }).catch(function() {});
-        }
-        return p;
-    };
-    var _xOpen = XMLHttpRequest.prototype.open;
-    var _xSend = XMLHttpRequest.prototype.send;
-    XMLHttpRequest.prototype.open = function(m, u) { this.__u = u; return _xOpen.apply(this, arguments); };
-    XMLHttpRequest.prototype.send = function() {
-        if (this.__u && (this.__u.indexOf('/oauth2/v3/token') !== -1 || this.__u.indexOf('auth.tesla') !== -1)) {
-            this.addEventListener('load', function() {
-                try {
-                    var d = JSON.parse(this.responseText);
-                    if (d && d.refresh_token) window.__teslaRefreshToken = d.refresh_token;
-                } catch(e) {}
-            });
-        }
-        return _xSend.apply(this, arguments);
-    };
-    return window.__teslaRefreshToken || '';
-})();
-"""
+    # Monkey-patch pywebview's platform-specific navigation handler
+    _patch_pywebview_navigation(result, state)
 
-    POLL_JS = "window.__teslaRefreshToken || '';"
-
-    def on_loaded():
-        def poll():
-            for _ in range(240):  # 2 min
-                try:
-                    # First inject the patch, then poll
-                    window.evaluate_js(INTERCEPT_JS)
-                    token = window.evaluate_js(POLL_JS)
-                    if token and isinstance(token, str) and len(token) > 20:
-                        result['refresh_token'] = token
-                        try:
-                            window.destroy()
-                        except Exception:
-                            pass
-                        return
-                except Exception:
-                    pass
-                time.sleep(0.5)
-        t = threading.Thread(target=poll, daemon=True)
-        t.start()
-
-    print("Opening Tesla login window...")
     window = webview.create_window(
-        "Tesla Login \u2014 pypowerwall",
+        "Tesla Login — pypowerwall",
         auth_url,
         width=500,
         height=750,
     )
-    window.events.loaded += on_loaded
+
+    def poll_token():
+        """Poll for the auth code and exchange it for a token."""
+        for _ in range(360):  # 3 minutes
+            if result["code"]:
+                try:
+                    token_data = _exchange_code(
+                        result["code"], code_verifier, region
+                    )
+                    result["token"] = token_data["refresh_token"]
+                except Exception as e:
+                    result["error"] = f"Token exchange failed: {e}"
+                try:
+                    window.destroy()
+                except Exception:
+                    pass
+                return
+            time.sleep(0.5)
+
+    import threading
+    poller = threading.Thread(target=poll_token, daemon=True)
+    poller.start()
+
+    print("Opening Tesla login window...")
     webview.start()
 
-    refresh_token = result.get('refresh_token')
-    if not refresh_token:
+    if result["error"]:
+        raise RuntimeError(result["error"])
+    if not result["token"]:
         raise RuntimeError("Login cancelled or timed out — no token received.")
 
-    print("  \u2705 Refresh token captured!")
-    return refresh_token
+    print("  ✅ Refresh token captured!")
+    return result["token"]
+
+
+def _patch_pywebview_navigation(result, expected_state):
+    """Monkey-patch pywebview's navigation handler to intercept tesla:// URLs.
+
+    This wraps the platform-specific navigation policy delegate to check
+    for tesla:// URLs before delegating to the original handler.
+    """
+    import sys
+
+    if sys.platform == "darwin":
+        _patch_pywebview_cocoa(result, expected_state)
+    elif sys.platform == "win32":
+        _patch_pywebview_win32(result, expected_state)
+    else:
+        _patch_pywebview_gtk(result, expected_state)
+
+
+def _patch_pywebview_cocoa(result, expected_state):
+    """Patch pywebview's macOS BrowserDelegate to intercept tesla:// URLs."""
+    try:
+        from webview.platforms import cocoa
+    except ImportError:
+        return
+
+    BrowserDelegate = cocoa.BrowserView.BrowserDelegate
+
+    # Get the original navigation handler
+    original_handler = BrowserDelegate.webView_decidePolicyForNavigationAction_decisionHandler_
+
+    def patched_handler(self, webview, action, handler):
+        try:
+            url = str(action.request().URL().absoluteString())
+            if url.startswith("tesla://"):
+                parsed = urllib.parse.urlparse(url)
+                params = urllib.parse.parse_qs(parsed.query)
+
+                if params.get("error", [None])[0] == "login_cancelled":
+                    result["error"] = "Login cancelled by user"
+                    handler(0)
+                    return
+
+                code = params.get("code", [None])[0]
+                returned_state = params.get("state", [None])[0]
+
+                if code and returned_state == expected_state:
+                    result["code"] = code
+                elif code:
+                    result["error"] = "CSRF state mismatch"
+
+                handler(0)  # Cancel navigation
+                return
+        except Exception:
+            pass
+
+        # Fall through to original handler for non-tesla:// URLs
+        original_handler(self, webview, action, handler)
+
+    BrowserDelegate.webView_decidePolicyForNavigationAction_decisionHandler_ = patched_handler
+
+
+def _patch_pywebview_win32(result, expected_state):
+    """Patch pywebview's Windows WebView2 handler to intercept tesla:// URLs."""
+    try:
+        from webview.platforms import winforms
+        # WebView2 fires a SourceChanged event or we can use the
+        # CoreWebView2.NavigationStarting event.
+        # For now, we'll use a JS-based approach as fallback on Windows,
+        # since the winforms backend may not expose navigation policy directly.
+        # TODO: Implement WebView2 navigation interception for Windows.
+    except ImportError:
+        pass
+
+
+def _patch_pywebview_gtk(result, expected_state):
+    """Patch pywebview's Linux WebKit2GTK handler to intercept tesla:// URLs."""
+    try:
+        from webview.platforms import gtk
+        # WebKit2GTK uses "decide-policy" signal on the WebView.
+        # pywebview's BrowserView connects this signal.
+        # TODO: Implement WebKit2GTK navigation interception for Linux.
+    except ImportError:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -264,7 +504,7 @@ def login(email: str = None, headless: bool = False, region: str = "us") -> str:
 
     Auto-detects local vs remote environment. On remote sessions (or if
     ``headless=True``), uses the paste-token flow. Otherwise opens a
-    pywebview window for browser login.
+    native WebView window for login.
 
     Args:
         email: Tesla account email (optional, used as login hint).
@@ -283,7 +523,7 @@ def login(email: str = None, headless: bool = False, region: str = "us") -> str:
 def get_authtoken(region: str = "us") -> str:
     """Get a refresh token for the ``authtoken`` CLI command.
 
-    Always uses the local pywebview path (no file saving). The caller
+    Always uses the local WebView path (no file saving). The caller
     is responsible for displaying or using the token.
     """
     return _local_login(region=region)

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -179,25 +179,53 @@ def _local_login(email: str = None, region: str = "us") -> str:
         height=750,
     )
 
-    def on_before_load(window, url):
-        """Fires before WKWebView navigates to any URL.
-        pywebview calls with (window, url) when function has 'window' parameter.
-        When Tesla redirects to tesla://auth/callback, capture code and cancel.
-        """
-        if url and url.startswith("tesla://"):
-            parsed = urllib.parse.urlparse(url)
-            params = urllib.parse.parse_qs(parsed.query)
-            code = params.get("code", [None])[0]
-            if code:
-                result["code"] = code
-                try:
-                    window.destroy()
-                except Exception:
-                    pass
-            return False  # cancel navigation
-        return True  # allow all other navigation
+    # Use a JS polling approach: inject a MutationObserver that watches for
+    # Tesla's redirect attempt by overriding XMLHttpRequest and fetch,
+    # then poll evaluate_js every 300ms to read window.__teslaCode
+    js_inject = """
+    if (!window.__teslaPatch) {
+        window.__teslaPatch = true;
+        window.__teslaCode = null;
+        var _origOpen = XMLHttpRequest.prototype.open;
+        // Patch fetch to intercept token responses
+        var _origFetch = window.fetch;
+        window.fetch = function(url, opts) {
+            var p = _origFetch.apply(this, arguments);
+            if (url && url.indexOf('/oauth2/v3/token') > -1) {
+                p.then(function(r) {
+                    r.clone().json().then(function(d) {
+                        if (d && d.refresh_token) window.__teslaRefresh = d.refresh_token;
+                    });
+                });
+            }
+            return p;
+        };
+    }
+    window.__teslaCode || window.__teslaRefresh || '';
+    """
 
-    window.events.before_load += on_before_load
+    import threading, time
+
+    def poll():
+        for _ in range(600):
+            try:
+                val = window.evaluate_js(js_inject)
+                if val and val not in ('', 'null', None):
+                    result['value'] = val
+                    try:
+                        window.destroy()
+                    except Exception:
+                        pass
+                    return
+            except Exception:
+                pass
+            time.sleep(0.3)
+
+    def on_loaded():
+        t = threading.Thread(target=poll, daemon=True)
+        t.start()
+
+    window.events.loaded += on_loaded
     webview.start()
 
     auth_code = result.get("code")

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """
 pypowerwall.tesla_auth - Pure Python Tesla OAuth 2.0 PKCE authentication
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -388,7 +388,11 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
 
         class WindowDelegate(AppKit.NSObject):
             def windowWillClose_(self, notification):
-                AppKit.NSApplication.sharedApplication().stop_(None)
+                app = AppKit.NSApplication.sharedApplication()
+                window = notification.object()
+                window.orderOut_(None)  # ensure window disappears immediately
+                app.hide_(None)  # return focus to previous app
+                app.stop_(None)
         win_delegate = WindowDelegate.alloc().init()
         win_delegate.retain()
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -179,15 +179,11 @@ def _local_login(email: str = None, region: str = "us") -> str:
         height=750,
     )
 
-    def on_before_load(*args):
+    def on_before_load(window, url):
         """Fires before WKWebView navigates to any URL.
-        When Tesla redirects to tesla://auth/callback, we capture the code here
-        and cancel navigation by returning False.
+        pywebview calls with (window, url) when function has 'window' parameter.
+        When Tesla redirects to tesla://auth/callback, capture code and cancel.
         """
-        # pywebview passes (window, url) or just (url,) depending on version
-        url = next((a for a in args if isinstance(a, str) and a.startswith('http')), None)
-        if url is None:
-            url = next((a for a in args if isinstance(a, str)), None)
         if url and url.startswith("tesla://"):
             parsed = urllib.parse.urlparse(url)
             params = urllib.parse.parse_qs(parsed.query)

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -334,6 +334,9 @@ def _login_interactive(
     except TimeoutError:
         return None
 
+    if result is None:
+        return None
+
     if "error" in result:
         print(f"  Error from Tesla: {result['error']}")
         return None

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -151,49 +151,34 @@ def _remote_login() -> str:
 # ---------------------------------------------------------------------------
 
 def _local_login(email: str = None, region: str = "us") -> str:
-    """Local login: open pywebview window, capture callback, exchange for token.
-
-    Returns refresh_token string.
-    """
+    """Local login: open pywebview window, capture callback, exchange for token."""
     try:
-        import webview  # noqa: F401
+        import webview
     except ImportError:
-        print("⚠️  pywebview is not installed.")
-        print("   Installing pywebview for native browser login...")
-        import subprocess
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "pywebview", "--quiet"]
-        )
-        print("   ✅ pywebview installed.\n")
-        # Re-import after install
+        print("Installing pywebview...")
+        import subprocess, sys
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "pywebview", "-q"])
         import webview
 
     auth_url, code_verifier, state = _build_auth_url(region)
-
     if email:
-        # Append login_hint for a smoother UX
         auth_url += f"&login_hint={urllib.parse.quote(email)}"
-
-    import threading
-    import time
 
     result = {}
     window_holder = {}
 
-    # Key insight: window.pywebview.api is async and may not complete before
-    # the failed tesla:// navigation. Instead, store URL in a plain JS global
-    # (synchronous), then poll it from a Python background thread.
+    # Use localStorage instead of a global — persists across page reloads/navigations
     intercept_js = """
     (function() {
         if (window.__teslaAuthPatched) return;
         window.__teslaAuthPatched = true;
-        window.__teslaUrl = null;
-
+        
         function capture(url) {
-            window.__teslaUrl = url;  // synchronous — always works
+            try {
+                window.localStorage.setItem('__teslaUrl', url);
+            } catch(e) {}
         }
-
-        // Override Location.prototype.href setter
+        
         try {
             var desc = Object.getOwnPropertyDescriptor(Location.prototype, 'href');
             if (desc && desc.set) {
@@ -207,8 +192,7 @@ def _local_login(email: str = None, region: str = "us") -> str:
                 });
             }
         } catch(e) {}
-
-        // Override location.assign and location.replace
+        
         try {
             var _assign = Location.prototype.assign;
             Location.prototype.assign = function(url) {
@@ -221,8 +205,7 @@ def _local_login(email: str = None, region: str = "us") -> str:
                 return _replace.call(this, url);
             };
         } catch(e) {}
-
-        // Override window.open
+        
         try {
             var _open = window.open;
             window.open = function(url, t, f) {
@@ -233,23 +216,26 @@ def _local_login(email: str = None, region: str = "us") -> str:
     })();
     """
 
-    def on_loaded():
+    def inject():
         try:
             window_holder["window"].evaluate_js(intercept_js)
-        except Exception:
-            pass
+            print("  [debug] JS injected successfully")
+        except Exception as e:
+            print(f"  [debug] JS inject error: {e}")
 
-    def poll_for_callback():
-        """Poll window.__teslaUrl via evaluate_js every 100ms.
-        Works even when tesla:// navigation fails — the page stays loaded
-        so window.__teslaUrl remains readable."""
-        for _ in range(1200):  # up to 120 seconds
+    def poll():
+        """Poll localStorage for the tesla:// URL."""
+        import time
+        for i in range(1200):  # 120 seconds max
             if not window_holder.get("window"):
                 time.sleep(0.1)
                 continue
             try:
-                url = window_holder["window"].evaluate_js('window.__teslaUrl || ""')
+                url = window_holder["window"].evaluate_js(
+                    'window.localStorage.getItem("__teslaUrl") || ""'
+                )
                 if url and url.startswith("tesla://"):
+                    print(f"  [debug] Got tesla:// URL at poll {i}: {url[:80]}...")
                     parsed = urllib.parse.urlparse(url)
                     params = urllib.parse.parse_qs(parsed.query)
                     code = params.get("code", [None])[0]
@@ -260,31 +246,35 @@ def _local_login(email: str = None, region: str = "us") -> str:
                         except Exception:
                             pass
                         return
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"  [debug] Poll error: {e}")
             time.sleep(0.1)
+        print("  [debug] Poll timed out after 120s")
 
     print("Opening Tesla login window...")
+    print("  [debug] Creating window...")
     window = webview.create_window(
         "Tesla Login — pypowerwall", auth_url, width=500, height=750
     )
     window_holder["window"] = window
-    window.events.loaded += on_loaded
-
-    t = threading.Thread(target=poll_for_callback, daemon=True)
+    window.events.loaded += inject
+    
+    import threading
+    t = threading.Thread(target=poll, daemon=True)
     t.start()
-
+    
+    print("  [debug] Starting webview...")
     webview.start()
+    print(f"  [debug] webview.start() returned, result code present: {bool(result.get('code'))}")
 
     auth_code = result.get("code")
     if not auth_code:
         raise RuntimeError("Login cancelled or timed out — no authorization code received.")
 
-    print("  ✅ Authorization code captured!")
+    print("  Authorization code captured!")
     print("  Exchanging for refresh token...")
     refresh_token = _exchange_code(auth_code, code_verifier, region)
     return refresh_token
-
 
 # ---------------------------------------------------------------------------
 # Public API

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -174,53 +174,36 @@ def _local_login(email: str = None, region: str = "us") -> str:
         # Append login_hint for a smoother UX
         auth_url += f"&login_hint={urllib.parse.quote(email)}"
 
+    import threading
+    import time
+
     result = {}
-
-    class TeslaAuthApi:
-        """JS API bridge — called from injected JS when tesla:// redirect fires."""
-        def __init__(self, window_holder):
-            self.window_holder = window_holder
-
-        def capture(self, url):
-            parsed = urllib.parse.urlparse(url)
-            params = urllib.parse.parse_qs(parsed.query)
-            result["code"] = params.get("code", [None])[0]
-            self.window_holder["window"].destroy()
-
     window_holder = {}
-    api = TeslaAuthApi(window_holder)
 
-    # JS injected on EVERY page load — intercepts all tesla:// navigation methods:
-    # window.open, anchor clicks, location.href setter, location.assign, location.replace
+    # Key insight: window.pywebview.api is async and may not complete before
+    # the failed tesla:// navigation. Instead, store URL in a plain JS global
+    # (synchronous), then poll it from a Python background thread.
     intercept_js = """
     (function() {
         if (window.__teslaAuthPatched) return;
         window.__teslaAuthPatched = true;
+        window.__teslaUrl = null;
 
         function capture(url) {
-            if (window.pywebview && window.pywebview.api) {
-                window.pywebview.api.capture(url);
-            }
+            window.__teslaUrl = url;  // synchronous — always works
         }
-
-        // Override window.open
-        var _open = window.open;
-        window.open = function(url, target, features) {
-            if (url && url.indexOf('tesla://') === 0) { capture(url); return; }
-            return _open.apply(this, arguments);
-        };
 
         // Override Location.prototype.href setter
         try {
-            var _locDesc = Object.getOwnPropertyDescriptor(Location.prototype, 'href');
-            if (_locDesc && _locDesc.set) {
+            var desc = Object.getOwnPropertyDescriptor(Location.prototype, 'href');
+            if (desc && desc.set) {
                 Object.defineProperty(Location.prototype, 'href', {
-                    get: _locDesc.get,
+                    get: desc.get,
                     set: function(val) {
                         if (val && val.indexOf('tesla://') === 0) { capture(val); return; }
-                        _locDesc.set.call(this, val);
+                        desc.set.call(this, val);
                     },
-                    configurable: true, enumerable: true
+                    configurable: true
                 });
             }
         } catch(e) {}
@@ -239,32 +222,58 @@ def _local_login(email: str = None, region: str = "us") -> str:
             };
         } catch(e) {}
 
-        // Intercept anchor clicks
-        document.addEventListener('click', function(e) {
-            var el = e.target;
-            while (el) {
-                if (el.tagName === 'A' && el.href && el.href.indexOf('tesla://') === 0) {
-                    e.preventDefault(); capture(el.href); return;
-                }
-                el = el.parentElement;
-            }
-        }, true);
+        // Override window.open
+        try {
+            var _open = window.open;
+            window.open = function(url, t, f) {
+                if (url && url.indexOf('tesla://') === 0) { capture(url); return; }
+                return _open.apply(this, arguments);
+            };
+        } catch(e) {}
     })();
     """
 
-    # Inject on EVERY page load so the completion page is also covered
     def on_loaded():
         try:
             window_holder["window"].evaluate_js(intercept_js)
         except Exception:
             pass
 
+    def poll_for_callback():
+        """Poll window.__teslaUrl via evaluate_js every 100ms.
+        Works even when tesla:// navigation fails — the page stays loaded
+        so window.__teslaUrl remains readable."""
+        for _ in range(1200):  # up to 120 seconds
+            if not window_holder.get("window"):
+                time.sleep(0.1)
+                continue
+            try:
+                url = window_holder["window"].evaluate_js('window.__teslaUrl || ""')
+                if url and url.startswith("tesla://"):
+                    parsed = urllib.parse.urlparse(url)
+                    params = urllib.parse.parse_qs(parsed.query)
+                    code = params.get("code", [None])[0]
+                    if code:
+                        result["code"] = code
+                        try:
+                            window_holder["window"].destroy()
+                        except Exception:
+                            pass
+                        return
+            except Exception:
+                pass
+            time.sleep(0.1)
+
     print("Opening Tesla login window...")
     window = webview.create_window(
-        "Tesla Login — pypowerwall", auth_url, width=500, height=750, js_api=api
+        "Tesla Login — pypowerwall", auth_url, width=500, height=750
     )
     window_holder["window"] = window
     window.events.loaded += on_loaded
+
+    t = threading.Thread(target=poll_for_callback, daemon=True)
+    t.start()
+
     webview.start()
 
     auth_code = result.get("code")

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -1,0 +1,517 @@
+"""
+pypowerwall.tesla_auth - Pure Python Tesla OAuth 2.0 PKCE authentication
+
+Replaces the external tesla_auth binary. Users can authenticate with Tesla
+and obtain refresh tokens using only Python — no Rust binary needed.
+
+Supports:
+  - Interactive browser login (opens browser, catches redirect via localhost)
+  - Headless/manual mode (prints URL, user pastes redirect URL back)
+  - Cross-platform: Linux, macOS, Windows, headless servers
+
+Usage:
+    python -m pypowerwall login
+    python -m pypowerwall login --headless
+    python -m pypowerwall login --email user@example.com
+    python -m pypowerwall login --region cn
+
+Or programmatically:
+    from pypowerwall.tesla_auth import login, save_token
+    refresh_token = login(email="user@example.com")
+    save_token(refresh_token)
+
+Based on the OAuth 2.0 PKCE flow from tesla_auth (Rust) by Adrian Kumpf.
+"""
+
+import base64
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import socket
+import sys
+import threading
+import urllib.parse
+import webbrowser
+
+try:
+    import requests
+except ImportError:
+    requests = None  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Constants — match tesla_auth exactly
+# ---------------------------------------------------------------------------
+
+CLIENT_ID = "ownerapi"
+
+AUTH_URL_US = "https://auth.tesla.com/oauth2/v3/authorize"
+TOKEN_URL_US = "https://auth.tesla.com/oauth2/v3/token"
+
+AUTH_URL_CN = "https://auth.tesla.cn/oauth2/v3/authorize"
+TOKEN_URL_CN = "https://auth.tesla.cn/oauth2/v3/token"
+
+# Tesla's custom URI scheme — used by the native tesla_auth app via WebView interception.
+# We do NOT use this directly; instead we try localhost or fall back to void/callback.
+REDIRECT_URL_CUSTOM = "tesla://auth/callback"
+
+# Tesla's void callback — shows "Page Not Found" but the URL contains the auth code.
+# This is what teslapy uses for the manual paste flow.
+REDIRECT_URL_VOID = "https://auth.tesla.com/void/callback"
+
+SCOPES = ["openid", "email", "offline_access"]
+
+REGION_CONFIG = {
+    "us": {
+        "auth_url": AUTH_URL_US,
+        "token_url": TOKEN_URL_US,
+        "void_redirect": "https://auth.tesla.com/void/callback",
+    },
+    "cn": {
+        "auth_url": AUTH_URL_CN,
+        "token_url": TOKEN_URL_CN,
+        "void_redirect": "https://auth.tesla.cn/void/callback",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# PKCE helpers
+# ---------------------------------------------------------------------------
+
+def generate_code_verifier() -> str:
+    """Generate a PKCE code_verifier (43-128 chars, base64url-encoded random bytes)."""
+    return secrets.token_urlsafe(86)  # 86 bytes → ~115 base64url chars
+
+
+def generate_code_challenge(code_verifier: str) -> str:
+    """Generate S256 code_challenge from code_verifier."""
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def generate_state() -> str:
+    """Generate a random state parameter for CSRF protection."""
+    return secrets.token_urlsafe(16)
+
+
+# ---------------------------------------------------------------------------
+# URL building
+# ---------------------------------------------------------------------------
+
+def build_auth_url(
+    code_challenge: str,
+    state: str,
+    region: str = "us",
+    redirect_uri: str = REDIRECT_URL_VOID,
+) -> str:
+    """Build the Tesla OAuth authorization URL."""
+    cfg = REGION_CONFIG.get(region, REGION_CONFIG["us"])
+    params = {
+        "client_id": CLIENT_ID,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": " ".join(SCOPES),
+        "state": state,
+    }
+    return f"{cfg['auth_url']}?{urllib.parse.urlencode(params)}"
+
+
+# ---------------------------------------------------------------------------
+# Token exchange
+# ---------------------------------------------------------------------------
+
+def exchange_code(
+    code: str,
+    code_verifier: str,
+    redirect_uri: str,
+    region: str = "us",
+) -> dict:
+    """
+    Exchange an authorization code for tokens.
+
+    Returns dict with: access_token, refresh_token, expires_in, token_type, etc.
+    Raises RuntimeError on failure.
+    """
+    if requests is None:
+        raise ImportError("The 'requests' package is required. Install with: pip install requests")
+
+    cfg = REGION_CONFIG.get(region, REGION_CONFIG["us"])
+    data = {
+        "grant_type": "authorization_code",
+        "client_id": CLIENT_ID,
+        "code": code,
+        "code_verifier": code_verifier,
+        "redirect_uri": redirect_uri,
+    }
+
+    resp = requests.post(cfg["token_url"], data=data, timeout=30)
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Token exchange failed (HTTP {resp.status_code}): {resp.text}"
+        )
+
+    result = resp.json()
+    if "refresh_token" not in result:
+        raise RuntimeError(f"No refresh_token in response: {result}")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Localhost redirect catcher
+# ---------------------------------------------------------------------------
+
+def _find_free_port() -> int:
+    """Find a free TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _RedirectHandler(http.server.BaseHTTPRequestHandler):
+    """HTTP handler that captures the OAuth redirect."""
+
+    auth_result = None  # type: ignore  # set by the handler
+    auth_event = None  # type: ignore  # threading.Event
+
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+
+        code = params.get("code", [None])[0]
+        state = params.get("state", [None])[0]
+        error = params.get("error", [None])[0]
+
+        if error:
+            self._respond(
+                400,
+                "<h1>Authentication Failed</h1>"
+                f"<p>Error: {error}</p>"
+                f"<p>You can close this window.</p>",
+            )
+            _RedirectHandler.auth_result = {"error": error}
+        elif code:
+            self._respond(
+                200,
+                "<h1>&#x2705; Authentication Successful!</h1>"
+                "<p>You can close this window and return to the terminal.</p>",
+            )
+            _RedirectHandler.auth_result = {"code": code, "state": state}
+        else:
+            self._respond(
+                400,
+                "<h1>Invalid Response</h1><p>No authorization code received.</p>",
+            )
+            _RedirectHandler.auth_result = {"error": "no_code"}
+
+        if _RedirectHandler.auth_event:
+            _RedirectHandler.auth_event.set()
+
+    def _respond(self, status: int, html: str):
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(html.encode())
+
+    def log_message(self, format, *args):
+        """Suppress default stderr logging."""
+        pass
+
+
+def _catch_redirect_on_localhost(port: int, timeout: int = 300) -> dict:
+    """Start a localhost HTTP server and wait for the OAuth redirect."""
+    _RedirectHandler.auth_result = None
+    _RedirectHandler.auth_event = threading.Event()
+
+    server = http.server.HTTPServer(("127.0.0.1", port), _RedirectHandler)
+    server.timeout = timeout
+
+    # Run server in a thread
+    server_thread = threading.Thread(target=server.handle_request, daemon=True)
+    server_thread.start()
+
+    # Wait for the redirect or timeout
+    if not _RedirectHandler.auth_event.wait(timeout=timeout):
+        server.server_close()
+        raise TimeoutError(
+            f"Timed out waiting for redirect after {timeout} seconds. "
+            "Try running with --headless instead."
+        )
+
+    server.server_close()
+    return _RedirectHandler.auth_result
+
+
+# ---------------------------------------------------------------------------
+# Main login function
+# ---------------------------------------------------------------------------
+
+def login(
+    email: str = None,
+    headless: bool = False,
+    region: str = "us",
+    timeout: int = 300,
+) -> str:
+    """
+    Authenticate with Tesla and return a refresh token.
+
+    Args:
+        email: Tesla account email (optional, will prompt if needed).
+        headless: If True, skip browser and use manual URL paste mode.
+        region: 'us' (default) or 'cn' for China.
+        timeout: Seconds to wait for browser redirect (default 300).
+
+    Returns:
+        refresh_token string.
+
+    Raises:
+        RuntimeError: On authentication failure.
+        TimeoutError: If redirect not received within timeout.
+    """
+    # Generate PKCE parameters
+    code_verifier = generate_code_verifier()
+    code_challenge = generate_code_challenge(code_verifier)
+    state = generate_state()
+
+    # Prompt for email if not provided
+    if not email:
+        email = input("Tesla account email: ").strip()
+        if not email or "@" not in email:
+            raise ValueError("A valid email address is required.")
+
+    print(f"\nTesla login for: {email}")
+    print("-" * 60)
+
+    # Try localhost redirect first (unless headless)
+    if not headless and _has_display():
+        refresh_token = _login_interactive(
+            code_verifier, code_challenge, state, region, email, timeout
+        )
+        if refresh_token:
+            return refresh_token
+        # Interactive failed — fall through to manual mode
+        print("\nFalling back to manual mode...")
+
+    # Headless / manual mode — use void/callback redirect
+    return _login_manual(code_verifier, code_challenge, state, region, email)
+
+
+def _has_display() -> bool:
+    """Check if a display is available for opening a browser."""
+    if sys.platform == "win32":
+        return True
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def _login_interactive(
+    code_verifier: str,
+    code_challenge: str,
+    state: str,
+    region: str,
+    email: str,
+    timeout: int,
+) -> str | None:
+    """Try interactive browser login with localhost redirect."""
+    port = _find_free_port()
+    redirect_uri = f"http://localhost:{port}/callback"
+
+    auth_url = build_auth_url(code_challenge, state, region, redirect_uri=redirect_uri)
+
+    print(f"Opening browser for Tesla login...")
+    print(f"If the browser doesn't open, visit:\n\n  {auth_url}\n")
+
+    # Open browser
+    webbrowser.open(auth_url)
+
+    # Wait for redirect
+    try:
+        result = _catch_redirect_on_localhost(port, timeout=timeout)
+    except TimeoutError:
+        return None
+
+    if "error" in result:
+        print(f"  Error from Tesla: {result['error']}")
+        return None
+
+    # Validate state
+    if result.get("state") != state:
+        print("  Error: CSRF state mismatch — possible tampering.")
+        return None
+
+    # Exchange code for tokens
+    print("  Exchanging authorization code for tokens...")
+    try:
+        tokens = exchange_code(result["code"], code_verifier, redirect_uri, region)
+    except Exception as e:
+        print(f"  Token exchange failed: {e}")
+        return None
+
+    refresh_token = tokens["refresh_token"]
+    print(f"  ✅ Refresh token obtained (expires in {tokens.get('expires_in', '?')}s)")
+    return refresh_token
+
+
+def _login_manual(
+    code_verifier: str,
+    code_challenge: str,
+    state: str,
+    region: str,
+    email: str,
+) -> str:
+    """Manual mode — user pastes the redirect URL from the browser."""
+    redirect_uri = REDIRECT_URL_VOID
+    auth_url = build_auth_url(code_challenge, state, region, redirect_uri=redirect_uri)
+
+    print("\nOpen the following URL in your browser to log into your Tesla account:\n")
+    print(f"  {auth_url}\n")
+    print(
+        "After logging in, you will be redirected to a 'Page Not Found' page.\n"
+        "Copy the FULL URL from your browser's address bar and paste it below.\n"
+    )
+
+    redirect_response = input("Enter the URL after login: ").strip()
+
+    # Parse the code and state from the redirect URL
+    parsed = urllib.parse.urlparse(redirect_response)
+    params = urllib.parse.parse_qs(parsed.query)
+
+    error = params.get("error", [None])[0]
+    if error:
+        raise RuntimeError(f"Tesla authentication error: {error}")
+
+    code = params.get("code", [None])[0]
+    returned_state = params.get("state", [None])[0]
+
+    if not code:
+        raise RuntimeError("No authorization code found in the redirect URL.")
+
+    if returned_state != state:
+        raise RuntimeError("CSRF state mismatch — possible tampering.")
+
+    print("  Exchanging authorization code for tokens...")
+    tokens = exchange_code(code, code_verifier, redirect_uri, region)
+
+    refresh_token = tokens["refresh_token"]
+    print(f"  ✅ Refresh token obtained (expires in {tokens.get('expires_in', '?')}s)")
+    return refresh_token
+
+
+# ---------------------------------------------------------------------------
+# Token storage — compatible with pypowerwall's existing auth format
+# ---------------------------------------------------------------------------
+
+def save_token(refresh_token: str, path: str = None, email: str = None):
+    """
+    Save a refresh token to pypowerwall's auth file.
+
+    The file format is a JSON dict keyed by email, compatible with teslapy's
+    cache format:
+        {
+            "user@example.com": {
+                "refresh_token": "...",
+                "access_token": "",
+                "expires_at": 0
+            }
+        }
+
+    Args:
+        refresh_token: The Tesla refresh token string.
+        path: Path to the auth file. Defaults to .pypowerwall.auth in current dir.
+        email: Email to key the token under. If None, prompts for input.
+    """
+    if not path:
+        path = os.path.join(os.getcwd(), ".pypowerwall.auth")
+
+    if not email:
+        email = input("Tesla account email: ").strip()
+
+    # Load existing data or start fresh
+    data = {}
+    if os.path.isfile(path):
+        try:
+            with open(path, "r") as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            data = {}
+
+    # Update with new token
+    data[email] = {
+        "refresh_token": refresh_token,
+        "access_token": "",
+        "expires_at": 0,
+    }
+
+    # Ensure directory exists
+    os.makedirs(os.path.dirname(path) if os.path.dirname(path) else ".", exist_ok=True)
+
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+    print(f"  Token saved to {path}")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    """CLI entry point for `python -m pypowerwall login`."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="pypowerwall login",
+        description="Authenticate with Tesla and obtain a refresh token",
+    )
+    parser.add_argument("--email", "-e", type=str, help="Tesla account email address")
+    parser.add_argument(
+        "--headless", "-H", action="store_true",
+        help="Manual mode — don't open browser, paste URL instead",
+    )
+    parser.add_argument(
+        "--region", "-r", type=str, default="us", choices=["us", "cn"],
+        help="Tesla region: 'us' (default) or 'cn' (China)",
+    )
+    parser.add_argument(
+        "--output", "-o", type=str, default=None,
+        help="Path to save the auth file (default: .pypowerwall.auth in current dir)",
+    )
+    parser.add_argument(
+        "--timeout", "-t", type=int, default=300,
+        help="Seconds to wait for browser redirect (default: 300)",
+    )
+
+    args = parser.parse_args()
+
+    print("⚡ Tesla Authentication — pypowerwall")
+    print("=" * 60)
+
+    try:
+        refresh_token = login(
+            email=args.email,
+            headless=args.headless,
+            region=args.region,
+            timeout=args.timeout,
+        )
+    except (KeyboardInterrupt, EOFError):
+        print("\n\nLogin cancelled.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n❌ Login failed: {e}")
+        sys.exit(1)
+
+    # Save the token
+    email = args.email or ""
+    save_token(refresh_token, path=args.output, email=email)
+
+    print("\n✅ Done! You can now use pypowerwall with cloud mode.")
+    print(f"   Run: python -m pypowerwall setup")
+
+
+if __name__ == "__main__":
+    main()

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -190,25 +190,61 @@ def _local_login(email: str = None, region: str = "us") -> str:
     window_holder = {}
     api = TeslaAuthApi(window_holder)
 
-    # JS injected on every page load — overrides window.open and link clicks
-    # to intercept the tesla:// redirect before the browser tries to launch it
+    # JS injected on EVERY page load — intercepts all tesla:// navigation methods:
+    # window.open, anchor clicks, location.href setter, location.assign, location.replace
     intercept_js = """
     (function() {
+        if (window.__teslaAuthPatched) return;
+        window.__teslaAuthPatched = true;
+
+        function capture(url) {
+            if (window.pywebview && window.pywebview.api) {
+                window.pywebview.api.capture(url);
+            }
+        }
+
+        // Override window.open
         var _open = window.open;
         window.open = function(url, target, features) {
-            if (url && url.indexOf('tesla://') === 0) {
-                window.pywebview.api.capture(url);
-                return;
-            }
-            return _open(url, target, features);
+            if (url && url.indexOf('tesla://') === 0) { capture(url); return; }
+            return _open.apply(this, arguments);
         };
+
+        // Override Location.prototype.href setter
+        try {
+            var _locDesc = Object.getOwnPropertyDescriptor(Location.prototype, 'href');
+            if (_locDesc && _locDesc.set) {
+                Object.defineProperty(Location.prototype, 'href', {
+                    get: _locDesc.get,
+                    set: function(val) {
+                        if (val && val.indexOf('tesla://') === 0) { capture(val); return; }
+                        _locDesc.set.call(this, val);
+                    },
+                    configurable: true, enumerable: true
+                });
+            }
+        } catch(e) {}
+
+        // Override location.assign and location.replace
+        try {
+            var _assign = Location.prototype.assign;
+            Location.prototype.assign = function(url) {
+                if (url && url.indexOf('tesla://') === 0) { capture(url); return; }
+                return _assign.call(this, url);
+            };
+            var _replace = Location.prototype.replace;
+            Location.prototype.replace = function(url) {
+                if (url && url.indexOf('tesla://') === 0) { capture(url); return; }
+                return _replace.call(this, url);
+            };
+        } catch(e) {}
+
+        // Intercept anchor clicks
         document.addEventListener('click', function(e) {
             var el = e.target;
             while (el) {
                 if (el.tagName === 'A' && el.href && el.href.indexOf('tesla://') === 0) {
-                    e.preventDefault();
-                    window.pywebview.api.capture(el.href);
-                    return;
+                    e.preventDefault(); capture(el.href); return;
                 }
                 el = el.parentElement;
             }
@@ -216,15 +252,20 @@ def _local_login(email: str = None, region: str = "us") -> str:
     })();
     """
 
+    # Inject on EVERY page load so the completion page is also covered
     def on_loaded():
-        window_holder["window"].evaluate_js(intercept_js)
+        try:
+            window_holder["window"].evaluate_js(intercept_js)
+        except Exception:
+            pass
 
     print("Opening Tesla login window...")
     window = webview.create_window(
         "Tesla Login — pypowerwall", auth_url, width=500, height=750, js_api=api
     )
     window_holder["window"] = window
-    webview.start(on_loaded)
+    window.events.loaded += on_loaded
+    webview.start()
 
     auth_code = result.get("code")
     if not auth_code:

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -207,18 +207,6 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
     exchange_done = threading.Event()
     webview_ref = [None]  # mutable container so closure can access it
 
-    def _stop_runloop():
-        """Stop the NSApp run loop cleanly without terminating the process."""
-        app = AppKit.NSApplication.sharedApplication()
-        app.stop_(None)
-        # Post a dummy event to wake the run loop immediately
-        try:
-            dummy = AppKit.NSEvent.otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2_(
-                15, Foundation.NSPoint(0, 0), 0, 0, 0, None, 0, 0, 0
-            )
-            app.postEvent_atStart_(dummy, True)
-        except Exception:
-            pass
 
     def dbg(msg):
         if debug:
@@ -254,7 +242,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                     except Exception as e:
                         dbg(f"Clipboard error: {e}")
                 elif action == "close":
-                    AppHelper.callAfter(_stop_runloop)
+                    AppKit.NSApplication.sharedApplication().stop_(None)
                 handler(0)
                 return
 
@@ -270,7 +258,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                         result["error"] = f"Tesla auth error: {error}"
                         dbg(f"Auth error from Tesla: {error}")
                         handler(0)
-                        AppHelper.callAfter(_stop_runloop)
+                        AppKit.NSApplication.sharedApplication().stop_(None)
                         return
 
                     code = params.get("code", [None])[0]
@@ -280,14 +268,14 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                     if not code:
                         result["error"] = f"No auth code in redirect: {url}"
                         handler(0)
-                        AppHelper.callAfter(_stop_runloop)
+                        AppKit.NSApplication.sharedApplication().stop_(None)
                         return
 
                     if returned_state != state:
                         result["error"] = "CSRF state mismatch"
                         dbg(f"State mismatch: got {returned_state!r} expected {state!r}")
                         handler(0)
-                        AppHelper.callAfter(_stop_runloop)
+                        AppKit.NSApplication.sharedApplication().stop_(None)
                         return
 
                     dbg("Auth code captured — exchanging for token...")
@@ -364,14 +352,14 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                             exchange_done.set()
                             # Stop event loop so run_window() returns and token is saved
                             # The success page will already be loaded at this point
-                            AppHelper.callAfter(_stop_runloop)
+                            AppKit.NSApplication.sharedApplication().stop_(None)
 
                     threading.Thread(target=do_exchange, daemon=True).start()
 
                 except Exception as e:
                     result["error"] = f"Failed to parse redirect: {e}"
                     dbg(f"Parse error: {e}")
-                    AppHelper.callAfter(_stop_runloop)
+                    AppKit.NSApplication.sharedApplication().stop_(None)
 
                 handler(0)  # Cancel the tesla:// navigation
             else:
@@ -392,7 +380,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
 
         class WindowDelegate(AppKit.NSObject):
             def windowWillClose_(self, notification):
-                _stop_runloop()
+                AppKit.NSApplication.sharedApplication().stop_(None)
         win_delegate = WindowDelegate.alloc().init()
         win_delegate.retain()
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -176,19 +176,55 @@ def _local_login(email: str = None, region: str = "us") -> str:
 
     result = {}
 
-    def on_navigated(window, url):
-        if url and url.startswith("tesla://"):
+    class TeslaAuthApi:
+        """JS API bridge — called from injected JS when tesla:// redirect fires."""
+        def __init__(self, window_holder):
+            self.window_holder = window_holder
+
+        def capture(self, url):
             parsed = urllib.parse.urlparse(url)
             params = urllib.parse.parse_qs(parsed.query)
             result["code"] = params.get("code", [None])[0]
-            window.destroy()
+            self.window_holder["window"].destroy()
+
+    window_holder = {}
+    api = TeslaAuthApi(window_holder)
+
+    # JS injected on every page load — overrides window.open and link clicks
+    # to intercept the tesla:// redirect before the browser tries to launch it
+    intercept_js = """
+    (function() {
+        var _open = window.open;
+        window.open = function(url, target, features) {
+            if (url && url.indexOf('tesla://') === 0) {
+                window.pywebview.api.capture(url);
+                return;
+            }
+            return _open(url, target, features);
+        };
+        document.addEventListener('click', function(e) {
+            var el = e.target;
+            while (el) {
+                if (el.tagName === 'A' && el.href && el.href.indexOf('tesla://') === 0) {
+                    e.preventDefault();
+                    window.pywebview.api.capture(el.href);
+                    return;
+                }
+                el = el.parentElement;
+            }
+        }, true);
+    })();
+    """
+
+    def on_loaded():
+        window_holder["window"].evaluate_js(intercept_js)
 
     print("Opening Tesla login window...")
     window = webview.create_window(
-        "Tesla Login — pypowerwall", auth_url, width=500, height=750
+        "Tesla Login — pypowerwall", auth_url, width=500, height=750, js_api=api
     )
-    window.events.navigated += on_navigated
-    webview.start()
+    window_holder["window"] = window
+    webview.start(on_loaded)
 
     auth_code = result.get("code")
     if not auth_code:

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -349,7 +349,9 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                             dbg(f"Token exchange error: {e}")
                         finally:
                             exchange_done.set()
-                            # Don't stop event loop — let user close the window manually
+                            # Stop event loop so run_window() returns and token is saved
+                            # The success page will already be loaded at this point
+                            AppHelper.callAfter(AppHelper.stopEventLoop)
 
                     threading.Thread(target=do_exchange, daemon=True).start()
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -267,13 +267,12 @@ def _local_login_macos(email: str = None, region: str = "us") -> str:
                     # Exchange code for token (in background to not block the delegate)
                     def do_exchange():
                         try:
-                            token_data = _exchange_code(code, code_verifier, region)
-                            result["token"] = token_data["refresh_token"]
+                            # _exchange_code returns a refresh_token string directly
+                            result["token"] = _exchange_code(code, code_verifier, region)
                         except Exception as e:
                             result["error"] = f"Token exchange failed: {e}"
                         finally:
-                            # Close the window
-                            AppHelper.stopEventLoop()
+                            AppHelper.callAfter(AppHelper.stopEventLoop)
 
                     threading.Thread(target=do_exchange, daemon=True).start()
 
@@ -287,22 +286,27 @@ def _local_login_macos(email: str = None, region: str = "us") -> str:
                 handler(1)  # WKNavigationActionPolicyAllow
 
     def run_window():
+        # Initialize NSApplication on the main thread
+        app = AppKit.NSApplication.sharedApplication()
+        app.setActivationPolicy_(AppKit.NSApplicationActivationPolicyRegular)
+
         # Create WebView configuration
         config = WebKit.WKWebViewConfiguration.alloc().init()
 
         # Create WebView
-        webview = WebKit.WKWebView.alloc().initWithFrame_configuration_(
+        webview_obj = WebKit.WKWebView.alloc().initWithFrame_configuration_(
             Foundation.NSMakeRect(0, 0, 500, 750),
             config,
         )
 
-        # Set navigation delegate
+        # Set navigation delegate (retain it so it's not GC'd)
         delegate = TeslaNavDelegate.alloc().init()
-        webview.setNavigationDelegate_(delegate)
+        delegate.retain()
+        webview_obj.setNavigationDelegate_(delegate)
 
         # Create window
-        window = AppKit.NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
-            Foundation.NSMakeRect(100, 100, 500, 750),
+        ns_window = AppKit.NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
+            Foundation.NSMakeRect(200, 200, 500, 750),
             (
                 AppKit.NSWindowStyleMaskTitled
                 | AppKit.NSWindowStyleMaskClosable
@@ -311,17 +315,21 @@ def _local_login_macos(email: str = None, region: str = "us") -> str:
             AppKit.NSBackingStoreBuffered,
             False,
         )
-        window.setContentView_(webview)
-        window.setTitle_("Tesla Login — pypowerwall")
-        window.makeKeyAndOrderFront_(None)
+        ns_window.setContentView_(webview_obj)
+        ns_window.setTitle_("Tesla Login \u2014 pypowerwall")
+        ns_window.makeKeyAndOrderFront_(None)
+        ns_window.retain()
 
         # Load the auth URL
         req = Foundation.NSURLRequest.requestWithURL_(
             Foundation.NSURL.URLWithString_(auth_url)
         )
-        webview.loadRequest_(req)
+        webview_obj.loadRequest_(req)
 
-        # Run the event loop (blocks until stopEventLoop is called)
+        # Activate the app so the window comes to front
+        app.activateIgnoringOtherApps_(True)
+
+        # Run the event loop (blocks until AppHelper.stopEventLoop is called)
         AppHelper.runEventLoop()
 
     print("Opening Tesla login window...")

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -179,11 +179,15 @@ def _local_login(email: str = None, region: str = "us") -> str:
         height=750,
     )
 
-    def on_before_load(url):
+    def on_before_load(*args):
         """Fires before WKWebView navigates to any URL.
         When Tesla redirects to tesla://auth/callback, we capture the code here
         and cancel navigation by returning False.
         """
+        # pywebview passes (window, url) or just (url,) depending on version
+        url = next((a for a in args if isinstance(a, str) and a.startswith('http')), None)
+        if url is None:
+            url = next((a for a in args if isinstance(a, str)), None)
         if url and url.startswith("tesla://"):
             parsed = urllib.parse.urlparse(url)
             params = urllib.parse.parse_qs(parsed.query)

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -223,7 +223,7 @@ class _RedirectHandler(http.server.BaseHTTPRequestHandler):
         pass
 
 
-def _catch_redirect_on_localhost(port: int, timeout: int = 300) -> dict:
+def _catch_redirect_on_localhost(port: int, timeout: int = 300) -> dict[str, str]:
     """Start a localhost HTTP server and wait for the OAuth redirect."""
     _RedirectHandler.auth_result = None
     _RedirectHandler.auth_event = threading.Event()
@@ -337,6 +337,7 @@ def _login_interactive(
     if result is None:
         return None
 
+    # pylint: disable=unsupported-membership-test,unsubscriptable-object
     if "error" in result:
         print(f"  Error from Tesla: {result['error']}")
         return None

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -260,8 +260,12 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
 
                     def do_exchange():
                         try:
-                            result["token"] = _exchange_code(code, code_verifier, region)
-                            dbg(f"Token exchange succeeded, token length: {len(result['token'])}")
+                            data = _exchange_code(code, code_verifier, region)
+                            # _exchange_code returns the full token dict
+                            token = data["refresh_token"] if isinstance(data, dict) else data
+                            dbg(f"Token exchange succeeded, token length: {len(token)}")
+                            dbg(f"Token preview: {token[:20]}...")
+                            result["token"] = token
                         except Exception as e:
                             result["error"] = f"Token exchange failed: {e}"
                             dbg(f"Token exchange error: {e}")

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -289,8 +289,31 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
 </style></head><body>
 <h2>\u2705 Authentication Successful</h2>
 <p>Your Tesla refresh token is ready. Copy it and paste it into your remote pypowerwall session.</p>
-<div class='token-box'>{token}</div>
-<button class='copy-btn' onclick="navigator.clipboard.writeText('{token}').then(()=>{{this.textContent='\u2705 Copied!';setTimeout(()=>{{this.textContent='Copy Token'}},2000)}})">
+<div class='token-box' id='tokenText'>{token}</div>
+<button class='copy-btn' id='copyBtn' onclick="
+  var btn = document.getElementById('copyBtn');
+  var txt = document.getElementById('tokenText').innerText;
+  try {{
+    navigator.clipboard.writeText(txt).then(function() {{
+      btn.textContent = '\u2705 Copied!';
+      btn.style.background = '#34c759';
+      setTimeout(function() {{ btn.textContent = 'Copy Token'; btn.style.background = '#0071e3'; }}, 3000);
+    }}).catch(function() {{
+      // Fallback: select text
+      var r = document.createRange(); r.selectNode(document.getElementById('tokenText'));
+      window.getSelection().removeAllRanges(); window.getSelection().addRange(r);
+      btn.textContent = '\u2705 Text Selected — Cmd+C to copy';
+      btn.style.background = '#34c759';
+      setTimeout(function() {{ btn.textContent = 'Copy Token'; btn.style.background = '#0071e3'; }}, 4000);
+    }});
+  }} catch(e) {{
+    var r = document.createRange(); r.selectNode(document.getElementById('tokenText'));
+    window.getSelection().removeAllRanges(); window.getSelection().addRange(r);
+    btn.textContent = '\u2705 Text Selected — Cmd+C to copy';
+    btn.style.background = '#34c759';
+    setTimeout(function() {{ btn.textContent = 'Copy Token'; btn.style.background = '#0071e3'; }}, 4000);
+  }}
+">
   Copy Token
 </button>
 <p style='margin-top:20px'>You can close this window when done.</p>

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -205,6 +205,7 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
 
     result = {"token": None, "error": None}
     exchange_done = threading.Event()
+    webview_ref = [None]  # mutable container so closure can access it
 
     def dbg(msg):
         if debug:
@@ -264,14 +265,45 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                             data = _exchange_code(code, code_verifier, region)
                             token = data["refresh_token"] if isinstance(data, dict) else data
                             dbg(f"Token exchange succeeded, token length: {len(token)}")
-                            dbg(f"Token preview: {token[:20]}...")
                             result["token"] = token
+                            # Print immediately to terminal
+                            print("\n" + "=" * 60)
+                            print("\u2705 Tesla Refresh Token:")
+                            print("-" * 60)
+                            print(token)
+                            print("-" * 60)
+                            print("Copy the token above. You can now close the window.")
+                            # Load success page in the WebView
+                            success_html = f"""<!DOCTYPE html><html><head>
+<meta charset='utf-8'>
+<style>
+  body {{ font-family: -apple-system, sans-serif; padding: 20px; background: #f5f5f7; }}
+  h2 {{ color: #1d1d1f; }}
+  .token-box {{ background: white; border: 1px solid #d2d2d7; border-radius: 10px;
+    padding: 15px; word-break: break-all; font-family: monospace; font-size: 11px;
+    color: #333; margin: 15px 0; }}
+  .copy-btn {{ background: #0071e3; color: white; border: none; border-radius: 8px;
+    padding: 10px 20px; font-size: 15px; cursor: pointer; width: 100%; }}
+  .copy-btn:active {{ background: #0077ed; }}
+  p {{ color: #6e6e73; font-size: 13px; }}
+</style></head><body>
+<h2>\u2705 Authentication Successful</h2>
+<p>Your Tesla refresh token is ready. Copy it and paste it into your remote pypowerwall session.</p>
+<div class='token-box'>{token}</div>
+<button class='copy-btn' onclick="navigator.clipboard.writeText('{token}').then(()=>{{this.textContent='\u2705 Copied!';setTimeout(()=>{{this.textContent='Copy Token'}},2000)}})">
+  Copy Token
+</button>
+<p style='margin-top:20px'>You can close this window when done.</p>
+</body></html>"""
+                            def load_success():
+                                webview_ref[0].loadHTMLString_baseURL_(success_html, None)
+                            AppHelper.callAfter(load_success)
                         except Exception as e:
                             result["error"] = f"Token exchange failed: {e}"
                             dbg(f"Token exchange error: {e}")
                         finally:
                             exchange_done.set()
-                            AppHelper.callAfter(AppHelper.stopEventLoop)
+                            # Don't stop event loop — let user close the window manually
 
                     threading.Thread(target=do_exchange, daemon=True).start()
 
@@ -286,70 +318,51 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                 handler(1)
 
     def run_window():
-        # Initialize NSApplication on the main thread
         app = AppKit.NSApplication.sharedApplication()
         app.setActivationPolicy_(AppKit.NSApplicationActivationPolicyRegular)
-
-        # Create WebView configuration
         config = WebKit.WKWebViewConfiguration.alloc().init()
-
-        # Create WebView
         webview_obj = WebKit.WKWebView.alloc().initWithFrame_configuration_(
-            Foundation.NSMakeRect(0, 0, 500, 750),
-            config,
+            Foundation.NSMakeRect(0, 0, 500, 750), config,
         )
-
-        # Set navigation delegate (retain it so it's not GC'd)
+        webview_ref[0] = webview_obj
         delegate = TeslaNavDelegate.alloc().init()
         delegate.retain()
         webview_obj.setNavigationDelegate_(delegate)
 
-        # Create window
+        class WindowDelegate(AppKit.NSObject):
+            def windowWillClose_(self, notification):
+                AppHelper.stopEventLoop()
+        win_delegate = WindowDelegate.alloc().init()
+        win_delegate.retain()
+
         ns_window = AppKit.NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
             Foundation.NSMakeRect(200, 200, 500, 750),
-            (
-                AppKit.NSWindowStyleMaskTitled
-                | AppKit.NSWindowStyleMaskClosable
-                | AppKit.NSWindowStyleMaskResizable
-            ),
-            AppKit.NSBackingStoreBuffered,
-            False,
+            (AppKit.NSWindowStyleMaskTitled | AppKit.NSWindowStyleMaskClosable
+             | AppKit.NSWindowStyleMaskResizable),
+            AppKit.NSBackingStoreBuffered, False,
         )
         ns_window.setContentView_(webview_obj)
-        ns_window.setTitle_("Tesla Login \u2014 pypowerwall")
+        ns_window.setTitle_("Tesla Login - pypowerwall")
+        ns_window.setDelegate_(win_delegate)
         ns_window.makeKeyAndOrderFront_(None)
         ns_window.retain()
-
-        # Load the auth URL
         req = Foundation.NSURLRequest.requestWithURL_(
             Foundation.NSURL.URLWithString_(auth_url)
         )
         webview_obj.loadRequest_(req)
-
-        # Activate the app so the window comes to front
         app.activateIgnoringOtherApps_(True)
-
-        # Run the event loop (blocks until AppHelper.stopEventLoop is called)
         AppHelper.runEventLoop()
 
     print("Opening Tesla login window...")
     run_window()
-
-    # Wait up to 15s for background token exchange thread to finish
     exchange_done.wait(timeout=15)
 
     if result["error"]:
         raise RuntimeError(result["error"])
     if not result["token"]:
-        raise RuntimeError("Login cancelled or timed out — no token received.")
-
-    print("  ✅ Refresh token captured!")
+        raise RuntimeError("Login cancelled - no token received.")
     return result["token"]
 
-
-# ---------------------------------------------------------------------------
-# Windows/Linux — pywebview with monkey-patched navigation handler
-# ---------------------------------------------------------------------------
 
 def _local_login_pywebview(email: str = None, region: str = "us") -> str:
     """pywebview login with navigation handler monkey-patch.

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -233,10 +233,21 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
     5. Exchange it for a refresh token
     """
     import threading
-    import AppKit
-    import WebKit
-    import Foundation
-    from PyObjCTools import AppHelper
+    try:
+        import AppKit
+        import WebKit
+        import Foundation
+        from PyObjCTools import AppHelper
+    except ImportError:
+        print("Installing pyobjc-framework-WebKit...")
+        import subprocess
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "pyobjc-framework-WebKit", "-q"]
+        )
+        import AppKit
+        import WebKit
+        import Foundation
+        from PyObjCTools import AppHelper
 
     auth_url, code_verifier, state = _build_auth_url(region)
     if email:
@@ -783,6 +794,20 @@ def _patch_pywebview_gtk(result, expected_state):
     where decision_type is a WebKit2.PolicyDecisionType enum and decision is a
     NavigationPolicyDecision (for NAVIGATION_ACTION) or ResponsePolicyDecision.
     """
+    # Check for system-level GTK/WebKit2 dependencies early so we can give
+    # a clear error rather than a cryptic ImportError later.
+    try:
+        import gi  # noqa: F401
+    except ImportError:
+        raise RuntimeError(
+            "Missing system libraries required for the Linux login window.\n"
+            "Please install them with your package manager and try again:\n\n"
+            "  Debian/Ubuntu:  sudo apt install python3-gi gir1.2-webkit2-4.0\n"
+            "  Fedora/RHEL:    sudo dnf install python3-gobject webkit2gtk4.0\n"
+            "  Arch:           sudo pacman -S python-gobject webkit2gtk\n\n"
+            "These are system packages and cannot be installed via pip."
+        )
+
     try:
         from webview.platforms import gtk as gtk_mod
     except ImportError:
@@ -798,8 +823,6 @@ def _patch_pywebview_gtk(result, expected_state):
         try:
             # WebKit2.PolicyDecisionType.NAVIGATION_ACTION = 0
             if decision_type == 0:
-                import gi
-                from gi.repository import WebKit2 as webkit
                 nav_decision = decision
                 request = nav_decision.get_request()
                 uri = request.get_uri() if request else None

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -205,8 +205,7 @@ def _local_login(email: str = None, region: str = "us", debug: bool = False):
     if sys.platform == "darwin":
         return _local_login_macos(email, region, debug=debug)
     else:
-        token = _local_login_pywebview(email, region)
-        return token, "", {}
+        return _local_login_pywebview(email, region)
 
 
 # ---------------------------------------------------------------------------
@@ -757,7 +756,6 @@ def _extract_email_from_token(token: str) -> str:
     except Exception:
         pass
     return ''
-''
 
 
 def save_token(token_data: dict, path: str = None, email: str = None, region: str = "us"):

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -516,10 +516,54 @@ def _local_login_pywebview(email: str = None, region: str = "us") -> str:
                     result["token"] = token_data["refresh_token"]
                 except Exception as e:
                     result["error"] = f"Token exchange failed: {e}"
+                    try:
+                        window.destroy()
+                    except Exception:
+                        pass
+                    return
+                # Show success page instead of auto-closing
+                # so user can copy the token from the window
+                token = result["token"]
+                print("\n" + "=" * 60)
+                print("\u2705 Tesla Refresh Token:")
+                print("-" * 60)
+                print(token)
+                print("-" * 60)
+                print("Copy the token above or use the button in the window.")
+                success_html = f"""<!DOCTYPE html><html><head>
+<meta charset='utf-8'>
+<style>
+  body {{ font-family: -apple-system, sans-serif; padding: 20px; background: #f5f5f7; }}
+  h2 {{ color: #1d1d1f; }}
+  .token-box {{ background: white; border: 1px solid #d2d2d7; border-radius: 10px;
+    padding: 15px; word-break: break-all; font-family: monospace; font-size: 11px;
+    color: #333; margin: 15px 0; }}
+  .copy-btn {{ background: #0071e3; color: white; border: none; border-radius: 8px;
+    padding: 10px 20px; font-size: 15px; cursor: pointer; width: 100%; }}
+  .copy-btn:active {{ background: #0077ed; }}
+  p {{ color: #6e6e73; font-size: 13px; }}
+</style></head><body>
+<h2>\u2705 Authentication Successful</h2>
+<p>Your Tesla refresh token is shown below. Copy it now.</p>
+<div class='token-box' id='tokenText'>{token}</div>
+<button class='copy-btn' id='copyBtn' onclick=\"
+  navigator.clipboard.writeText(document.getElementById('tokenText').textContent);
+  document.getElementById('copyBtn').textContent = '\u2705 Copied!';
+  document.getElementById('copyBtn').style.background = '#34c759';
+  setTimeout(function(){{
+    document.getElementById('copyBtn').textContent = 'Copy Token';
+    document.getElementById('copyBtn').style.background = '#0071e3';
+  }}, 2500);
+\">Copy Token</button>
+<p style='margin-top:15px'>You can safely close this window.</p>
+</body></html>"""
                 try:
-                    window.destroy()
+                    window.load_html(success_html)
                 except Exception:
-                    pass
+                    try:
+                        window.destroy()
+                    except Exception:
+                        pass
                 return
             time.sleep(0.5)
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -200,19 +200,29 @@ def _remote_login() -> str:
 # Path 2 — Local login (native WebView with navigation interception)
 # ---------------------------------------------------------------------------
 
-def _local_login(email: str = None, region: str = "us", debug: bool = False):
-    """Local login via native WebView. Returns (refresh_token, email, token_data) tuple."""
+def _local_login(email: str = None, region: str = "us", debug: bool = False,
+                   show_token_page: bool = False):
+    """Local login via native WebView. Returns (refresh_token, email, token_data) tuple.
+
+    Args:
+        show_token_page: If True, show a success page with the token after auth
+                         (for `authtoken` command). If False, auto-close window
+                         after token capture (for `setup` command).
+    """
     if sys.platform == "darwin":
-        return _local_login_macos(email, region, debug=debug)
+        return _local_login_macos(email, region, debug=debug,
+                                  show_token_page=show_token_page)
     else:
-        return _local_login_pywebview(email, region)
+        return _local_login_pywebview(email, region,
+                                      show_token_page=show_token_page)
 
 
 # ---------------------------------------------------------------------------
 # macOS — Native WKWebView via PyObjC
 # ---------------------------------------------------------------------------
 
-def _local_login_macos(email: str = None, region: str = "us", debug: bool = False) -> str:
+def _local_login_macos(email: str = None, region: str = "us", debug: bool = False,
+                          show_token_page: bool = False) -> str:
     """Native WKWebView on macOS with WKNavigationDelegate to intercept tesla://.
 
     This mirrors exactly what tesla_auth's wry does on macOS:
@@ -339,12 +349,16 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
                             print("-" * 60)
                             print(token)
                             print("-" * 60)
-                            if clipboard_ok:
+                            if not show_token_page:
+                                # Auto-close for setup — no success page needed
+                                print("  \u2705 Token captured — setup will continue.")
+                            elif clipboard_ok:
                                 print("Token copied to clipboard! You can now close the window.")
                             else:
                                 print("Copy the token above. You can now close the window.")
-                            # Load success page in the WebView
-                            success_html = f"""<!DOCTYPE html><html><head>
+                            # Only load success page for authtoken (show_token_page=True)
+                            if show_token_page:
+                              success_html = f"""<!DOCTYPE html><html><head>
 <meta charset='utf-8'>
 <style>
   body {{ font-family: -apple-system, sans-serif; padding: 20px; background: #f5f5f7; }}
@@ -377,16 +391,23 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
   </a>
 </div>
 </body></html>"""
-                            def load_success():
-                                webview_ref[0].loadHTMLString_baseURL_(success_html, None)
-                            AppHelper.callAfter(load_success)
+                              def load_success():
+                                  webview_ref[0].loadHTMLString_baseURL_(success_html, None)
+                              AppHelper.callAfter(load_success)
                         except Exception as e:
                             result["error"] = f"Token exchange failed: {e}"
                             dbg(f"Token exchange error: {e}")
                         finally:
                             exchange_done.set()
-                            # Window stays open for user to click Close button
-                            # DO NOT stop event loop here
+                            if not show_token_page:
+                                # Auto-close for setup — token is saved to file
+                                def close_after_exchange():
+                                    if window_ref[0]:
+                                        window_ref[0].close()
+                                    else:
+                                        AppKit.NSApplication.sharedApplication().stop_(None)
+                                AppHelper.callAfter(close_after_exchange)
+                            # else: Window stays open for user to click Close button
 
                     threading.Thread(target=do_exchange, daemon=True).start()
 
@@ -467,7 +488,8 @@ def _local_login_macos(email: str = None, region: str = "us", debug: bool = Fals
     return result["token"], result.get("email", ""), result.get("token_data", {})
 
 
-def _local_login_pywebview(email: str = None, region: str = "us") -> str:
+def _local_login_pywebview(email: str = None, region: str = "us",
+                            show_token_page: bool = False) -> str:
     """pywebview login with navigation handler monkey-patch.
 
     On Windows (WebView2) and Linux (WebKit2GTK), we use pywebview but
@@ -521,16 +543,20 @@ def _local_login_pywebview(email: str = None, region: str = "us") -> str:
                     except Exception:
                         pass
                     return
-                # Show success page instead of auto-closing
-                # so user can copy the token from the window
                 token = result["token"]
                 print("\n" + "=" * 60)
                 print("\u2705 Tesla Refresh Token:")
                 print("-" * 60)
                 print(token)
                 print("-" * 60)
-                print("Copy the token above or use the button in the window.")
-                success_html = f"""<!DOCTYPE html><html><head>
+
+                if show_token_page:
+                    # Show success page with Copy Token button
+                    # Uses hidden textarea + execCommand fallback because
+                    # navigator.clipboard.writeText() fails in WebView2 on Windows
+                    # (requires secure context / HTTPS which local HTML doesn't have)
+                    print("Copy the token above or use the button in the window.")
+                    success_html = f"""<!DOCTYPE html><html><head>
 <meta charset='utf-8'>
 <style>
   body {{ font-family: -apple-system, sans-serif; padding: 20px; background: #f5f5f7; }}
@@ -542,24 +568,42 @@ def _local_login_pywebview(email: str = None, region: str = "us") -> str:
     padding: 10px 20px; font-size: 15px; cursor: pointer; width: 100%; }}
   .copy-btn:active {{ background: #0077ed; }}
   p {{ color: #6e6e73; font-size: 13px; }}
+  #fallback {{ position: absolute; left: -9999px; }}
 </style></head><body>
 <h2>\u2705 Authentication Successful</h2>
 <p>Your Tesla refresh token is shown below. Copy it now.</p>
 <div class='token-box' id='tokenText'>{token}</div>
+<textarea id='fallback'>{token}</textarea>
 <button class='copy-btn' id='copyBtn' onclick=\"
-  navigator.clipboard.writeText(document.getElementById('tokenText').textContent);
-  document.getElementById('copyBtn').textContent = '\u2705 Copied!';
-  document.getElementById('copyBtn').style.background = '#34c759';
-  setTimeout(function(){{
-    document.getElementById('copyBtn').textContent = 'Copy Token';
-    document.getElementById('copyBtn').style.background = '#0071e3';
-  }}, 2500);
+  var ta = document.getElementById('fallback');
+  ta.style.position='fixed'; ta.style.left='0'; ta.style.top='0';
+  ta.style.opacity='0'; ta.select(); ta.setSelectionRange(0, 99999);
+  var ok = document.execCommand('copy');
+  ta.style.position='absolute'; ta.style.left='-9999px';
+  if(ok){{
+    document.getElementById('copyBtn').textContent = '\u2705 Copied!';
+    document.getElementById('copyBtn').style.background = '#34c759';
+    setTimeout(function(){{
+      document.getElementById('copyBtn').textContent = 'Copy Token';
+      document.getElementById('copyBtn').style.background = '#0071e3';
+    }}, 2500);
+  }} else {{
+    document.getElementById('copyBtn').textContent = 'Select & copy manually';
+    document.getElementById('copyBtn').style.background = '#ff3b30';
+  }}
 \">Copy Token</button>
 <p style='margin-top:15px'>You can safely close this window.</p>
 </body></html>"""
-                try:
-                    window.load_html(success_html)
-                except Exception:
+                    try:
+                        window.load_html(success_html)
+                    except Exception:
+                        try:
+                            window.destroy()
+                        except Exception:
+                            pass
+                else:
+                    # Auto-close window for setup flow (token is saved to file)
+                    print("  \u2705 Token captured — setup will continue.")
                     try:
                         window.destroy()
                     except Exception:
@@ -777,12 +821,13 @@ def login(email: str = None, headless: bool = False, region: str = "us", debug: 
     """Authenticate with Tesla. Returns (refresh_token, email, token_data) tuple."""
     if headless or _detect_mode() == "remote":
         return _remote_login(), "", {}
-    return _local_login(email=email, region=region, debug=debug)
+    return _local_login(email=email, region=region, debug=debug,
+                        show_token_page=False)
 
 
 def get_authtoken(region: str = "us", debug: bool = False) -> str:
     """Get a refresh token for the authtoken CLI command (no file save)."""
-    token, _, _ = _local_login(region=region, debug=debug)
+    token, _, _ = _local_login(region=region, debug=debug, show_token_page=True)
     return token
 
 

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -555,6 +555,26 @@ def _local_login_pywebview(email: str = None, region: str = "us",
                     # Uses hidden textarea + execCommand fallback because
                     # navigator.clipboard.writeText() fails in WebView2 on Windows
                     # (requires secure context / HTTPS which local HTML doesn't have)
+                    # Try Python-side clipboard copy first (works on all platforms)
+                    try:
+                        import subprocess
+                        if sys.platform == 'win32':
+                            subprocess.run(['clip'], input=token.encode(), check=True)
+                            print("Token copied to clipboard!")
+                        elif sys.platform == 'linux':
+                            # Try xclip, then xsel, then wl-copy
+                            for cmd in [['xclip', '-selection', 'clipboard'], ['xsel', '--clipboard', '--input'], ['wl-copy']]:
+                                try:
+                                    subprocess.run(cmd, input=token.encode(), check=True)
+                                    print("Token copied to clipboard!")
+                                    break
+                                except (FileNotFoundError, subprocess.CalledProcessError):
+                                    continue
+                        elif sys.platform == 'darwin':
+                            subprocess.run(['pbcopy'], input=token.encode(), check=True)
+                            print("Token copied to clipboard!")
+                    except Exception:
+                        pass
                     print("Copy the token above or use the button in the window.")
                     success_html = f"""<!DOCTYPE html><html><head>
 <meta charset='utf-8'>
@@ -563,7 +583,7 @@ def _local_login_pywebview(email: str = None, region: str = "us",
   h2 {{ color: #1d1d1f; }}
   .token-box {{ background: white; border: 1px solid #d2d2d7; border-radius: 10px;
     padding: 15px; word-break: break-all; font-family: monospace; font-size: 11px;
-    color: #333; margin: 15px 0; }}
+    color: #333; margin: 15px 0; user-select: all; cursor: text; }}
   .copy-btn {{ background: #0071e3; color: white; border: none; border-radius: 8px;
     padding: 10px 20px; font-size: 15px; cursor: pointer; width: 100%; }}
   .copy-btn:active {{ background: #0077ed; }}
@@ -571,8 +591,8 @@ def _local_login_pywebview(email: str = None, region: str = "us",
   #fallback {{ position: absolute; left: -9999px; }}
 </style></head><body>
 <h2>\u2705 Authentication Successful</h2>
-<p>Your Tesla refresh token is shown below. Copy it now.</p>
-<div class='token-box' id='tokenText'>{token}</div>
+<p>Your Tesla refresh token is shown below. Click the token box to select it, then press Ctrl+C to copy.</p>
+<div class='token-box' id='tokenText' onclick="document.execCommand('selectAll',false,null)">{token}</div>
 <textarea id='fallback'>{token}</textarea>
 <button class='copy-btn' id='copyBtn' onclick=\"
   var ta = document.getElementById('fallback');
@@ -588,11 +608,12 @@ def _local_login_pywebview(email: str = None, region: str = "us",
       document.getElementById('copyBtn').style.background = '#0071e3';
     }}, 2500);
   }} else {{
-    document.getElementById('copyBtn').textContent = 'Select & copy manually';
-    document.getElementById('copyBtn').style.background = '#ff3b30';
+    document.getElementById('tokenText').click();
+    document.getElementById('copyBtn').textContent = 'Press Ctrl+C to copy';
+    document.getElementById('copyBtn').style.background = '#ff9500';
   }}
 \">Copy Token</button>
-<p style='margin-top:15px'>You can safely close this window.</p>
+<p style='margin-top:15px'>Token is also printed in your terminal. You can safely close this window.</p>
 </body></html>"""
                     try:
                         window.load_html(success_html)
@@ -604,10 +625,14 @@ def _local_login_pywebview(email: str = None, region: str = "us",
                 else:
                     # Auto-close window for setup flow (token is saved to file)
                     print("  \u2705 Token captured — setup will continue.")
-                    try:
-                        window.destroy()
-                    except Exception:
-                        pass
+                    def _close():
+                        for attempt in range(5):
+                            try:
+                                window.destroy()
+                                return
+                            except Exception:
+                                time.sleep(0.2 * (attempt + 1))
+                    _close()
                 return
             time.sleep(0.5)
 


### PR DESCRIPTION
## What This Does

Replaces the `tesla-auth` external binary dependency with **native Python** Tesla authentication. No more downloading platform-specific binaries — just pure Python that works everywhere.

This PR also **replaces the deprecated `login` command** with a unified **`setup`** command that handles authentication AND site selection in one flow. Plus an **`authtoken`** command for remote SSH use cases.

---

## `setup` — Full Cloud Setup (recommended)

The new `setup` command authenticates with Tesla, writes the token, fetches your sites, and lets you pick which one to use:

```bash
# Local machine (macOS native WKWebView, or headless on Linux/Windows):
python -m pypowerwall setup

# Specify email upfront:
python -m pypowerwall setup -email you@example.com

# Headless mode (servers / SSH):
python -m pypowerwall setup -headless
```

**What happens:**
1. Opens native WebView window (macOS) or prints URL (headless)
2. User logs in with Tesla credentials (or pastes token in headless mode)
3. Token saved to `.pypowerwall.auth`
4. Fetches list of Tesla Energy sites
5. User picks which site to monitor
6. Site ID saved to `.pypowerwall.site`
7. `python -m pypowerwall get` works immediately

---

## `authtoken` — Get Token for Remote Machines

For SSH/headless servers that can't open a browser window:

**On your local Mac/PC:**
```bash
python -m pypowerwall authtoken
```
- Opens login window, copies token to clipboard
- Prints token to terminal for easy copy

**On the remote server:**
```bash
python -m pypowerwall setup
# Paste the refresh token when prompted
```

---

## `get` — Check Your Powerwall

```bash
# Auto-select best available mode:
python -m pypowerwall get

# Force a specific mode:
python -m pypowerwall get -mode cloud
python -m pypowerwall get -mode fleetapi
python -m pypowerwall get -mode local -host 10.0.1.99 -password yourpassword
```

---

## China Region Support

All commands support the `-region cn` flag:
```bash
python -m pypowerwall setup -region cn
```

---

## Cross-Platform Status

| Platform | Method | Status | Notes |
|----------|--------|--------|-------|
| **macOS** | Native WKWebView (PyObjC) | ✅ Tested | Window with Copy Token + Close buttons |
| **Linux** | Headless (paste URL/token) | ✅ Tested | `setup -headless` or `authtoken` |
| **Windows** | pywebview WebView2 | 🔄 Needs testing | Monkey-patch implemented, needs real machine |
| **SSH** | Headless paste | ✅ Tested | `setup -headless` flow works end-to-end |

---

## Testing Steps for the Community

```bash
git clone https://github.com/jasonacox-sam/pypowerwall.git
cd pypowerwall
git checkout feature/python-tesla-auth
pip install -e .

# Test full setup (browser window on macOS, headless on Linux/Windows/SSH):
python -m pypowerwall setup

# Test authtoken for remote use:
python -m pypowerwall authtoken

# Test get command:
python -m pypowerwall get
python -m pypowerwall get -mode cloud

# Test China region:
python -m pypowerwall setup -region cn
```

### What to Verify

- ✅ Refresh token is obtained successfully
- ✅ No `tesla-auth` binary is needed (no download step)
- ✅ `setup` command handles auth + site selection in one flow
- ✅ `authtoken` works for remote/SSH workflows
- ✅ `--headless` mode works for server/SSH environments
- ✅ `--region cn` uses the correct auth endpoint
- ✅ `get -mode` flag forces specific connection mode
- ✅ Existing `pypowerwall` functionality still works with the new token

---

## Deprecation Note

The old `login` command is **deprecated** and replaced by `setup`. `login` now prints a message directing users to `setup`.

---

Closes #282

---

*Flux ⚡ | Sam's Powerwall agent*