### PR TITLE
fix(v1r): correct key verification check + surface authorization errors clearly

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,13 @@
 # RELEASE NOTES
 
-## v0.15.5 - Native Python Tesla Authentication
+## v0.15.5 - Native Python Tesla Authentication + v1r Key Verification Fixes
 
 * Feat: Replace external `tesla-auth` binary dependency with native Python Tesla authentication — no more platform-specific binary downloads
 * Feat: New `setup` command handles authentication and site selection in a single flow using a native WebView popup window (macOS, Windows, Linux)
 * Feat: New `authtoken` command for obtaining a refresh token on a local machine, then using it on a remote/headless server
 * Fix: Cross-platform WebView interception of `tesla://auth/callback` using WKWebView (macOS), WebView2 (Windows), and WebKit2GTK (Linux)
+* Fix: `v1r_register.py` now verifies the specific newly-registered RSA key rather than any key in the authorized clients list — prevents false VERIFIED result when only the Tesla app key is verified (fixes #274)
+* Fix: `tedapi_v1r.py` now detects and clearly logs `client authorization not verified` inner-payload errors, with actionable instructions to complete physical key verification — previously silently returned `None` with no diagnostic output
 * Release prep:
      * Bump library version to `0.15.5`
 

--- a/pypowerwall/tedapi/tedapi_v1r.py
+++ b/pypowerwall/tedapi/tedapi_v1r.py
@@ -221,6 +221,24 @@ class TEDAPIv1r:
             if not inner:
                 log.error("v1r response has no protobuf_message_as_bytes")
                 return None
+
+            # Check for plain-text authorization errors in the inner payload.
+            # When the RSA key is registered but not yet verified, the gateway
+            # returns HTTP 200 with MESSAGEFAULT_ERROR_NONE but the inner bytes
+            # contain a plain-text error like "v1r: client authorization not verified"
+            # instead of a valid protobuf payload.
+            try:
+                inner_text = inner.decode('utf-8', errors='replace').strip()
+                if 'authorization not verified' in inner_text:
+                    log.error("v1r: RSA key not yet verified by the gateway.")
+                    log.error("  The key is registered but still PENDING. To verify it:")
+                    log.error("  1. Toggle ONE Powerwall breaker OFF, wait 2 seconds, then back ON.")
+                    log.error("  2. Wait 30-60 seconds, then retry.")
+                    log.error("  Or check key state: python -m pypowerwall register")
+                    return None
+            except Exception:
+                pass
+
             return inner
 
         except Exception as e:

--- a/pypowerwall/tedapi/tedapi_v1r.py
+++ b/pypowerwall/tedapi/tedapi_v1r.py
@@ -229,12 +229,13 @@ class TEDAPIv1r:
             # instead of a valid protobuf payload.
             try:
                 inner_text = inner.decode('utf-8', errors='replace').strip()
-                if 'authorization not verified' in inner_text:
-                    log.error("v1r: RSA key not yet verified by the gateway.")
-                    log.error("  The key is registered but still PENDING. To verify it:")
+                if 'authorization not verified' in inner_text.lower():
+                    log.error("v1r: RSA key not yet VERIFIED by the gateway.")
+                    log.error("  The key is registered but not yet VERIFIED (may be PENDING or PENDING_VERIFICATION).")
                     log.error("  1. Toggle ONE Powerwall breaker OFF, wait 2 seconds, then back ON.")
                     log.error("  2. Wait 30-60 seconds, then retry.")
-                    log.error("  Or check key state: python -m pypowerwall register")
+                    log.error("  Re-run 'python -m pypowerwall register' to inspect registration and verification state.")
+                    log.error("  See: https://github.com/jasonacox/pypowerwall/issues/274")
                     return None
             except Exception:
                 pass

--- a/pypowerwall/tedapi/tedapi_v1r.py
+++ b/pypowerwall/tedapi/tedapi_v1r.py
@@ -227,18 +227,15 @@ class TEDAPIv1r:
             # returns HTTP 200 with MESSAGEFAULT_ERROR_NONE but the inner bytes
             # contain a plain-text error like "v1r: client authorization not verified"
             # instead of a valid protobuf payload.
-            try:
-                inner_text = inner.decode('utf-8', errors='replace').strip()
-                if 'authorization not verified' in inner_text.lower():
-                    log.error("v1r: RSA key not yet VERIFIED by the gateway.")
-                    log.error("  The key is registered but not yet VERIFIED (may be PENDING or PENDING_VERIFICATION).")
-                    log.error("  1. Toggle ONE Powerwall breaker OFF, wait 2 seconds, then back ON.")
-                    log.error("  2. Wait 30-60 seconds, then retry.")
-                    log.error("  Re-run 'python -m pypowerwall register' to inspect registration and verification state.")
-                    log.error("  See: https://github.com/jasonacox/pypowerwall/issues/274")
-                    return None
-            except Exception:
-                pass
+            # Check in bytes first to avoid decoding large protobuf blobs on every call.
+            if b'authorization not verified' in inner.lower():
+                log.error("v1r: RSA key not yet VERIFIED by the gateway.")
+                log.error("  The key is registered but not yet VERIFIED (may be PENDING or PENDING_VERIFICATION).")
+                log.error("  1. Toggle ONE Powerwall breaker OFF, wait 2 seconds, then back ON.")
+                log.error("  2. Wait 30-60 seconds, then retry.")
+                log.error("  Re-run 'python -m pypowerwall register' to inspect registration and verification state.")
+                log.error("  See: https://github.com/jasonacox/pypowerwall/issues/274")
+                return None
 
             return inner
 

--- a/pypowerwall/v1r_register.py
+++ b/pypowerwall/v1r_register.py
@@ -307,11 +307,16 @@ def step3_get_site_id(token, fleet_api_base):
     return selected["energy_site_id"], selected["gateway_din"]
 
 
-def _check_key_state(resp):
+def _check_key_state(resp, pubkey_der=None):
     """Extract client state from Fleet API registration/list response.
 
     Returns the state integer if found, None otherwise.
     State values: 1=PENDING, 2=PENDING_VERIFICATION, 3=VERIFIED
+
+    If pubkey_der is provided and the response is a ListAuthorizedClientsResponse,
+    only returns the state for the client whose public key matches pubkey_der.
+    This prevents false VERIFIED results when another key (e.g. Tesla app key)
+    is already verified.
     """
     try:
         msg = resp["response"]["message"]["Payload"]["Authorization"]["Message"]
@@ -335,6 +340,20 @@ def _check_key_state(resp):
         if key in msg:
             clients = msg[key].get("clients") or msg[key].get("Clients") or []
             for client in clients:
+                # If pubkey_der is provided, match the specific key
+                if pubkey_der is not None:
+                    client_pubkey = client.get("public_key") or client.get("PublicKey") or ""
+                    if client_pubkey:
+                        try:
+                            decoded = base64.b64decode(client_pubkey)
+                            if decoded != pubkey_der:
+                                continue
+                        except Exception:
+                            # Fallback: compare raw string representation
+                            if client_pubkey != base64.b64encode(pubkey_der).decode():
+                                continue
+                    else:
+                        continue  # no public_key to match
                 state = client.get("state") or client.get("State")
                 if state is not None:
                     return int(state)
@@ -342,10 +361,11 @@ def _check_key_state(resp):
     return None
 
 
-def _poll_key_state(token, energy_site_id, fleet_api_base, attempts=3, delay=5):
+def _poll_key_state(token, energy_site_id, fleet_api_base, attempts=3, delay=5, pubkey_der=None):
     """Poll list_authorized_clients_request to check key verification state.
 
     Returns the state integer of the most recently registered key, or None.
+    If pubkey_der is provided, checks the specific key instead of any key.
     """
     verify_payload = {
         "command_properties": {
@@ -369,7 +389,7 @@ def _poll_key_state(token, energy_site_id, fleet_api_base, attempts=3, delay=5):
             token=token,
         )
         print(f"  Poll attempt {attempt + 1}/{attempts}: ({code})")
-        state = _check_key_state(resp)
+        state = _check_key_state(resp, pubkey_der=pubkey_der)
         if state is not None:
             print(f"  Key state: {state} ({'VERIFIED' if state == 3 else 'PENDING' if state < 3 else 'UNKNOWN'})")
             if state == 3:
@@ -420,7 +440,7 @@ def step4_register_key(token, energy_site_id, public_key_der, fleet_api_base):
         sys.exit(1)
 
     # Check if cloud registration auto-verified the key
-    state = _check_key_state(resp)
+    state = _check_key_state(resp, pubkey_der=public_key_der)
     if state == 3:
         print("\n  Key verified automatically via cloud — no breaker toggle needed!")
     else:
@@ -430,7 +450,7 @@ def step4_register_key(token, energy_site_id, public_key_der, fleet_api_base):
             print(f"\n  Response ({code}): {json.dumps(resp, indent=2)}")
         # Poll to see if state transitions to VERIFIED
         print("\n  Checking key verification status...")
-        state = _poll_key_state(token, energy_site_id, fleet_api_base)
+        state = _poll_key_state(token, energy_site_id, fleet_api_base, pubkey_der=public_key_der)
         if state == 3:
             print("\n  Key verified via cloud!")
         else:
@@ -446,7 +466,7 @@ def step4_register_key(token, energy_site_id, public_key_der, fleet_api_base):
             print()
             input("  Press Enter after toggling the breaker...")
             print("\n  Verifying key registration...")
-            state = _poll_key_state(token, energy_site_id, fleet_api_base, attempts=6)
+            state = _poll_key_state(token, energy_site_id, fleet_api_base, attempts=6, pubkey_der=public_key_der)
 
     # Done
     verified = state == 3


### PR DESCRIPTION
## Fixes #274 — v1r key verification and runtime error surfacing

### Two fixes in this PR

**1. v1r_register.py — verify the specific registered key, not just any key**

`list_authorized_clients_request` returns ALL authorized keys including the Tesla app key. The old `_check_key_state()` returned VERIFIED if ANY key was state 3, which falsely reported success when only the Tesla app key was verified — causing users to believe their LAN key was ready when it was still PENDING.

Fix: `_check_key_state(resp, pubkey_der=None)` now accepts the registered public key DER and matches only that specific client in the list response.

**2. tedapi_v1r.py — surface `authorization not verified` clearly at runtime**

When the RSA key is registered but not yet physically verified, the gateway returns HTTP 200 with `MESSAGEFAULT_ERROR_NONE` but the inner payload contains a plain-text string:

`v1r: client authorization not verified`

Previously this was silently swallowed — parsed as JSON/protobuf, failed, and returned None with no log output. Users saw opaque connection failures with no hint about root cause.

Fix: `post_v1r()` now detects this pattern and logs a clear actionable message with instructions to complete physical verification (breaker toggle).

### Root cause chain this closes
1. User registers key → `v1r_register.py` falsely reports VERIFIED (fix 1)
2. User tries to connect → gets silent None from v1r calls (fix 2)
3. User has no idea what went wrong

Both fixes together close the full failure path described in #274.