### PR TITLE
feat(proxy): optional companion param on /control/reserve and /control/mode

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,17 @@
 # RELEASE NOTES
 
+## v0.15.10 - Combined Reserve + Mode Control Endpoint
+
+* feat(proxy): Optional companion parameters on `/control/reserve` and `/control/mode` POST endpoints to update both reserve and mode in a single `set_operation()` call (#308)
+  * `/control/reserve` now accepts optional `mode=$MODE` parameter — calls `set_operation(level, mode)` instead of `set_reserve(level)`
+  * `/control/mode` now accepts optional `level=$RESERVE` parameter — calls `set_operation(level, mode)` instead of `set_mode(mode)`
+  * Prevents duplicate Tesla audit-log entries caused by calling set_reserve + set_mode separately
+  * Invalid companion values return a 400 error without making any Powerwall call (no silent fallback)
+  * Full backward compatibility: omitting the companion parameter preserves original behavior
+  * Added unit tests for all code paths (legacy single-value, combined, and invalid companion)
+  * Updated proxy README with combined-request examples
+* Bump library version to `0.15.10`
+
 ## v0.15.9 - Improved Connection Error Diagnostics
 
 * Fix: Promote connection failure messages from `debug` to `error`/`warning` log level so users see actionable diagnostics without enabling debug mode (#160)

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -343,7 +343,7 @@ curl -X POST -d "value=$MODE&token=$PW_CONTROL_SECRET" http://localhost:8675/con
 # Set Reserve
 curl -X POST -d "value=$RESERVE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/reserve
 
-# Set Mode AND Reserve atomically in a single request (either form works)
+# Set Mode AND Reserve in a single request (either form works)
 curl -X POST -d "value=$MODE&level=$RESERVE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/mode
 curl -X POST -d "value=$RESERVE&mode=$MODE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/reserve
 

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -326,7 +326,9 @@ APIs
 
 * Use `GET` method to read and `POST` to set.
 * Mode: `/control/mode` value=$MODE token=$PW_CONTROL_SECRET
+  * Optional `level=$RESERVE` to update reserve in the same request (single `set_operation()` call).
 * Reserve: `/control/reserve` value=$RESERVE token=$PW_CONTROL_SECRET
+  * Optional `mode=$MODE` to update mode in the same request (single `set_operation()` call).
 
 Examples
 
@@ -340,6 +342,10 @@ curl -X POST -d "value=$MODE&token=$PW_CONTROL_SECRET" http://localhost:8675/con
 
 # Set Reserve
 curl -X POST -d "value=$RESERVE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/reserve
+
+# Set Mode AND Reserve atomically in a single request (either form works)
+curl -X POST -d "value=$MODE&level=$RESERVE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/mode
+curl -X POST -d "value=$RESERVE&mode=$MODE&token=$PW_CONTROL_SECRET" http://localhost:8675/control/reserve
 
 # Enable Grid Charging (true/false)
 curl -X POST -d "value=true&token=$PW_CONTROL_SECRET" http://localhost:8675/control/grid_charging

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -1030,15 +1030,48 @@ class Handler(BaseHTTPRequestHandler):
                                         safe_pw_call(pw_control.get_reserve) or 0
                                     )
                                 elif value.isdigit():
-                                    result = safe_pw_call(
-                                        pw_control.set_reserve, int(value)
-                                    )
-                                    message = json.dumps(
-                                        result
-                                        if result is not None
-                                        else {"error": "Failed to set reserve"}
-                                    )
-                                    log.info(f"Control Command: Set Reserve to {value}")
+                                    # Optional companion `mode` parameter lets a single
+                                    # /control/reserve POST update both reserve and mode
+                                    # in one set_operation() invocation. Without it, a
+                                    # caller that wants to change both has to POST to
+                                    # /control/reserve AND /control/mode, which causes
+                                    # set_operation() to run twice -- writing the Tesla
+                                    # /backup and /operation endpoints twice each and
+                                    # producing duplicate audit-log entries. Omitting
+                                    # the parameter preserves the original behaviour.
+                                    mode = query_params.get("mode", [""])[0]
+                                    if mode in [
+                                        "self_consumption",
+                                        "backup",
+                                        "autonomous",
+                                    ]:
+                                        result = safe_pw_call(
+                                            pw_control.set_operation,
+                                            int(value),
+                                            mode,
+                                        )
+                                        message = json.dumps(
+                                            result
+                                            if result is not None
+                                            else {"error": "Failed to set reserve+mode"}
+                                        )
+                                        log.info(
+                                            f"Control Command: Set Reserve to {value} (mode={mode})"
+                                        )
+                                    elif mode:
+                                        message = (
+                                            '{"error": "Control Command Mode Invalid"}'
+                                        )
+                                    else:
+                                        result = safe_pw_call(
+                                            pw_control.set_reserve, int(value)
+                                        )
+                                        message = json.dumps(
+                                            result
+                                            if result is not None
+                                            else {"error": "Failed to set reserve"}
+                                        )
+                                        log.info(f"Control Command: Set Reserve to {value}")
                                 else:
                                     message = (
                                         '{"error": "Control Command Value Invalid"}'
@@ -1054,13 +1087,35 @@ class Handler(BaseHTTPRequestHandler):
                                     "backup",
                                     "autonomous",
                                 ]:
-                                    result = safe_pw_call(pw_control.set_mode, value)
-                                    message = json.dumps(
-                                        result
-                                        if result is not None
-                                        else {"error": "Failed to set mode"}
-                                    )
-                                    log.info(f"Control Command: Set Mode to {value}")
+                                    # Optional companion `level` parameter -- see the
+                                    # comment in the /control/reserve branch above.
+                                    level = query_params.get("level", [""])[0]
+                                    if level.isdigit():
+                                        result = safe_pw_call(
+                                            pw_control.set_operation,
+                                            int(level),
+                                            value,
+                                        )
+                                        message = json.dumps(
+                                            result
+                                            if result is not None
+                                            else {"error": "Failed to set reserve+mode"}
+                                        )
+                                        log.info(
+                                            f"Control Command: Set Mode to {value} (level={level})"
+                                        )
+                                    elif level:
+                                        message = (
+                                            '{"error": "Control Command Level Invalid"}'
+                                        )
+                                    else:
+                                        result = safe_pw_call(pw_control.set_mode, value)
+                                        message = json.dumps(
+                                            result
+                                            if result is not None
+                                            else {"error": "Failed to set mode"}
+                                        )
+                                        log.info(f"Control Command: Set Mode to {value}")
                                 else:
                                     message = (
                                         '{"error": "Control Command Value Invalid"}'

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -128,7 +128,7 @@ from pypowerwall.fleetapi.exceptions import (
     PyPowerwallFleetAPIInvalidPayload,
 )
 
-BUILD = "t89"
+BUILD = "t90"
 ALLOWLIST = [
     "/api/status",
     "/api/site_info/site_name",

--- a/proxy/tests/test_control_endpoints.py
+++ b/proxy/tests/test_control_endpoints.py
@@ -1,0 +1,196 @@
+"""Tests for /control/reserve and /control/mode POST handlers.
+
+Covers the single-value (legacy) form and the optional companion-parameter
+form (mode= on /control/reserve, level= on /control/mode) added to let a
+caller update both reserve and mode in a single set_operation() invocation.
+"""
+import json
+import unittest
+from http import HTTPStatus
+from io import BytesIO
+from unittest.mock import Mock, patch
+
+from proxy.tests.test_csv_endpoints import UnittestHandler, common_patches
+
+
+SECRET = "test-secret"
+
+
+def _encode(params):
+    return "&".join(f"{k}={v}" for k, v in params.items()).encode("utf-8")
+
+
+def _passthrough_safe_pw_call(fn, *args, **kwargs):
+    return fn(*args, **kwargs)
+
+
+class BaseDoPostTest(unittest.TestCase):
+    def setUp(self):
+        self.handler = UnittestHandler()
+        self.handler.command = "POST"
+
+    def _post(self, path, params):
+        body = _encode(params)
+        self.handler.path = path
+        self.handler.rfile = BytesIO(body)
+        self.handler.headers = {"Content-Length": str(len(body))}
+        self.handler.do_POST()
+
+    def _response_body(self):
+        return self.handler.wfile.getvalue().decode("utf-8")
+
+    def _make_pw_control(self, set_reserve=None, set_mode=None, set_operation=None):
+        pw_control = Mock()
+        pw_control.client = Mock()  # not None -> passes cloud-mode connectivity check
+        pw_control.set_reserve.return_value = set_reserve if set_reserve is not None else {"set_reserve": "ok"}
+        pw_control.set_mode.return_value = set_mode if set_mode is not None else {"set_mode": "ok"}
+        pw_control.set_operation.return_value = set_operation if set_operation is not None else {"set_operation": "ok"}
+        return pw_control
+
+
+class TestControlReserve(BaseDoPostTest):
+    """POST /control/reserve — single-value and combined-with-mode forms."""
+
+    @common_patches
+    @patch("proxy.server.control_secret", SECRET)
+    @patch("proxy.server.pw")
+    @patch("proxy.server.pw_control")
+    @patch("proxy.server.safe_pw_call", side_effect=_passthrough_safe_pw_call)
+    def test_value_only_calls_set_reserve(self, _proxystats_lock, mock_safe, mock_pw_control, mock_pw):
+        """value= alone -> set_reserve(level), set_operation not called (legacy behaviour)."""
+        pw_control = self._make_pw_control()
+        mock_pw_control.client = pw_control.client
+        mock_pw_control.set_reserve = pw_control.set_reserve
+        mock_pw_control.set_operation = pw_control.set_operation
+        mock_pw.tedapi = None
+
+        self._post("/control/reserve", {"value": "50", "token": SECRET})
+
+        pw_control.set_reserve.assert_called_once_with(50)
+        pw_control.set_operation.assert_not_called()
+        self.handler.send_response.assert_called_with(HTTPStatus.OK)
+        self.assertEqual(json.loads(self._response_body()), {"set_reserve": "ok"})
+
+    @common_patches
+    @patch("proxy.server.control_secret", SECRET)
+    @patch("proxy.server.pw")
+    @patch("proxy.server.pw_control")
+    @patch("proxy.server.safe_pw_call", side_effect=_passthrough_safe_pw_call)
+    def test_value_with_valid_mode_calls_set_operation(self, _proxystats_lock, mock_safe, mock_pw_control, mock_pw):
+        """value= + valid mode= -> set_operation(level, mode), neither set_reserve nor set_mode."""
+        pw_control = self._make_pw_control()
+        mock_pw_control.client = pw_control.client
+        mock_pw_control.set_reserve = pw_control.set_reserve
+        mock_pw_control.set_mode = pw_control.set_mode
+        mock_pw_control.set_operation = pw_control.set_operation
+        mock_pw.tedapi = None
+
+        self._post(
+            "/control/reserve",
+            {"value": "5", "mode": "self_consumption", "token": SECRET},
+        )
+
+        pw_control.set_operation.assert_called_once_with(5, "self_consumption")
+        pw_control.set_reserve.assert_not_called()
+        pw_control.set_mode.assert_not_called()
+        self.handler.send_response.assert_called_with(HTTPStatus.OK)
+        self.assertEqual(json.loads(self._response_body()), {"set_operation": "ok"})
+
+    @common_patches
+    @patch("proxy.server.control_secret", SECRET)
+    @patch("proxy.server.pw")
+    @patch("proxy.server.pw_control")
+    @patch("proxy.server.safe_pw_call", side_effect=_passthrough_safe_pw_call)
+    def test_value_with_invalid_mode_returns_error(self, _proxystats_lock, mock_safe, mock_pw_control, mock_pw):
+        """value= + invalid mode= -> 400 error, no Powerwall call (no silent fallback to set_reserve)."""
+        pw_control = self._make_pw_control()
+        mock_pw_control.client = pw_control.client
+        mock_pw_control.set_reserve = pw_control.set_reserve
+        mock_pw_control.set_operation = pw_control.set_operation
+        mock_pw.tedapi = None
+
+        self._post(
+            "/control/reserve",
+            {"value": "5", "mode": "garbage", "token": SECRET},
+        )
+
+        pw_control.set_reserve.assert_not_called()
+        pw_control.set_operation.assert_not_called()
+        self.handler.send_response.assert_called_with(HTTPStatus.BAD_REQUEST)
+        self.assertIn("error", json.loads(self._response_body()))
+
+
+class TestControlMode(BaseDoPostTest):
+    """POST /control/mode — single-value and combined-with-level forms."""
+
+    @common_patches
+    @patch("proxy.server.control_secret", SECRET)
+    @patch("proxy.server.pw")
+    @patch("proxy.server.pw_control")
+    @patch("proxy.server.safe_pw_call", side_effect=_passthrough_safe_pw_call)
+    def test_value_only_calls_set_mode(self, _proxystats_lock, mock_safe, mock_pw_control, mock_pw):
+        """value= alone -> set_mode(mode), set_operation not called (legacy behaviour)."""
+        pw_control = self._make_pw_control()
+        mock_pw_control.client = pw_control.client
+        mock_pw_control.set_mode = pw_control.set_mode
+        mock_pw_control.set_operation = pw_control.set_operation
+        mock_pw.tedapi = None
+
+        self._post("/control/mode", {"value": "backup", "token": SECRET})
+
+        pw_control.set_mode.assert_called_once_with("backup")
+        pw_control.set_operation.assert_not_called()
+        self.handler.send_response.assert_called_with(HTTPStatus.OK)
+        self.assertEqual(json.loads(self._response_body()), {"set_mode": "ok"})
+
+    @common_patches
+    @patch("proxy.server.control_secret", SECRET)
+    @patch("proxy.server.pw")
+    @patch("proxy.server.pw_control")
+    @patch("proxy.server.safe_pw_call", side_effect=_passthrough_safe_pw_call)
+    def test_value_with_valid_level_calls_set_operation(self, _proxystats_lock, mock_safe, mock_pw_control, mock_pw):
+        """value= + valid level= -> set_operation(level, mode), neither set_mode nor set_reserve."""
+        pw_control = self._make_pw_control()
+        mock_pw_control.client = pw_control.client
+        mock_pw_control.set_mode = pw_control.set_mode
+        mock_pw_control.set_reserve = pw_control.set_reserve
+        mock_pw_control.set_operation = pw_control.set_operation
+        mock_pw.tedapi = None
+
+        self._post(
+            "/control/mode",
+            {"value": "backup", "level": "80", "token": SECRET},
+        )
+
+        pw_control.set_operation.assert_called_once_with(80, "backup")
+        pw_control.set_mode.assert_not_called()
+        pw_control.set_reserve.assert_not_called()
+        self.handler.send_response.assert_called_with(HTTPStatus.OK)
+        self.assertEqual(json.loads(self._response_body()), {"set_operation": "ok"})
+
+    @common_patches
+    @patch("proxy.server.control_secret", SECRET)
+    @patch("proxy.server.pw")
+    @patch("proxy.server.pw_control")
+    @patch("proxy.server.safe_pw_call", side_effect=_passthrough_safe_pw_call)
+    def test_value_with_invalid_level_returns_error(self, _proxystats_lock, mock_safe, mock_pw_control, mock_pw):
+        """value= + non-numeric level= -> 400 error, no Powerwall call (no silent fallback to set_mode)."""
+        pw_control = self._make_pw_control()
+        mock_pw_control.client = pw_control.client
+        mock_pw_control.set_mode = pw_control.set_mode
+        mock_pw_control.set_operation = pw_control.set_operation
+        mock_pw.tedapi = None
+
+        self._post(
+            "/control/mode",
+            {"value": "backup", "level": "not-a-number", "token": SECRET},
+        )
+
+        pw_control.set_mode.assert_not_called()
+        pw_control.set_operation.assert_not_called()
+        self.handler.send_response.assert_called_with(HTTPStatus.BAD_REQUEST)
+        self.assertIn("error", json.loads(self._response_body()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -89,7 +89,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 15, 9)
+version_tuple = (0, 15, 10)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 


### PR DESCRIPTION
## Problem

`Powerwall.set_operation(level, mode)` writes both Tesla owner-api endpoints (`/backup` and `/operation`) in one invocation. The proxy currently exposes this only via `set_reserve(level)` and `set_mode(mode)`, each of which backfills the missing argument from `get_reserve()` / `get_mode()` and then runs the full `set_operation()` fan-out.

A caller that needs to change both ends up POSTing to `/control/reserve` **and** `/control/mode`, which calls `set_operation()` twice and hits Tesla's `/backup` and `/operation` endpoints twice each. The Tesla mobile app surfaces every owner-api write in its **Settings → Settings Changes** audit log, so a routine "set reserve and mode together" event shows up as 4 entries (2× Backup Reserve, 2× Operational Mode) instead of 2.

## Change

Add an **optional** companion form parameter to each handler:

```
POST /control/reserve   value=<int>     mode=<self_consumption|backup|autonomous>   # mode optional
POST /control/mode      value=<mode>    level=<int>                                 # level optional
```

When the companion is present and valid, the handler calls `set_operation(level, mode)` directly, avoiding the second dispatcher round-trip. When it's absent the existing `set_reserve` / `set_mode` path is taken unchanged.

Invalid companion values return a clear error rather than silently falling through to the single-value path.

## Compatibility

Fully additive. Existing callers passing only `value=` get exactly today's behaviour — same `set_reserve` / `set_mode` calls, same number of Tesla writes, same response shape. No existing endpoint behaviour changes.

## Examples

```bash
# Change reserve to 5 AND mode to self_consumption in one request:
curl -X POST -d "value=5&mode=self_consumption&token=..." \
     http://pypowerwall:8675/control/reserve

# Equivalent inverse form:
curl -X POST -d "value=self_consumption&level=5&token=..." \
     http://pypowerwall:8675/control/mode

# Original single-value usage is unchanged:
curl -X POST -d "value=5&token=..." http://pypowerwall:8675/control/reserve
curl -X POST -d "value=self_consumption&token=..." http://pypowerwall:8675/control/mode
```

## What's included

- `proxy/server.py`: handler changes for `/control/reserve` and `/control/mode`
- `proxy/tests/test_control_endpoints.py`: new test file covering the legacy and combined forms for both endpoints, plus invalid-companion error paths (6 tests; all 31 proxy tests still pass)
- `proxy/README.md`: documented the new optional params and combined-write example