### PR TITLE
Fix WiFi backoff race condition in multi-threaded proxy

### DIFF
--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -1384,11 +1384,13 @@ class TEDAPI:
             self._test_wifi_path()
             if not self.wifi_available:
                 with self._wifi_lock:
-                    self.wifi_fail_count += 1
-                    backoff = min(60 * (2 ** self.wifi_fail_count), 7680)  # caps at ~128 min
-                    self.wifi_cooldown = time.time() + backoff
-                    log.debug("WiFi unavailable, next retry in %.0fs (failure #%d)",
-                               backoff, self.wifi_fail_count)
+                    # Re-check cooldown: another thread may have set one while we tested
+                    if self.wifi_cooldown <= time.time():
+                        self.wifi_fail_count += 1
+                        backoff = min(60 * (2 ** self.wifi_fail_count), 7680)  # caps at ~128 min
+                        self.wifi_cooldown = time.time() + backoff
+                        log.debug("WiFi unavailable, next retry in %.0fs (failure #%d)",
+                                   backoff, self.wifi_fail_count)
                 return None
         url = f'https://{self.wifi_host}{url_suffix}'
         try:
@@ -1396,15 +1398,17 @@ class TEDAPI:
             if r.status_code in BUSY_CODES:
                 log.warning("WiFi TEDAPI rate limited, activating 60s cooldown")
                 with self._wifi_lock:
-                    self.wifi_fail_count += 1
-                    self.wifi_cooldown = time.time() + 60
+                    if self.wifi_cooldown <= time.time():
+                        self.wifi_fail_count += 1
+                        self.wifi_cooldown = time.time() + 60
                 return None
             if r.status_code != HTTPStatus.OK:
                 log.error("WiFi TEDAPI error for %s: %s", url_suffix, r.status_code)
                 with self._wifi_lock:
-                    self.wifi_fail_count += 1
-                    backoff = min(60 * (2 ** self.wifi_fail_count), 7680)
-                    self.wifi_cooldown = time.time() + backoff
+                    if self.wifi_cooldown <= time.time():
+                        self.wifi_fail_count += 1
+                        backoff = min(60 * (2 ** self.wifi_fail_count), 7680)
+                        self.wifi_cooldown = time.time() + backoff
                 self.wifi_available = False
                 return None
             # Success — reset failure tracking
@@ -1416,9 +1420,10 @@ class TEDAPI:
         except Exception as e:
             log.error("WiFi TEDAPI request failed: %s", e)
             with self._wifi_lock:
-                self.wifi_fail_count += 1
-                backoff = min(60 * (2 ** self.wifi_fail_count), 7680)
-                self.wifi_cooldown = time.time() + backoff
+                if self.wifi_cooldown <= time.time():
+                    self.wifi_fail_count += 1
+                    backoff = min(60 * (2 ** self.wifi_fail_count), 7680)
+                    self.wifi_cooldown = time.time() + backoff
             self.wifi_available = False
             return None
 

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -162,6 +162,7 @@ class TEDAPI:
         self.wifi_cooldown = 0      # timestamp when follower WiFi cooldown expires
         self.wifi_last_success = 0  # timestamp of last successful WiFi call
         self.wifi_fail_count = 0    # consecutive follower WiFi failures (exponential backoff)
+        self._wifi_lock = threading.Lock()  # protects wifi_fail_count and wifi_cooldown
         # LAN (v1r) failure tracking — triggers full fallback to WiFi TEDAPI v1
         self.lan_failed = False     # True when wired LAN is unreachable
         self.lan_fail_count = 0     # consecutive LAN failures
@@ -1371,45 +1372,53 @@ class TEDAPI:
         if not self.wifi_session:
             return None
         # Exponential backoff for follower WiFi failures (60s * 2^fail_count, max 128 min)
-        if self.wifi_cooldown > time.time():
-            remaining = self.wifi_cooldown - time.time()
-            log.debug("WiFi cooldown active (%.0fs remaining), skipping", remaining)
-            return None
+        # Use a lock so concurrent threads don't all increment fail_count simultaneously
+        # and spike the backoff to maximum in one burst (issue #310).
+        with self._wifi_lock:
+            if self.wifi_cooldown > time.time():
+                remaining = self.wifi_cooldown - time.time()
+                log.debug("WiFi cooldown active (%.0fs remaining), skipping", remaining)
+                return None
         # Re-test WiFi if previously unavailable and cooldown has expired
         if not self.wifi_available:
             self._test_wifi_path()
             if not self.wifi_available:
-                self.wifi_fail_count += 1
-                backoff = min(60 * (2 ** self.wifi_fail_count), 7680)  # caps at ~128 min
-                self.wifi_cooldown = time.time() + backoff
-                log.debug("WiFi unavailable, next retry in %.0fs (failure #%d)",
-                           backoff, self.wifi_fail_count)
+                with self._wifi_lock:
+                    self.wifi_fail_count += 1
+                    backoff = min(60 * (2 ** self.wifi_fail_count), 7680)  # caps at ~128 min
+                    self.wifi_cooldown = time.time() + backoff
+                    log.debug("WiFi unavailable, next retry in %.0fs (failure #%d)",
+                               backoff, self.wifi_fail_count)
                 return None
         url = f'https://{self.wifi_host}{url_suffix}'
         try:
             r = self.wifi_session.post(url, data=pb_bytes, timeout=self.timeout)
             if r.status_code in BUSY_CODES:
                 log.warning("WiFi TEDAPI rate limited, activating 60s cooldown")
-                self.wifi_fail_count += 1
-                self.wifi_cooldown = time.time() + 60
+                with self._wifi_lock:
+                    self.wifi_fail_count += 1
+                    self.wifi_cooldown = time.time() + 60
                 return None
             if r.status_code != HTTPStatus.OK:
                 log.error("WiFi TEDAPI error for %s: %s", url_suffix, r.status_code)
-                self.wifi_fail_count += 1
-                backoff = min(60 * (2 ** self.wifi_fail_count), 7680)
-                self.wifi_cooldown = time.time() + backoff
+                with self._wifi_lock:
+                    self.wifi_fail_count += 1
+                    backoff = min(60 * (2 ** self.wifi_fail_count), 7680)
+                    self.wifi_cooldown = time.time() + backoff
                 self.wifi_available = False
                 return None
             # Success — reset failure tracking
             self.wifi_available = True
-            self.wifi_fail_count = 0
-            self.wifi_last_success = time.time()
+            with self._wifi_lock:
+                self.wifi_fail_count = 0
+                self.wifi_last_success = time.time()
             return decompress_response(r.content)
         except Exception as e:
             log.error("WiFi TEDAPI request failed: %s", e)
-            self.wifi_fail_count += 1
-            backoff = min(60 * (2 ** self.wifi_fail_count), 7680)
-            self.wifi_cooldown = time.time() + backoff
+            with self._wifi_lock:
+                self.wifi_fail_count += 1
+                backoff = min(60 * (2 ** self.wifi_fail_count), 7680)
+                self.wifi_cooldown = time.time() + backoff
             self.wifi_available = False
             return None
 


### PR DESCRIPTION
## Problem

Fixes #310 — the WiFi exponential backoff for follower TEDAPI queries jumps to the ~2h maximum in a single burst instead of progressing gradually (60s → 120s → 240s → ...).

**Root cause:** Multiple concurrent threads (one per endpoint poller) all call `_post_tedapi_wifi()` at the same time during a WiFi outage. They all pass the cooldown check simultaneously (none has set it yet), then all increment `wifi_fail_count` independently in the same second:

```
fail_count goes: 1 → 2 → 3 → 4 → 5 → 6 → 7  (7 threads)
backoff goes:   120s → 240s → 480s → 960s → 1920s → 3840s → 7680s (capped)
```

This produces the ~6426s cooldown the reporter saw in `/health`.

## Fix

Add a `threading.Lock` (`_wifi_lock`) that protects all reads and writes of `wifi_fail_count` and `wifi_cooldown` in `_post_tedapi_wifi()`. The cooldown check is now atomic with the cooldown set — only one thread at a time can increment the failure counter and compute the backoff.

**Before:** 7 concurrent failures → backoff jumps straight to 7680s (~2h)
**After:** 7 concurrent failures → first sets 120s, remaining 6 see cooldown active and return immediately

## Testing

- Module imports cleanly
- No new dependencies (threading already imported)
- Lock is per-instance (no cross-instance contention)