### PR TITLE
fix: promote connection diagnostics from debug to error/warning level

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,16 @@
 # RELEASE NOTES
 
+## v0.15.9 - Improved Connection Error Diagnostics
+
+* Fix: Promote connection failure messages from `debug` to `error`/`warning` log level so users see actionable diagnostics without enabling debug mode (#160)
+  * Login failures in local mode now show `error`-level messages with specific guidance (check password, check network reachability)
+  * Login errors now distinguish between auth failures (401/403 → "check password") and connectivity failures (other HTTP status → "check gateway reachability")
+  * Connection attempt fallback messages (Local → FleetAPI → Cloud) promoted from `debug` to `warning` level, including the exception details
+  * API timeout and connection errors during polling now log at `error` level with the affected endpoint and host
+  * Connection refused errors include the specific exception message
+* Fix: Final "Unable to connect to Powerwall" error message now includes guidance to verify host, credentials, and network connectivity, and suggests enabling debug logging for more detail
+* Bump library version to `0.15.9`
+
 ## v0.15.8 - authpath Support for v1r Setup Files
 
 * Fix: `python -m pypowerwall setup -v1r -authpath <dir>` now correctly writes all generated files into the specified directory instead of the current working directory

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -89,7 +89,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 15, 8)
+version_tuple = (0, 15, 9)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -230,7 +230,8 @@ class Powerwall(object):
 
         # Connect to Powerwall
         if not self.connect(self.retry_modes):
-            log.error("Unable to connect to Powerwall.")
+            log.error("Unable to connect to Powerwall. Verify host, credentials, and network connectivity."
+                     " Enable debug logging for detailed diagnostics.")
 
     def connect(self, retry=False) -> bool:
         """
@@ -295,7 +296,7 @@ class Powerwall(object):
                         self.tedapi_mode = "off"
                     return True
                 except Exception as exc:
-                    log.debug(f"Failed to connect using Local mode: {exc} - trying fleetapi mode.")
+                    log.warning(f"Failed to connect using Local mode: {exc} - trying fleetapi mode.")
                     self.tedapi = False
                     self.tedapi_mode = "off"
                     self.mode = "fleetapi"
@@ -309,7 +310,7 @@ class Powerwall(object):
                     self.siteid = self.client.siteid
                     return True
                 except Exception as exc:
-                    log.debug(f"Failed to connect using FleetAPI mode: {exc} - trying cloud mode.")
+                    log.warning(f"Failed to connect using FleetAPI mode: {exc} - trying cloud mode.")
                     self.mode = "cloud"
                     continue
             if self.mode == "cloud":
@@ -321,7 +322,7 @@ class Powerwall(object):
                     self.siteid = self.client.siteid
                     return True
                 except Exception as exc:
-                    log.debug(f"Failed to connect using Cloud mode: {exc} - trying local mode.")
+                    log.warning(f"Failed to connect using Cloud mode: {exc} - trying local mode.")
                     self.mode = "local"
                     continue
         return False

--- a/pypowerwall/local/pypowerwall_local.py
+++ b/pypowerwall/local/pypowerwall_local.py
@@ -97,7 +97,7 @@ class PyPowerwallLocal(PyPowerwallBase):
             log.debug('login - %s' % r.text)
         except Exception as exc:
             err = f"Unable to connect to Powerwall at https://{self.host}: {exc}"
-            log.debug(err)
+            log.error(f'{err} - check that the gateway is reachable on the network')
             raise ConnectionError(err)
 
         # Save Auth cookies
@@ -114,8 +114,8 @@ class PyPowerwallLocal(PyPowerwallBase):
             except Exception as exc:
                 log.debug(f'unable to cache auth session - continuing: {exc}')
         except Exception as e:
-            log.debug(f'login failed: {e}')
-            raise LoginError("Invalid Powerwall Login")
+            log.warning(f'Login failed: {e}')
+            raise LoginError(f"Invalid Powerwall Login - check password for {self.host}")
 
     def close_session(self):
         url = "https://%s/api/logout" % self.host
@@ -162,13 +162,13 @@ class PyPowerwallLocal(PyPowerwallBase):
                     r: Response = self.session.get(url, cookies=self.auth, verify=False, timeout=self.timeout,
                                                    stream=raw)
             except requests.exceptions.Timeout:
-                log.debug('ERROR Timeout waiting for Powerwall API %s' % url)
+                log.error('Timeout waiting for Powerwall API %s - check network connectivity to %s' % (api, self.host))
                 return None
             except requests.exceptions.ConnectionError:
-                log.debug('ERROR Unable to connect to Powerwall at %s' % url)
+                log.error('Unable to connect to Powerwall at %s - check that the gateway is reachable and powered on' % self.host)
                 return None
             except Exception as exc:
-                log.debug(f'ERROR Unknown error connecting to Powerwall at {url}: {exc}')
+                log.error(f'Unexpected error connecting to Powerwall at {url}: {exc}')
                 return None
             if r.status_code == 404:
                 # API not found or no longer supported

--- a/pypowerwall/local/pypowerwall_local.py
+++ b/pypowerwall/local/pypowerwall_local.py
@@ -115,7 +115,13 @@ class PyPowerwallLocal(PyPowerwallBase):
                 log.debug(f'unable to cache auth session - continuing: {exc}')
         except Exception as e:
             log.warning(f'Login failed: {e}')
-            raise LoginError(f"Invalid Powerwall Login - check password for {self.host}")
+            if r.status_code in (401, 403):
+                raise LoginError(f"Invalid Powerwall Login - check password for {self.host}")
+            else:
+                raise LoginError(
+                    f"Login failed for {self.host} (HTTP {r.status_code}) - "
+                    f"check that the gateway is reachable and responding correctly"
+                )
 
     def close_session(self):
         url = "https://%s/api/logout" % self.host
@@ -164,8 +170,8 @@ class PyPowerwallLocal(PyPowerwallBase):
             except requests.exceptions.Timeout:
                 log.error('Timeout waiting for Powerwall API %s - check network connectivity to %s' % (api, self.host))
                 return None
-            except requests.exceptions.ConnectionError:
-                log.error('Unable to connect to Powerwall at %s - check that the gateway is reachable and powered on' % self.host)
+            except requests.exceptions.ConnectionError as exc:
+                log.error('Unable to connect to Powerwall at %s - %s - check that the gateway is reachable and powered on' % (self.host, exc))
                 return None
             except Exception as exc:
                 log.error(f'Unexpected error connecting to Powerwall at {url}: {exc}')


### PR DESCRIPTION
## Summary

Fixes #160 — pypowerwall silently fails when it can't connect to the gateway, providing no diagnostic information at default logging levels.

## Problem

When the Powerwall gateway becomes unreachable (network issue, password change, firmware reset), users see only generic errors like:

```
[pypowerwall] [ERROR] Failed to get /api/system_status/grid_status
```

This gives no indication of **why** the connection is failing — is it a network issue? Wrong password? Token expired? Gateway powered off?

All the meaningful diagnostic messages were logged at `DEBUG` level, invisible to users running at the default `ERROR` level.

## Changes

**`pypowerwall/local/pypowerwall_local.py`:**
- `poll()`: Timeout, ConnectionError, and unexpected exceptions now log at **error** level with actionable messages
  - Timeout → `"Timeout waiting for Powerwall API /api/... - check network connectivity to <host>"`
  - ConnectionError → `"Unable to connect to Powerwall at <host> - check that the gateway is reachable and powered on"`
  - Unexpected → `"Unexpected error connecting to Powerwall at <url>: <exception>"`
- `_get_session()`: Connection and login failures now log at **error/warning** level
  - Connection failure → `"Unable to connect to Powerwall at https://<host>: <exc> - check that the gateway is reachable on the network"`
  - Login failure → `"Invalid Powerwall Login - check password for <host>"`

**`pypowerwall/__init__.py`:**
- `connect()`: Mode fallback messages promoted from `debug` to `warning` level
- Init error message now includes actionable guidance: `"Verify host, credentials, and network connectivity. Enable debug logging for detailed diagnostics."`

## Before (default logging)

```
[ERROR] Unable to connect to Powerwall.
[ERROR] Failed to get /api/system_status/grid_status
[ERROR] Failed to get /api/system_status/grid_status
[ERROR] Failed to get /api/system_status/grid_status
```

## After (default logging)

```
[WARNING] Failed to connect using Local mode: [errno 111] Connection refused - trying fleetapi mode.
[ERROR] Unable to connect to Powerwall. Verify host, credentials, and network connectivity. Enable debug logging for detailed diagnostics.
[ERROR] Unable to connect to Powerwall at 192.168.1.1 - check that the gateway is reachable and powered on
[ERROR] Timeout waiting for Powerwall API /api/system_status/grid_status - check network connectivity to 192.168.1.1
```

## Testing

- No functional changes — only log level and message text changes
- All existing behavior preserved (returns `None` on errors, same retry logic, same caching)

— Sam 🌊