### PR TITLE
CLI Redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,12 +711,12 @@ Example output (`-format text`, the default):
 pyPowerwall [0.15.6] - Get Powerwall settings using Local (v1r+wifi+control) mode.
 
   Site               Cox Power Plant
-  Site Id            N/A
-  Din                1707000-11-M--TG1234567890TB
+  Site ID            N/A
+  DIN                1707000-11-M--TG1234567890TB
   Firmware           25.10.0
   Mode               self_consumption
   Reserve            20.0
-  Soc                87.5
+  Battery Level      64.2
   Grid Status        UP
   Grid               12
   Home               5588.5

--- a/README.md
+++ b/README.md
@@ -679,8 +679,8 @@ Returns settings and live power levels. Choose a connection mode or omit for aut
 | `-local` | Local Gateway API (PW2/+) | `-host`, `-password` |
 | `-cloud` | Tesla Cloud (Owners API) | prior `setup` |
 | `-fleetapi` | Tesla Fleet API | prior `setup -fleetapi` |
-| `-tedapi` | TEDAPI Wi-Fi | `-gw_pwd` |
-| `-v1r` | v1r LAN TEDAPI (PW3) | `-gw_pwd`, RSA key |
+| `-tedapi` | TEDAPI Wi-Fi | `-gw_pwd` (host defaults to `192.168.91.1`) |
+| `-v1r` | v1r LAN TEDAPI (PW3) | `-host`, `-gw_pwd`, RSA key |
 
 ```bash
 # Auto-select (uses available config/credentials)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ python3 -m pip install pypowerwall
 python3 -m pypowerwall scan
 
 # Option 2 - FLEETAPI CLOUD MODE - Setup to use the official Tesla FleetAPI - See notes below.
-python3 -m pypowerwall fleetapi
+python3 -m pypowerwall setup -fleetapi
 
 # Option 3 - CLOUD MODE - Setup to use Tesla Owners cloud API
 python3 -m pypowerwall setup
@@ -44,7 +44,8 @@ python3 -m pypowerwall setup
 # Option 4 - TEDAPI MODE - Test this mode (requires extended setup - see below)
 python3 -m pypowerwall tedapi
 
-# Option 5 - v1r LAN TEDAPI MODE - Powerwall 3 wired LAN access (see below)
+# Option 5 - v1r LAN TEDAPI MODE - Register RSA key for Powerwall 3 wired LAN access
+python3 -m pypowerwall setup -v1r
 ```
 
 ### Local Setup - Option 1
@@ -618,43 +619,148 @@ The following are some useful tools based on pypowerwall:
 
 ## pyPowerwall Command Line Interface (CLI)
 
-pyPowerwall has a built-in feature to scan your network for available Powerwall gateways and set/get operational and reserve modes.
+pyPowerwall includes a CLI for scanning your network, setting up cloud/gateway access, and querying or controlling your Powerwall.
 
 ```
-Usage: PyPowerwall [-h] {setup,scan,set,get,version} ...
+Usage: PyPowerwall [-h] [-debug] [-authpath AUTHPATH]
+                   {setup,login,authtoken,fleetapi,tedapi,register,scan,set,get,version}
+                   ...
 
-PyPowerwall Module v0.8.1
+PyPowerwall Module v0.15.6
 
-Options:
-  -h, --help            Show this help message and exit
+Global options (apply to all commands):
+  -debug              Enable debug output
+  -authpath PATH      Override auth file directory (default: PW_AUTH_PATH env var)
 
-Commands (run <command> -h to see usage information):
-  {setup,fleetapi,tedapi,scan,set,get,version}
-    setup                 Setup Tesla Login for Cloud Mode access
-    fleetapi              Setup Tesla FleetAPI for Cloud Mode access
-    tedapi                Test TEDAPI connection to Powerwall Gateway
-    scan                  Scan local network for Powerwall gateway
-    set                   Set Powerwall Mode and Reserve Level
-    get                   Get Powerwall Settings and Power Levels
-    version               Print version information
-
-   set options:
-      -mode MODE          Powerwall Mode: self_consumption, backup, or autonomous
-      -reserve RESERVE    Set Battery Reserve Level [Default=20]
-      -current            Set Battery Reserve Level to Current Charge
-      -gridcharging MODE  Set Grid Charging (allow) Mode ("on" or "off")
-      -gridexport MODE    Set Export to Grid Mode ("battery_ok", "pv_only", or "never")
-
-   get options:
-      -format FORMAT      Output format: text, json, csv
-      -host HOST          IP address of Powerwall Gateway
-      -password PASSWORD  Password for Powerwall Gateway
+Commands (run <command> -h for full usage):
+  setup               Setup Tesla Cloud, Fleet API, or v1r LAN TEDAPI access
+  login               [Deprecated] Use: setup
+  authtoken           Get a Tesla Cloud refresh token (prints to stdout)
+  fleetapi            [Deprecated] Use: setup -fleetapi
+  tedapi              Test TEDAPI connection to Powerwall Gateway
+  register            Register RSA key with Powerwall (for v1r LAN mode)
+  scan                Scan local network for Powerwall gateway
+  set                 Set Powerwall operating mode and reserve level
+  get                 Get Powerwall settings and power levels
+  version             Print version information
 ```
-   
+
+### Setup
+
 ```bash
 # Install pyPowerwall if you haven't already
 python -m pip install pypowerwall
 
+# Option 1 — Scan network for Powerwall gateways (local mode)
+python -m pypowerwall scan
+
+# Option 2 — Setup Tesla Fleet API (official)
+python -m pypowerwall setup -fleetapi
+
+# Option 3 — Setup Tesla Cloud (Owners API)
+python -m pypowerwall setup
+
+# Option 4 — Test TEDAPI Wi-Fi connection
+python -m pypowerwall tedapi -gw_pwd ABCDEXXXXX
+
+# Option 5 — Register RSA key for v1r LAN TEDAPI (Powerwall 3 wired LAN)
+python -m pypowerwall setup -v1r
+```
+
+### `get` — Read Powerwall Status
+
+Returns settings and live power levels. Choose a connection mode or omit for auto-select.
+
+**Connection mode flags** (mutually exclusive, all optional):
+
+| Flag | Mode | Required credentials |
+|------|------|----------------------|
+| _(none)_ | Auto-select from available config | — |
+| `-local` | Local Gateway API (PW2/+) | `-host`, `-password` |
+| `-cloud` | Tesla Cloud (Owners API) | prior `setup` |
+| `-fleetapi` | Tesla Fleet API | prior `setup -fleetapi` |
+| `-tedapi` | TEDAPI Wi-Fi | `-gw_pwd` |
+| `-v1r` | v1r LAN TEDAPI (PW3) | `-gw_pwd`, RSA key |
+
+```bash
+# Auto-select (uses available config/credentials)
+python -m pypowerwall get
+python -m pypowerwall get -format json
+python -m pypowerwall get -format csv
+
+# Local gateway
+python -m pypowerwall get -local -host 10.0.1.123 -password XXXXX
+
+# Tesla Cloud
+python -m pypowerwall get -cloud
+
+# Tesla Fleet API
+python -m pypowerwall get -fleetapi
+
+# TEDAPI (Wi-Fi — needs access to 192.168.91.1)
+python -m pypowerwall get -tedapi -gw_pwd ABCDEXXXXX
+
+# v1r LAN TEDAPI (Powerwall 3 wired LAN)
+python -m pypowerwall get -v1r -host 10.42.1.40 -gw_pwd ABCDEXXXXX \
+    -rsa_key_path ./tedapi_rsa_private.pem
+```
+
+Example output (`-format text`, the default):
+
+```
+pyPowerwall [0.15.6] - Get Powerwall settings using Local (v1r+wifi+control) mode.
+
+  Site               Cox Power Plant
+  Site Id            N/A
+  Din                1707000-11-M--TG1234567890TB
+  Firmware           25.10.0
+  Mode               self_consumption
+  Reserve            20.0
+  Soc                87.5
+  Grid Status        UP
+  Grid               12
+  Home               5588.5
+  Battery            1613
+  Solar              3965
+  Grid Charging      True
+  Grid Export Mode   pv_only
+  Time Remaining     N/A
+```
+
+### `set` — Control Powerwall
+
+Accepts the same connection mode flags as `get`, plus control options:
+
+```bash
+# Set operating mode
+python -m pypowerwall set -mode self_consumption
+python -m pypowerwall set -mode backup
+python -m pypowerwall set -mode autonomous
+
+# Set battery reserve
+python -m pypowerwall set -reserve 20
+
+# Set reserve to current charge level
+python -m pypowerwall set -current
+
+# Grid charging and export
+python -m pypowerwall set -gridcharging on
+python -m pypowerwall set -gridcharging off
+python -m pypowerwall set -gridexport battery_ok
+python -m pypowerwall set -gridexport pv_only
+python -m pypowerwall set -gridexport never
+
+# Combine multiple settings in one call
+python -m pypowerwall set -mode self_consumption -reserve 20 -gridcharging off
+
+# Use a specific connection mode with set
+python -m pypowerwall set -v1r -host 10.42.1.40 -gw_pwd ABCDEXXXXX \
+    -rsa_key_path ./tedapi_rsa_private.pem -mode backup -reserve 100
+```
+
+### `scan` — Find Powerwall Gateways
+
+```bash
 # Scan Network for Powerwalls
 python -m pypowerwall scan
 ```
@@ -666,45 +772,16 @@ Scan local network for Tesla Powerwall Gateways
 
     Your network appears to be: 10.0.1.0/24
 
-    Enter Network or press enter to use 10.0.1.0/24: 
+    Enter Network or press enter to use 10.0.1.0/24:
 
     Running Scan...
       Host: 10.0.1.16 ... OPEN - Not a Powerwall
       Host: 10.0.1.26 ... OPEN - Not a Powerwall
       Host: 10.0.1.36 ... OPEN - Found Powerwall 1232100-00-E--TG123456789ABG
-      Done                           
+      Done
 
 Discovered 1 Powerwall Gateway
      10.0.1.36 [1232100-00-E--TG123456789ABG]
-```
-
-Get Power Levels, Operation Mode, and Battery Reserve Level
-
-```bash
-# Setup Connection with Tesla Cloud
-python -m pypowerwall setup
-
-# Get Power Levels, Operation Mode, and Battery Reserve Setting
-#
-# Usage: PyPowerwall get [-h] [-format FORMAT]
-#  -h, --help      show this help message and exit
-#  -format FORMAT  Output format: text, json, csv
-#
-python -m pypowerwall get
-python -m pypowerwall get -format json
-python -m pypowerwall get -format csv
-
-# Set Operation Mode and Battery Reserve Setting
-#
-# Usage: PyPowerwall set [-h] [-mode MODE] [-reserve RESERVE] [-current]
-#  -h, --help        show this help message and exit
-#  -mode MODE        Powerwall Mode: self_consumption, backup, or autonomous
-#  -reserve RESERVE  Set Battery Reserve Level [Default=20]
-#  -current          Set Battery Reserve Level to Current Charge
-#
-python -m pypowerwall set -mode self_consumption
-python -m pypowerwall set -reserve 30
-python -m pypowerwall set -current
 ```
 
 ## Example API Calls

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,22 @@
 # RELEASE NOTES
 
-## v0.15.6 - Reserve Percent Scaling Fix
+## v0.15.6 - Reserve Percent Scaling Fix + CLI Redesign
 
 * Fix: `set_operation()` reserve percent scaling — reverse Tesla App scaling (0–100%) to raw API scale (5–100%) only in TEDAPI v1r mode, avoiding incorrect round-trip values in cloud and FleetAPI modes
 * Fix: Correctly handle `level=0` in `set_reserve()` via `level is not None` check
 * Fix: Revert universal scaling from `set_operation()`; move raw conversion into `PyPowerwallTEDAPI.post_api_operation()` where it belongs
+* Fix: FleetAPI config validation in `Powerwall.__init__()` — changed `os.access(file, W_OK)` check (fails when file doesn't exist) to check directory writability when config file is absent, preventing spurious `PyPowerwallInvalidConfigurationParameter` on first-time setup
+* Feat: CLI (`python -m pypowerwall`) redesigned for consistency across all connection modes
+    * Replace string `-mode` flag on `get` (which clashed with `set -mode`) with explicit boolean connection flags: `-local`, `-cloud`, `-fleetapi`, `-tedapi`, `-v1r` — available on both `get` and `set`
+    * **Backward compat:** `get -mode <value>` still accepted with a deprecation warning; e.g. `get -mode v1r` behaves identically to `get -v1r`
+    * Add `-host`, `-password`, `-gw_pwd`, `-rsa_key_path` credential flags to `get` and `set` subcommands
+    * Add global `-debug` and `-authpath` flags (via shared parent parser) available to every subcommand
+    * `setup` subcommand now handles all auth flows: default/`-cloud` (Tesla Owners API), `-fleetapi` (Fleet API wizard), `-v1r` (RSA key registration) — replacing the now-deprecated `fleetapi` top-level command
+    * `get` output expanded: adds `firmware`, `grid_status`, and `time_remaining` fields; `None` values display as `N/A` in text/CSV output
+    * Pre-flight checks in `get` and `set`: if `-cloud` or `-fleetapi` is specified but the required config file is missing, a clear error message with setup instructions is printed before any connection attempt
+    * Connection check (`is_connected()`) now runs before the output banner — no partial output on failure
+    * `fleetapi` top-level command shows deprecation warning and points to `setup -fleetapi`; `login` command shows deprecation warning and exits
+* Docs: Update `README.md` CLI section — new command list with global flags, connection mode flag reference table, examples for all 5 connection modes, updated setup commands (`fleetapi` → `setup -fleetapi`, `setup -v1r`)
 * Release prep:
      * Bump library version to `0.15.6`
      * Update proxy pinned dependency to `pypowerwall==0.15.6`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,8 @@
 * Fix: `set_operation()` reserve percent scaling — reverse Tesla App scaling (0–100%) to raw API scale (5–100%) only in TEDAPI v1r mode, avoiding incorrect round-trip values in cloud and FleetAPI modes
 * Fix: Correctly handle `level=0` in `set_reserve()` via `level is not None` check
 * Fix: Revert universal scaling from `set_operation()`; move raw conversion into `PyPowerwallTEDAPI.post_api_operation()` where it belongs
+* Fix: FleetAPI `get_api_system_status_soe()` was returning `battery_level()` (Tesla App-scaled, 0–100% usable) directly as the raw SOE percentage — missing the reverse-scaling applied by the cloud backend. This caused `level()` (default `scale=False`) to return the already-scaled app value instead of the physical percentage, making FleetAPI SOC appear ~2% lower than v1r/TEDAPI for the same battery. Fix: apply `soe = (percentage_charged + 5/0.95) * 0.95` to convert app scale → raw, matching the cloud backend.
+* Fix: `get` command now reports SOC using `level(scale=True)` — matching the Tesla app display (usable capacity, 0–100% of non-reserved energy) rather than the raw physical percentage including Tesla's 5% buffer reserve.
 * Fix: FleetAPI config validation in `Powerwall.__init__()` — changed `os.access(file, W_OK)` check (fails when file doesn't exist) to check directory writability when config file is absent, preventing spurious `PyPowerwallInvalidConfigurationParameter` on first-time setup
 * Feat: CLI (`python -m pypowerwall`) redesigned for consistency across all connection modes
     * Replace string `-mode` flag on `get` (which clashed with `set -mode`) with explicit boolean connection flags: `-local`, `-cloud`, `-fleetapi`, `-tedapi`, `-v1r` — available on both `get` and `set`

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -1074,12 +1074,16 @@ class Powerwall(object):
                 dirname = '.'
             self._check_if_dir_is_writable(dirname, "authpath")
         elif self.fleetapi:
-            # Ensure we can write to the configfile
+            # Ensure we can write to the configfile (or its directory if it doesn't exist yet)
             self.configfile = os.path.join(self.authpath, CONFIGFILE)
-            if os.access(self.configfile, os.W_OK):
-                log.debug(f"Config file '{self.configfile}' is writable.")
+            if os.path.exists(self.configfile):
+                if os.access(self.configfile, os.W_OK):
+                    log.debug(f"Config file '{self.configfile}' is writable.")
+                else:
+                    raise PyPowerwallInvalidConfigurationParameter(f"Config file '{self.configfile}' is not writable.")
             else:
-                raise PyPowerwallInvalidConfigurationParameter(f"Config file '{self.configfile}' is not writable.")
+                dirname = self.authpath or '.'
+                self._check_if_dir_is_writable(dirname, "authpath")
         else:
             # If local mode, check appropriate parameters, and ensure we can write to the provided cachefile
             dirname = os.path.dirname(self.cachefile)

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -504,7 +504,7 @@ def main():
             'firmware': pw.version(),
             'mode': pw.get_mode(),
             'reserve': pw.get_reserve(),
-            'soc': pw.level(),
+            'soc': pw.level(scale=True),
             'grid_status': pw.grid_status(),
             'grid': pw.grid(),
             'home': pw.home(),
@@ -522,9 +522,14 @@ def main():
             values = ",".join("N/A" if v is None else str(v) for v in output.values())
             print(values)
         else:
-            # Table Output
+            # Table Output — override display labels for terse keys
+            _labels = {
+                'site_id': 'Site ID',
+                'din': 'DIN',
+                'soc': 'Battery Level',
+            }
             for item in output:
-                name = item.replace("_", " ").title()
+                name = _labels.get(item, item.replace("_", " ").title())
                 value = output[item]
                 print("  {:<18}{}".format(name, "N/A" if value is None else value))
             print("")

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -80,6 +80,9 @@ def _build_powerwall(args, authpath):
         if not args.gw_pwd:
             print("ERROR: -v1r requires -gw_pwd <gateway_password>")
             sys.exit(1)
+        if not args.host:
+            print("ERROR: -v1r requires -host <gateway_ip>")
+            sys.exit(1)
         rsa_key_path = args.rsa_key_path
         if not rsa_key_path:
             default_key = "tedapi_rsa_private.pem"
@@ -102,7 +105,8 @@ def _build_powerwall(args, authpath):
         if not args.gw_pwd:
             print("ERROR: -tedapi requires -gw_pwd <gateway_password>")
             sys.exit(1)
-        return pypowerwall.Powerwall(host=args.host or None, gw_pwd=args.gw_pwd, authpath=authpath)
+        host = args.host or "192.168.91.1"
+        return pypowerwall.Powerwall(host=host, gw_pwd=args.gw_pwd, authpath=authpath)
     if getattr(args, 'local', False):
         return pypowerwall.Powerwall(host=args.host, password=args.password, authpath=authpath)
     if getattr(args, 'cloud', False):
@@ -274,7 +278,7 @@ def main():
     if command == 'setup':
         if args.v1r:
             from pypowerwall.v1r_register import main as fleet_register_main
-            fleet_register_main()
+            fleet_register_main(authpath=authpath)
             return
 
         if args.fleetapi:
@@ -469,6 +473,13 @@ def main():
     elif command == 'get':
         # Backward compat: deprecated 'get -mode <value>' → new boolean flag
         if getattr(args, 'legacy_mode', None):
+            # Check for conflict: boolean flag already set by user
+            boolean_flags = ['local', 'cloud', 'fleetapi', 'tedapi', 'v1r']
+            active_booleans = [f for f in boolean_flags if getattr(args, f, False)]
+            if active_booleans:
+                print(f"ERROR: Cannot use both -{active_booleans[0]} flag and deprecated -mode {args.legacy_mode}. "
+                      f"Use only the boolean flag (e.g. -{args.legacy_mode}).")
+                sys.exit(1)
             _legacy_mode_map = {
                 'local': 'local', 'cloud': 'cloud', 'fleetapi': 'fleetapi',
                 'tedapi': 'tedapi', 'v1r': 'v1r',

--- a/pypowerwall/__main__.py
+++ b/pypowerwall/__main__.py
@@ -1,4 +1,4 @@
-# pyPowerWall Module - Scan Function
+# pyPowerWall Module - CLI Entry Point
 # -*- coding: utf-8 -*-
 """
  Python module to interface with Tesla Solar Powerwall Gateway
@@ -6,8 +6,18 @@
  Author: Jason A. Cox
  For more information see https://github.com/jasonacox/pypowerwall
 
- Scan Function:
-    python -m pypowerwall <scan>
+ CLI Usage:
+    python -m pypowerwall <command> [options]
+
+ Commands:
+    setup       Setup Tesla Cloud, Fleet API, or v1r LAN TEDAPI access
+    get         Get Powerwall settings and power levels
+    set         Set Powerwall operating mode and reserve level
+    tedapi      Test TEDAPI connection to Powerwall Gateway
+    scan        Scan local network for Powerwall gateway
+    register    Register RSA key for v1r LAN mode
+    authtoken   Get Tesla Cloud refresh token
+    version     Print version information
 
 """
 
@@ -31,6 +41,96 @@ def _email_from_auth(authpath):
         return None
 
 
+def _add_connection_args(parser):
+    """Add mutually exclusive connection mode flags and credential args to a subparser.
+
+    Modes (choose at most one):
+      -local      Local Powerwall Gateway  (needs -host, -password)
+      -cloud      Tesla Cloud              (needs prior 'setup')
+      -fleetapi   Tesla Fleet API          (needs prior 'setup -fleetapi')
+      -tedapi     TEDAPI direct            (needs -gw_pwd)
+      -v1r        v1r LAN TEDAPI           (needs -gw_pwd and RSA private key)
+      (none)      Auto-select from available configuration
+    """
+    grp = parser.add_mutually_exclusive_group()
+    grp.add_argument("-local", action="store_true", default=False,
+                     help="Connect via local Powerwall Gateway (requires -host)")
+    grp.add_argument("-cloud", action="store_true", default=False,
+                     help="Connect via Tesla Cloud (requires prior 'setup')")
+    grp.add_argument("-fleetapi", action="store_true", default=False,
+                     help="Connect via Tesla Fleet API (requires prior 'setup -fleetapi')")
+    grp.add_argument("-tedapi", action="store_true", default=False,
+                     help="Connect via TEDAPI (requires -gw_pwd)")
+    grp.add_argument("-v1r", action="store_true", default=False,
+                     help="Connect via v1r LAN TEDAPI (requires -gw_pwd and RSA private key)")
+    parser.add_argument("-host", type=str, default="",
+                        help="IP address of Powerwall Gateway [local/tedapi/v1r]")
+    parser.add_argument("-password", type=str, default="",
+                        help="Customer password [local/v1r; v1r defaults to last 5 of gw_pwd]")
+    parser.add_argument("-gw_pwd", type=str, default=None,
+                        help="Gateway password [required for -tedapi and -v1r]")
+    parser.add_argument("-rsa_key_path", type=str, default=None,
+                        help="RSA private key PEM path [v1r; default: ./tedapi_rsa_private.pem]")
+
+
+def _build_powerwall(args, authpath):
+    """Construct a Powerwall instance from the parsed connection mode flags."""
+    import pypowerwall
+    if getattr(args, 'v1r', False):
+        if not args.gw_pwd:
+            print("ERROR: -v1r requires -gw_pwd <gateway_password>")
+            sys.exit(1)
+        rsa_key_path = args.rsa_key_path
+        if not rsa_key_path:
+            default_key = "tedapi_rsa_private.pem"
+            if os.path.isfile(default_key):
+                rsa_key_path = default_key
+            else:
+                print(
+                    f"ERROR: -v1r requires an RSA private key. "
+                    f"Specify -rsa_key_path or place '{default_key}' in the current directory."
+                )
+                sys.exit(1)
+        return pypowerwall.Powerwall(
+            host=args.host or None,
+            password=args.password or None,
+            gw_pwd=args.gw_pwd,
+            rsa_key_path=rsa_key_path,
+            authpath=authpath,
+        )
+    if getattr(args, 'tedapi', False):
+        if not args.gw_pwd:
+            print("ERROR: -tedapi requires -gw_pwd <gateway_password>")
+            sys.exit(1)
+        return pypowerwall.Powerwall(host=args.host or None, gw_pwd=args.gw_pwd, authpath=authpath)
+    if getattr(args, 'local', False):
+        return pypowerwall.Powerwall(host=args.host, password=args.password, authpath=authpath)
+    if getattr(args, 'cloud', False):
+        auth_file = os.path.join(authpath, ".pypowerwall.auth") if authpath else ".pypowerwall.auth"
+        if not os.path.isfile(auth_file):
+            print(f"ERROR: Tesla Cloud auth file not found: {auth_file}")
+            print("  Run 'python -m pypowerwall setup' to authenticate.")
+            sys.exit(1)
+        email = _email_from_auth(authpath)
+        return pypowerwall.Powerwall(cloudmode=True, fleetapi=False, authpath=authpath, email=email)
+    if getattr(args, 'fleetapi', False):
+        from pypowerwall.fleetapi.fleetapi import CONFIGFILE as FLEET_CONFIGFILE
+        config_file = os.path.join(authpath, FLEET_CONFIGFILE) if authpath else FLEET_CONFIGFILE
+        if not os.path.isfile(config_file):
+            print(f"ERROR: Fleet API config file not found: {config_file}")
+            print("  Run 'python -m pypowerwall setup -fleetapi' to configure Fleet API access.")
+            sys.exit(1)
+        email = _email_from_auth(authpath)
+        return pypowerwall.Powerwall(cloudmode=True, fleetapi=True, authpath=authpath, email=email)
+    # No mode flag — auto-select from available configuration
+    return pypowerwall.Powerwall(
+        auto_select=True,
+        authpath=authpath,
+        password=getattr(args, 'password', ''),
+        host=getattr(args, 'host', ''),
+    )
+
+
 def main():
     """Main entry point for the pypowerwall CLI."""
     # Global Variables
@@ -38,28 +138,38 @@ def main():
 
     timeout = 1.0
     hosts = 30
-    color = True
-    ip = None
-    email = None
+
+    # Shared parent parser: flags that apply to every subcommand
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("-debug", action="store_true", default=False,
+                        help="Enable debug output")
+    common.add_argument("-authpath", type=str, default=None,
+                        help="Override auth path (default uses PW_AUTH_PATH env var)")
 
     # Setup parser and groups
-    p = argparse.ArgumentParser(prog="PyPowerwall", description=f"PyPowerwall Module v{version}")
+    p = argparse.ArgumentParser(prog="PyPowerwall", description=f"PyPowerwall Module v{version}",
+                                parents=[common])
     subparsers = p.add_subparsers(dest="command", title='commands (run <command> -h to see usage information)',
                                   required=True)
 
-    setup_args = subparsers.add_parser("setup", help='Setup Tesla Login for Cloud Mode access')
-    setup_args.add_argument("-email", type=str, default=email, help="Email address for Tesla Login.")
+    setup_args = subparsers.add_parser("setup", parents=[common],
+                                       help='Setup Tesla Cloud, Fleet API, or v1r LAN TEDAPI access')
+    setup_grp = setup_args.add_mutually_exclusive_group()
+    setup_grp.add_argument("-cloud", action="store_true", default=False,
+                           help="Setup Tesla Cloud Mode (default)")
+    setup_grp.add_argument("-fleetapi", action="store_true", default=False,
+                           help="Setup Tesla Fleet API mode")
+    setup_grp.add_argument("-v1r", action="store_true", default=False,
+                           help="Register RSA key with Powerwall for v1r LAN TEDAPI mode")
+    setup_args.add_argument("-email", type=str, default=None, help="Email address for Tesla Login.")
     setup_args.add_argument("-headless", action="store_true", default=False,
                            help="Manual mode — paste URL instead of opening browser")
     setup_args.add_argument("-region", type=str, default="us", choices=["us", "cn"],
                            help="Tesla region: 'us' (default) or 'cn' (China)")
-    setup_args.add_argument("-debug", action="store_true", default=False,
-                           help="Enable debug output for auth flow")
 
-    login_args = subparsers.add_parser("login", help='Authenticate with Tesla and get refresh token')
+    login_args = subparsers.add_parser("login", parents=[common],
+                                       help='Authenticate with Tesla Cloud and get refresh token (deprecated: use setup)')
     login_args.add_argument("-email", type=str, default=None, help="Tesla account email address")
-    login_args.add_argument("-debug", action="store_true", default=False,
-                           help="Enable debug output for auth flow")
     login_args.add_argument("-headless", action="store_true", default=False,
                            help="Manual mode — paste URL instead of opening browser")
     login_args.add_argument("-timeout", type=int, default=120,
@@ -67,16 +177,16 @@ def main():
     login_args.add_argument("-region", type=str, default="us", choices=["us", "cn"],
                            help="Tesla region: 'us' (default) or 'cn' (China)")
 
-    authtoken_args = subparsers.add_parser("authtoken",
-                                            help='Get refresh token via local browser login (prints to stdout)')
-    authtoken_args.add_argument("-debug", action="store_true", default=False,
-                               help="Enable debug output for auth flow")
+    authtoken_args = subparsers.add_parser("authtoken", parents=[common],
+                                            help='Get Tesla Cloud refresh token via local browser login (prints to stdout)')
     authtoken_args.add_argument("-region", type=str, default="us", choices=["us", "cn"],
                                 help="Tesla region: 'us' (default) or 'cn' (China)")
 
-    fleetapi_args = subparsers.add_parser("fleetapi", help='Setup Tesla FleetAPI for Cloud Mode access')
+    fleetapi_args = subparsers.add_parser("fleetapi", parents=[common],
+                                           help='[Deprecated] Setup Tesla FleetAPI — use: setup -fleetapi')
 
-    tedapi_args = subparsers.add_parser("tedapi", help='Test TEDAPI connection to Powerwall Gateway')
+    tedapi_args = subparsers.add_parser("tedapi", parents=[common],
+                                        help='Test TEDAPI connection to Powerwall Gateway')
     tedapi_args.add_argument("gw_pwd", type=str, nargs="?", default=None,
                              help="Powerwall Gateway Password")
     tedapi_args.add_argument("-gw_pwd", dest="gw_pwd_option", metavar="GW_PWD", type=str, default=None,
@@ -92,13 +202,14 @@ def main():
     tedapi_args.add_argument("-wifi_host", type=str, default=None,
                              help="Optional WiFi TEDAPI host for v1r follower fallback")
 
-    register_args = subparsers.add_parser("register",
-                                          help='Register RSA key with Powerwall via Tesla Owner API or Fleet API (for v1r LAN mode)')
+    register_args = subparsers.add_parser("register", parents=[common],
+                                           help='Register RSA key with Powerwall via Tesla Owner API or Fleet API (for v1r LAN mode)')
 
-    scan_args = subparsers.add_parser("scan", help='Scan local network for Powerwall gateway')
+    scan_args = subparsers.add_parser("scan", parents=[common],
+                                      help='Scan local network for Powerwall gateway')
     scan_args.add_argument("-timeout", type=float, default=timeout,
                            help=f"Seconds to wait per host [Default={timeout:.1f}]")
-    scan_args.add_argument("-nocolor", action="store_true", default=not color,
+    scan_args.add_argument("-nocolor", action="store_true", default=False,
                            help="Disable color text output.")
     scan_args.add_argument("network", type=str, nargs="?", default=None, metavar="CIDR",
                            help="IPv4 CIDR network to scan (e.g. 192.168.1.0/24). Auto-detects if omitted.")
@@ -109,34 +220,31 @@ def main():
     scan_args.add_argument("-json", action="store_true", default=False,
                            help="Output discovered gateways as JSON and suppress all other output.")
 
-    set_mode_args = subparsers.add_parser("set", help='Set Powerwall Mode and Reserve Level')
+    set_mode_args = subparsers.add_parser("set", parents=[common],
+                                           help='Set Powerwall operating mode and reserve level')
+    _add_connection_args(set_mode_args)
     set_mode_args.add_argument("-mode", type=str, default=None,
-                                help="Powerwall Mode: self_consumption, backup, or autonomous")
+                                help="Operating mode: self_consumption, backup, or autonomous")
     set_mode_args.add_argument("-reserve", type=int, default=-1,
                                 help="Set Battery Reserve Level [Default=20]")
     set_mode_args.add_argument("-current", action="store_true", default=False,
                                 help="Set Battery Reserve Level to Current Charge")
     set_mode_args.add_argument("-gridcharging", type=str, default=None,
-                                help="Enable Grid Charging Mode: on or off")
+                                help="Grid Charging Mode: on or off")
     set_mode_args.add_argument("-gridexport", type=str, default=None,
                                 help="Grid Export Mode: battery_ok, pv_only, or never")
 
-    get_mode_args = subparsers.add_parser("get", help='Get Powerwall Settings and Power Levels')
+    get_mode_args = subparsers.add_parser("get", parents=[common],
+                                           help='Get Powerwall settings and power levels')
+    _add_connection_args(get_mode_args)
     get_mode_args.add_argument("-format", type=str, default="text",
                                 help="Output format: text, json, csv")
-    get_mode_args.add_argument("-host", type=str, default="",
-                                help="IP address of Powerwall Gateway")
-    get_mode_args.add_argument("-password", type=str, default="",
-                                help="Password for Powerwall Gateway")
-    get_mode_args.add_argument("-mode", type=str, default=None,
-                                help="Force connection mode: local, cloud, fleetapi, or tedapi")
+    # Deprecated: old string -mode flag for connection selection; hidden from help
+    get_mode_args.add_argument("-mode", type=str, default=None, dest="legacy_mode",
+                                help=argparse.SUPPRESS)
 
-    version_args = subparsers.add_parser("version", help='Print version information')
-
-    # Add a global debug flag
-    p.add_argument("-debug", action="store_true", default=False, help="Enable debug output")
-    p.add_argument("-authpath", type=str, default=None,
-                   help="Override auth path (default uses PW_AUTH_PATH env var)")
+    version_args = subparsers.add_parser("version", parents=[common],
+                                         help='Print version information')
 
     if len(sys.argv) == 1:
         p.print_help(sys.stderr)
@@ -156,18 +264,31 @@ def main():
         # If env var produced None (shouldn't) or still None-like, fallback to "" (cwd)
         authpath = authpath or ""
 
-    # Debug: Show final authpath resolution before using it
+    # Debug setup
     if args.debug:
-        # Show absolute path if non-empty, otherwise indicate current directory
         display_authpath = os.path.abspath(authpath) if authpath else os.path.abspath(os.getcwd())
         print(f"[DEBUG] Using auth path: {display_authpath} (raw='{authpath}')")
-
-    # Set Debug Mode
-    if args.debug:
         set_debug(True)
 
-    # Cloud Mode Setup
-    elif command == 'setup':
+    # Cloud, FleetAPI, or v1r Setup
+    if command == 'setup':
+        if args.v1r:
+            from pypowerwall.v1r_register import main as fleet_register_main
+            fleet_register_main()
+            return
+
+        if args.fleetapi:
+            from pypowerwall import PyPowerwallFleetAPI
+            print("pyPowerwall [%s] - FleetAPI Mode Setup\n" % version)
+            c = PyPowerwallFleetAPI(None, authpath=authpath)
+            if c.setup():
+                print(f"Setup Complete. Config file {c.configfile} ready to use.")
+            else:
+                print("Setup Aborted.")
+                sys.exit(1)
+            return
+
+        # Cloud setup (default, also explicit with -cloud)
         from pypowerwall.tesla_auth import login as tesla_login
         from pypowerwall import PyPowerwallCloud
 
@@ -246,11 +367,12 @@ def main():
             print(f"\n❌ Login failed: {e}")
             sys.exit(1)
 
-    # FleetAPI Mode Setup
+    # FleetAPI Mode Setup (deprecated — use: setup -fleetapi)
     elif command == 'fleetapi':
+        print("⚠️  'fleetapi' command is deprecated. Use 'setup -fleetapi' instead.")
+        print("   python -m pypowerwall setup -fleetapi")
         from pypowerwall import PyPowerwallFleetAPI
-
-        print("pyPowerwall [%s] - FleetAPI Mode Setup\n" % version)
+        print("\npyPowerwall [%s] - FleetAPI Mode Setup\n" % version)
         # Run Setup
         c = PyPowerwallFleetAPI(None, authpath=authpath)
         if c.setup():
@@ -304,17 +426,15 @@ def main():
 
     # Set Powerwall Mode
     elif command == 'set':
-        # If no arguments, print usage
+        # If no action arguments, print usage
         if not args.mode and args.reserve == -1 and not args.current and not args.gridcharging and not args.gridexport:
-            print("usage: pypowerwall set [-h] [-mode MODE] [-reserve RESERVE] [-current] [-gridcharging MODE] [-gridexport MODE]")
+            set_mode_args.print_usage()
             sys.exit(1)
-        import pypowerwall
-        # Determine which cloud mode to use
-        pw = pypowerwall.Powerwall(auto_select=True, host="", authpath=authpath)
-        print(f"pyPowerwall [{version}] - Set Powerwall Mode and Power Levels using {pw.mode} mode.\n")
+        pw = _build_powerwall(args, authpath)
         if not pw.is_connected():
-            print("ERROR: FleetAPI and Cloud access are not configured. Run 'fleetapi' or 'setup'.")
+            print("ERROR: Unable to connect. Check connection mode and credentials.")
             sys.exit(1)
+        print(f"pyPowerwall [{version}] - Set Powerwall settings using {pw.mode} mode.\n")
         if args.mode:
             mode = args.mode.lower()
             if mode not in ['self_consumption', 'backup', 'autonomous']:
@@ -347,57 +467,55 @@ def main():
 
     # Get Powerwall Mode
     elif command == 'get':
-        import pypowerwall
-        # Determine connection mode
-        if args.mode:
-            mode = args.mode.lower()
-            if mode == 'local':
-                pw = pypowerwall.Powerwall(host=args.host, password=args.password, authpath=authpath)
-            elif mode == 'cloud':
-                email = _email_from_auth(authpath)
-                pw = pypowerwall.Powerwall(cloudmode=True, fleetapi=False, authpath=authpath, email=email)
-            elif mode == 'fleetapi':
-                email = _email_from_auth(authpath)
-                pw = pypowerwall.Powerwall(cloudmode=True, fleetapi=True, authpath=authpath, email=email)
+        # Backward compat: deprecated 'get -mode <value>' → new boolean flag
+        if getattr(args, 'legacy_mode', None):
+            _legacy_mode_map = {
+                'local': 'local', 'cloud': 'cloud', 'fleetapi': 'fleetapi',
+                'tedapi': 'tedapi', 'v1r': 'v1r',
+            }
+            _mapped = _legacy_mode_map.get(args.legacy_mode.lower())
+            if _mapped:
+                print(f"⚠️  Deprecated: 'get -mode {args.legacy_mode}' — use 'get -{args.legacy_mode}' instead.")
+                setattr(args, _mapped, True)
             else:
-                print(f"ERROR: Invalid mode '{mode}' - must be one of: local, cloud, fleetapi")
+                print(f"ERROR: Unknown connection mode '{args.legacy_mode}'. Use -local, -cloud, -fleetapi, -tedapi, or -v1r.")
                 sys.exit(1)
-        else:
-            pw = pypowerwall.Powerwall(auto_select=True, authpath=authpath, password=args.password,
-                                        host=args.host)
-        if args.format == 'text':
-            print(f"pyPowerwall [{version}] - Get Powerwall Mode and Power Levels using {pw.mode} mode.\n")
+        pw = _build_powerwall(args, authpath)
         if not pw.is_connected():
             print("ERROR: Unable to connect. Set -host and -password or configure FleetAPI or Cloud access.")
             sys.exit(1)
+        if args.format == 'text':
+            print(f"pyPowerwall [{version}] - Get Powerwall settings using {pw.mode} mode.\n")
         output = {
             'site': pw.site_name(),
             'site_id': pw.siteid or "N/A",
             'din': pw.din(),
+            'firmware': pw.version(),
             'mode': pw.get_mode(),
             'reserve': pw.get_reserve(),
             'soc': pw.level(),
-            'current': pw.level(),
+            'grid_status': pw.grid_status(),
             'grid': pw.grid(),
             'home': pw.home(),
             'battery': pw.battery(),
             'solar': pw.solar(),
             'grid_charging': pw.get_grid_charging(),
             'grid_export_mode': pw.get_grid_export(),
+            'time_remaining': pw.get_time_remaining(),
         }
         if args.format == 'json':
             print(json.dumps(output, indent=2))
         elif args.format == 'csv':
-            # create a csv header from keys
             header = ",".join(output.keys())
             print(header)
-            values = ",".join(str(value) for value in output.values())
+            values = ",".join("N/A" if v is None else str(v) for v in output.values())
             print(values)
         else:
             # Table Output
             for item in output:
                 name = item.replace("_", " ").title()
-                print("  {:<18}{}".format(name, output[item]))
+                value = output[item]
+                print("  {:<18}{}".format(name, "N/A" if value is None else value))
             print("")
 
     # Print Version

--- a/pypowerwall/fleetapi/pypowerwall_fleetapi.py
+++ b/pypowerwall/fleetapi/pypowerwall_fleetapi.py
@@ -396,8 +396,12 @@ class PyPowerwallFleetAPI(PyPowerwallBase):
     def get_api_system_status_soe(self, **kwargs) -> Optional[Union[dict, list, str, bytes]]:
         force = kwargs.get('force', False)
         percentage_charged = self.fleet.battery_level(force=force) or 0
+        # battery_level() returns Tesla App scale (0–100% of usable capacity);
+        # convert to raw physical percentage so level(scale=False) returns the
+        # actual level and level(scale=True) correctly derives the app value.
+        soe = (percentage_charged + (5 / 0.95)) * 0.95
         data = {
-            "percentage": percentage_charged
+            "percentage": soe
         }
         return data
 

--- a/pypowerwall/v1r_register.py
+++ b/pypowerwall/v1r_register.py
@@ -580,7 +580,7 @@ def owner_api_login(email=None, authpath="", force_reauth=False):
     return token
 
 
-def main():
+def main(authpath=""):
     print("=" * 70)
     print("  Tesla RSA Key Registration for Powerwall v1r LAN Mode")
     print("=" * 70)
@@ -624,7 +624,7 @@ def main():
         # ── Owner API path (default) ──────────────────────────────────────────
         email = None
         for attempt in range(2):
-            token = owner_api_login(email=email, force_reauth=(attempt > 0))
+            token = owner_api_login(email=email, authpath=authpath, force_reauth=(attempt > 0))
             try:
                 site_id, din = step3_get_site_id(token, OWNER_API_BASE)
                 break


### PR DESCRIPTION
## Summary

The pypowerwall CLI was inconsistent and difficult to use. It has grown organically over time. This is an attempt to clean it up.

```
Usage: PyPowerwall [-h] [-debug] [-authpath AUTHPATH]
                   {setup,login,authtoken,fleetapi,tedapi,register,scan,set,get,version}
                   ...

PyPowerwall Module v0.15.6

Global options (apply to all commands):
  -debug              Enable debug output
  -authpath PATH      Override auth file directory (default: PW_AUTH_PATH env var)

Commands (run <command> -h for full usage):
  setup               Setup Tesla Cloud, Fleet API, or v1r LAN TEDAPI access
  login               [Deprecated] Use: setup
  authtoken           Get a Tesla Cloud refresh token (prints to stdout)
  fleetapi            [Deprecated] Use: setup -fleetapi
  tedapi              Test TEDAPI connection to Powerwall Gateway
  register            Register RSA key with Powerwall (for v1r LAN mode)
  scan                Scan local network for Powerwall gateway
  set                 Set Powerwall operating mode and reserve level
  get                 Get Powerwall settings and power levels
  version             Print version information
```

## Details

* Feat: CLI (`python -m pypowerwall`) redesigned for consistency across all connection modes
    * Replace string `-mode` flag on `get` (which clashed with `set -mode`) with explicit boolean connection flags: `-local`, `-cloud`, `-fleetapi`, `-tedapi`, `-v1r` — available on both `get` and `set`
    * **Backward compat:** `get -mode <value>` still accepted with a deprecation warning; e.g. `get -mode v1r` behaves identically to `get -v1r`
    * Add `-host`, `-password`, `-gw_pwd`, `-rsa_key_path` credential flags to `get` and `set` subcommands
    * Add global `-debug` and `-authpath` flags (via shared parent parser) available to every subcommand
    * `setup` subcommand now handles all auth flows: default/`-cloud` (Tesla Owners API), `-fleetapi` (Fleet API wizard), `-v1r` (RSA key registration) — replacing the now-deprecated `fleetapi` top-level command
    * `get` output expanded: adds `firmware`, `grid_status`, and `time_remaining` fields; `None` values display as `N/A` in text/CSV output
    * Pre-flight checks in `get` and `set`: if `-cloud` or `-fleetapi` is specified but the required config file is missing, a clear error message with setup instructions is printed before any connection attempt
    * Connection check (`is_connected()`) now runs before the output banner — no partial output on failure
    * `fleetapi` top-level command shows deprecation warning and points to `setup -fleetapi`; `login` command shows deprecation warning and exits
* Docs: Update `README.md` CLI section — new command list with global flags, connection mode flag reference table, examples for all 5 connection modes, updated setup commands (`fleetapi` → `setup -fleetapi`, `setup -v1r`)
