### PR TITLE
feat: Add PW_SITE_ZERO_THRESHOLD to suppress phantom grid noise

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 # RELEASE NOTES
 
+## v0.15.7 - Site Zero Threshold (Phantom Grid Noise Suppression)
+
+* Feat: Add `PW_SITE_ZERO_THRESHOLD` environment variable to suppress phantom grid noise readings
+  * When set to a positive integer value (in watts), site power readings with absolute value at or below the threshold are reported as 0
+  * Applies to `/api/meters/aggregates` site power, `/vitals` grid power, and CSV/grid power endpoints
+  * Useful for off-grid and night-time scenarios where sensor noise causes small non-zero grid readings (e.g. 5–15W phantom draw)
+  * Default is `0` (disabled — no suppression)
+* Proxy build t89
+
 ## v0.15.6 - Reserve Percent Scaling Fix + CLI Redesign
 
 * Fix: `set_operation()` reserve percent scaling — reverse Tesla App scaling (0–100%) to raw API scale (5–100%) only in TEDAPI v1r mode, avoiding incorrect round-trip values in cloud and FleetAPI modes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 
 * Feat: Add `PW_SITE_ZERO_THRESHOLD` environment variable to suppress phantom grid noise readings
   * When set to a positive integer value (in watts), site power readings with absolute value at or below the threshold are reported as 0
-  * Applies to `/api/meters/aggregates` site power, `/vitals` grid power, and CSV/grid power endpoints
+  * Applies to `/api/meters/aggregates` site power, `/csv`/`/csv/v2` grid power, and `/json` grid power endpoints
   * Useful for off-grid and night-time scenarios where sensor noise causes small non-zero grid readings (e.g. 5–15W phantom draw)
   * Default is `0` (disabled — no suppression)
 * Proxy build t89

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -1271,12 +1271,14 @@ class Handler(BaseHTTPRequestHandler):
                 if site_zero_threshold > 0 and grid is not None and abs(grid) <= site_zero_threshold:
                     grid = 0
 
+                # Convert None to 0 for output (None = data gap, output as 0)
+                grid = grid or 0
+                solar = solar or 0
+                battery = battery or 0
+                home = home or 0
+
                 # Get battery level - poll() handles caching internally
                 batterylevel = safe_pw_call(pw.level) or 0
-
-                # If data fetch failed, return None to indicate a gap
-                if grid is None:
-                    return None
 
                 if is_v2:
                     # Get grid status and reserve - these use cached data internally
@@ -1772,6 +1774,12 @@ class Handler(BaseHTTPRequestHandler):
                 # Pass through None values — they indicate a data gap, not zero
                 if site_zero_threshold > 0 and grid is not None and abs(grid) <= site_zero_threshold:
                     grid = 0
+
+                # Convert None to 0 for output (None = data gap, output as 0)
+                grid = grid or 0
+                solar = solar or 0
+                battery = battery or 0
+                home = home or 0
 
                 # Get remaining data
                 d = safe_pw_call(pw.system_status) or {}

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -1242,6 +1242,7 @@ class Handler(BaseHTTPRequestHandler):
             # CSV Output - Grid,Home,Solar,Battery,Level
             # CSV2 Output - Grid,Home,Solar,Battery,Level,GridStatus,Reserve
             # Add ?headers to include CSV headers, e.g. http://localhost:8675/csv?headers
+            # None values are treated as 0 in CSV output (use JSON endpoints to see data gaps as nulls)
             contenttype = "text/plain; charset=utf-8"
 
             # Determine endpoint and whether to include headers
@@ -1258,17 +1259,17 @@ class Handler(BaseHTTPRequestHandler):
                     battery = aggregates.get('battery', {}).get('instant_power', 0)
                     home = aggregates.get('load', {}).get('instant_power', 0)
                 else:
-                    grid = solar = battery = home = None
+                    grid = solar = battery = home = 0
                 
                 # Apply negative solar correction if configured
-                if not neg_solar and solar is not None and solar < 0:
+                if not neg_solar and solar < 0:
                     # Shift energy from solar to load
                     home -= solar
                     solar = 0
 
                 # Apply site zero threshold - suppress phantom grid noise
                 # Pass through None values — they indicate a data gap, not zero
-                if site_zero_threshold > 0 and grid is not None and abs(grid) <= site_zero_threshold:
+                if site_zero_threshold > 0 and abs(grid) <= site_zero_threshold:
                     grid = 0
 
                 # Convert None to 0 for output (None = data gap, output as 0)

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -189,6 +189,7 @@ gw_pwd = os.getenv("PW_GW_PWD", None)
 rsa_key_path = os.getenv("PW_RSA_KEY_PATH", None)
 wifi_host = os.getenv("PW_WIFI_HOST", None)
 neg_solar = os.getenv("PW_NEG_SOLAR", "yes").lower() == "yes"
+site_zero_threshold = int(os.getenv("PW_SITE_ZERO_THRESHOLD", "0"))
 api_base_url = os.getenv(
     "PROXY_BASE_URL", "/"
 )  # Prefix for public API calls, e.g. if you have everything behind a reverse proxy
@@ -259,6 +260,7 @@ proxystats = {
         "PW_RSA_KEY_PATH": rsa_key_path,
         "PW_WIFI_HOST": wifi_host,
         "PW_NEG_SOLAR": neg_solar,
+        "PW_SITE_ZERO_THRESHOLD": site_zero_threshold,
         "PW_SUPPRESS_NETWORK_ERRORS": suppress_network_errors,
         "PW_NETWORK_ERROR_RATE_LIMIT": network_error_rate_limit,
         "PW_FAIL_FAST": fail_fast_mode,
@@ -1183,6 +1185,16 @@ class Handler(BaseHTTPRequestHandler):
                     except (json.JSONDecodeError, TypeError):
                         aggregates = None
 
+                # Apply site zero threshold - suppress phantom grid noise
+                if (
+                    site_zero_threshold > 0
+                    and aggregates
+                    and "site" in aggregates
+                    and "instant_power" in aggregates["site"]
+                    and abs(aggregates["site"]["instant_power"]) <= site_zero_threshold
+                ):
+                    aggregates["site"]["instant_power"] = 0
+
                 if aggregates and not neg_solar and "solar" in aggregates:
                     solar = aggregates["solar"]
                     if solar and "instant_power" in solar and solar["instant_power"] < 0:
@@ -1247,7 +1259,11 @@ class Handler(BaseHTTPRequestHandler):
                     # Shift energy from solar to load
                     home -= solar
                     solar = 0
-                
+
+                # Apply site zero threshold - suppress phantom grid noise
+                if site_zero_threshold > 0 and abs(grid) <= site_zero_threshold:
+                    grid = 0
+
                 # Get battery level - poll() handles caching internally
                 batterylevel = safe_pw_call(pw.level) or 0
                 
@@ -1740,7 +1756,11 @@ class Handler(BaseHTTPRequestHandler):
                     # Shift energy from solar to load
                     home -= solar
                     solar = 0
-                
+
+                # Apply site zero threshold - suppress phantom grid noise
+                if site_zero_threshold > 0 and abs(grid) <= site_zero_threshold:
+                    grid = 0
+
                 # Get remaining data
                 d = safe_pw_call(pw.system_status) or {}
                 values = {

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -192,7 +192,7 @@ neg_solar = os.getenv("PW_NEG_SOLAR", "yes").lower() == "yes"
 try:
     site_zero_threshold = int(os.getenv("PW_SITE_ZERO_THRESHOLD", "0"))
 except (ValueError, TypeError):
-    log("WARNING: PW_SITE_ZERO_THRESHOLD must be an integer, defaulting to 0")
+    print(f"WARNING: PW_SITE_ZERO_THRESHOLD must be an integer, defaulting to 0")
     site_zero_threshold = 0
 api_base_url = os.getenv(
     "PROXY_BASE_URL", "/"

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -494,20 +494,20 @@ def get_performance_cached(cache_key):
     """
     Get cached endpoint response for performance optimization.
     Uses standard cache_expire TTL (typically 5 seconds).
-    
+
     Args:
         cache_key: The cache key (e.g., '/csv/v2', '/json', '/freq', '/pod')
-    
+
     Returns:
         Cached response string if available and fresh, None otherwise
     """
     with _performance_cache_lock:
         if cache_key not in _performance_cache:
             return None
-        
+
         data, timestamp = _performance_cache[cache_key]
         age = time.time() - timestamp
-        
+
         # Use standard cache_expire (same as pypowerwall's internal cache)
         if age < cache_expire:
             log.debug(f"Performance cache hit for {cache_key} (age: {age:.2f}s)")
@@ -520,7 +520,7 @@ def get_performance_cached(cache_key):
 def cache_performance_response(cache_key, data):
     """
     Cache endpoint response for performance optimization.
-    
+
     Args:
         cache_key: The cache key (e.g., '/csv/v2', '/json', '/freq', '/pod')
         data: The response string to cache
@@ -533,10 +533,10 @@ def cache_performance_response(cache_key, data):
 def performance_cached(cache_key):
     """
     Decorator for performance caching of route handlers.
-    
+
     Args:
         cache_key: The cache key to use (e.g., '/vitals', '/strings', '/freq')
-    
+
     Returns:
         Decorator function that wraps route handlers with caching logic
     """
@@ -546,16 +546,16 @@ def performance_cached(cache_key):
             cached_response = get_performance_cached(cache_key)
             if cached_response is not None:
                 return cached_response
-            
+
             # Cache miss - generate fresh data
             result = func(*args, **kwargs)
-            
+
             # Only cache non-None results
             if result is not None:
                 cache_performance_response(cache_key, result)
-            
+
             return result
-        
+
         return wrapper
     return decorator
 
@@ -563,11 +563,11 @@ def performance_cached(cache_key):
 def cached_route_handler(cache_key, data_generator):
     """
     Helper function for performance-cached route handling.
-    
+
     Args:
         cache_key: The cache key to use for this route
         data_generator: Function that generates the response data
-    
+
     Returns:
         Cached response if available, otherwise fresh data (and caches it)
     """
@@ -575,14 +575,14 @@ def cached_route_handler(cache_key, data_generator):
     cached_response = get_performance_cached(cache_key)
     if cached_response is not None:
         return cached_response
-    
+
     # Cache miss - generate fresh data
     result = data_generator()
-    
+
     # Only cache non-None results
     if result is not None:
         cache_performance_response(cache_key, result)
-    
+
     return result
 
 
@@ -1190,7 +1190,7 @@ class Handler(BaseHTTPRequestHandler):
                         aggregates = None
 
                 # Apply site zero threshold - suppress phantom grid noise
-                # Pass through None values — they indicate a data gap, not zero
+                # Pass through None values - they indicate a data gap, not zero
                 if (
                     site_zero_threshold > 0
                     and aggregates
@@ -1243,12 +1243,12 @@ class Handler(BaseHTTPRequestHandler):
             # CSV2 Output - Grid,Home,Solar,Battery,Level,GridStatus,Reserve
             # Add ?headers to include CSV headers, e.g. http://localhost:8675/csv?headers
             contenttype = "text/plain; charset=utf-8"
-            
+
             # Determine endpoint and whether to include headers
             is_v2 = request_path.startswith("/csv/v2")
             include_headers = "headers" in request_path
             cache_key = f"/csv/v2{'_headers' if include_headers else ''}" if is_v2 else f"/csv{'_headers' if include_headers else ''}"
-            
+
             def generate_csv():
                 # Optimization: Use single aggregates call for all power values
                 aggregates = safe_endpoint_call("/aggregates", pw.poll, "/api/meters/aggregates", jsonformat=False)
@@ -1258,10 +1258,10 @@ class Handler(BaseHTTPRequestHandler):
                     battery = aggregates.get('battery', {}).get('instant_power', 0)
                     home = aggregates.get('load', {}).get('instant_power', 0)
                 else:
-                    grid = solar = battery = home = 0
+                    grid = solar = battery = home = None
                 
                 # Apply negative solar correction if configured
-                if not neg_solar and solar < 0:
+                if not neg_solar and solar is not None and solar < 0:
                     # Shift energy from solar to load
                     home -= solar
                     solar = 0
@@ -1273,12 +1273,16 @@ class Handler(BaseHTTPRequestHandler):
 
                 # Get battery level - poll() handles caching internally
                 batterylevel = safe_pw_call(pw.level) or 0
-                
+
+                # If data fetch failed, return None to indicate a gap
+                if grid is None:
+                    return None
+
                 if is_v2:
                     # Get grid status and reserve - these use cached data internally
                     gridstatus = 1 if safe_pw_call(pw.grid_status) == "UP" else 0
                     reserve = safe_pw_call(pw.get_reserve) or 0
-                
+
                 # Build CSV response
                 if is_v2:
                     result = ""
@@ -1307,7 +1311,7 @@ class Handler(BaseHTTPRequestHandler):
                         batterylevel,
                     )
                 return result
-            
+
             message = cached_route_handler(cache_key, generate_csv)
         elif request_path == "/vitals":
             # Vitals Data - JSON
@@ -1360,7 +1364,7 @@ class Handler(BaseHTTPRequestHandler):
                     proxystats["mem_cache"]["error_counts"] = {
                         "entries": len(_error_counts),
                         "size_bytes": sys.getsizeof(_error_counts) + sum(
-                            sys.getsizeof(k) + sys.getsizeof(v) 
+                            sys.getsizeof(k) + sys.getsizeof(v)
                             for k, v in _error_counts.items()
                         ),
                     }
@@ -1368,7 +1372,7 @@ class Handler(BaseHTTPRequestHandler):
                         "entries": len(_network_error_summary),
                         "size_bytes": sys.getsizeof(_network_error_summary) + sum(
                             sys.getsizeof(k) + sys.getsizeof(v) + sum(
-                                sys.getsizeof(ek) + sys.getsizeof(ev) 
+                                sys.getsizeof(ek) + sys.getsizeof(ev)
                                 for ek, ev in v.items()
                             ) for k, v in _network_error_summary.items()
                         ),
@@ -1397,7 +1401,7 @@ class Handler(BaseHTTPRequestHandler):
                         "entries": len(_endpoint_stats),
                         "size_bytes": sys.getsizeof(_endpoint_stats) + sum(
                             sys.getsizeof(k) + sys.getsizeof(v) + sum(
-                                sys.getsizeof(ek) + sys.getsizeof(ev) 
+                                sys.getsizeof(ek) + sys.getsizeof(ev)
                                 for ek, ev in v.items()
                             ) for k, v in _endpoint_stats.items()
                         ),
@@ -1562,7 +1566,7 @@ class Handler(BaseHTTPRequestHandler):
                         pwtemp[key] = temps[i]
                         idx = idx + 1
                 return json.dumps(pwtemp)
-            
+
             message = cached_route_handler("/temps/pw", generate_temps_pw)
         elif request_path == "/alerts":
             # Alerts
@@ -1578,7 +1582,7 @@ class Handler(BaseHTTPRequestHandler):
                     for alert in alerts:
                         pwalerts[alert] = 1
                     return json.dumps(pwalerts) or json.dumps({})
-            
+
             message = cached_route_handler("/alerts/pw", generate_alerts_pw)
         elif request_path == "/freq":
             # Frequency, Current, Voltage and Grid Status
@@ -1624,7 +1628,7 @@ class Handler(BaseHTTPRequestHandler):
                                 fcv[i] = d[i]
                 fcv["grid_status"] = safe_pw_call(pw.grid_status, "numeric")
                 return json.dumps(fcv)
-            
+
             message = cached_route_handler("/freq", generate_freq)
         elif request_path == "/pod":
             # Powerwall Battery Data
@@ -1743,7 +1747,7 @@ class Handler(BaseHTTPRequestHandler):
                 pod["time_remaining_hours"] = safe_pw_call(pw.get_time_remaining)
                 pod["backup_reserve_percent"] = safe_pw_call(pw.get_reserve)
                 return json.dumps(pod)
-            
+
             message = cached_route_handler("/pod", generate_pod)
         elif request_path == "/json":
             # JSON - Grid,Home,Solar,Battery,Level,GridStatus,Reserve,TimeRemaining,FullEnergy,RemainingEnergy,Strings
@@ -1756,10 +1760,10 @@ class Handler(BaseHTTPRequestHandler):
                     battery = aggregates.get('battery', {}).get('instant_power', 0)
                     home = aggregates.get('load', {}).get('instant_power', 0)
                 else:
-                    grid = solar = battery = home = 0
-                
+                    grid = solar = battery = home = None
+
                 # Apply negative solar correction if configured
-                if not neg_solar and solar < 0:
+                if not neg_solar and solar is not None and solar < 0:
                     # Shift energy from solar to load
                     home -= solar
                     solar = 0
@@ -1785,7 +1789,7 @@ class Handler(BaseHTTPRequestHandler):
                     "strings": safe_pw_call(pw.strings, jsonformat=False) or {},
                 }
                 return json.dumps(values)
-            
+
             message = cached_route_handler("/json", generate_json)
         elif request_path == "/version":
             # Firmware Version

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -128,7 +128,7 @@ from pypowerwall.fleetapi.exceptions import (
     PyPowerwallFleetAPIInvalidPayload,
 )
 
-BUILD = "t88"
+BUILD = "t89"
 ALLOWLIST = [
     "/api/status",
     "/api/site_info/site_name",

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -189,7 +189,11 @@ gw_pwd = os.getenv("PW_GW_PWD", None)
 rsa_key_path = os.getenv("PW_RSA_KEY_PATH", None)
 wifi_host = os.getenv("PW_WIFI_HOST", None)
 neg_solar = os.getenv("PW_NEG_SOLAR", "yes").lower() == "yes"
-site_zero_threshold = int(os.getenv("PW_SITE_ZERO_THRESHOLD", "0"))
+try:
+    site_zero_threshold = int(os.getenv("PW_SITE_ZERO_THRESHOLD", "0"))
+except (ValueError, TypeError):
+    log("WARNING: PW_SITE_ZERO_THRESHOLD must be an integer, defaulting to 0")
+    site_zero_threshold = 0
 api_base_url = os.getenv(
     "PROXY_BASE_URL", "/"
 )  # Prefix for public API calls, e.g. if you have everything behind a reverse proxy
@@ -1186,11 +1190,13 @@ class Handler(BaseHTTPRequestHandler):
                         aggregates = None
 
                 # Apply site zero threshold - suppress phantom grid noise
+                # Pass through None values — they indicate a data gap, not zero
                 if (
                     site_zero_threshold > 0
                     and aggregates
                     and "site" in aggregates
                     and "instant_power" in aggregates["site"]
+                    and aggregates["site"]["instant_power"] is not None
                     and abs(aggregates["site"]["instant_power"]) <= site_zero_threshold
                 ):
                     aggregates["site"]["instant_power"] = 0
@@ -1261,7 +1267,8 @@ class Handler(BaseHTTPRequestHandler):
                     solar = 0
 
                 # Apply site zero threshold - suppress phantom grid noise
-                if site_zero_threshold > 0 and abs(grid) <= site_zero_threshold:
+                # Pass through None values — they indicate a data gap, not zero
+                if site_zero_threshold > 0 and grid is not None and abs(grid) <= site_zero_threshold:
                     grid = 0
 
                 # Get battery level - poll() handles caching internally
@@ -1758,7 +1765,8 @@ class Handler(BaseHTTPRequestHandler):
                     solar = 0
 
                 # Apply site zero threshold - suppress phantom grid noise
-                if site_zero_threshold > 0 and abs(grid) <= site_zero_threshold:
+                # Pass through None values — they indicate a data gap, not zero
+                if site_zero_threshold > 0 and grid is not None and abs(grid) <= site_zero_threshold:
                     grid = 0
 
                 # Get remaining data


### PR DESCRIPTION
## Summary

Adds `PW_SITE_ZERO_THRESHOLD` environment variable (default: `0`, disabled) to suppress phantom grid import/export readings caused by CT sensor noise.

When set to a positive integer (watts), any `site.instant_power` value with an absolute value at or below the threshold is clamped to `0W`.

## Problem

When the Tesla Gateway is physically off-grid (or at night with idle solar), the local API reports a persistent tiny grid import — typically 1–5W. This is a known CT sensor noise artifact, and the official Tesla app already suppresses these readings. However, pypowerwall passes them through, accumulating phantom grid totals in dashboards and historical data.

## Implementation

- **Config:** `PW_SITE_ZERO_THRESHOLD` env var, parsed as `int`, default `0` (disabled — no behavior change)
- **Applied in three locations:**
  - `/aggregates` endpoint — modifies `aggregates["site"]["instant_power"]` directly
  - `/csv` and `/csv/v2` endpoints — clamps the extracted `grid` value
  - `/json` endpoint — clamps the extracted `grid` value
- **Uses `<=` threshold** — values exactly at the threshold are suppressed
- **Bidirectional** — suppresses both import and export noise (matching the request)
- **Follows `PW_NEG_SOLAR` pattern** — same style of env-var-driven data cleanup

## Testing

With `PW_SITE_ZERO_THRESHOLD=5`:
- Raw site.instant_power of +2W → reported as 0W ✅
- Raw site.instant_power of -3W → reported as 0W ✅
- Raw site.instant_power of +50W → passed through as 50W ✅
- Default (0) → all values passed through unchanged ✅

Closes #295