### PR TITLE
Fix TypeError when Fleet API returns error during setup

### DIFF
--- a/pypowerwall/fleetapi/fleetapi.py
+++ b/pypowerwall/fleetapi/fleetapi.py
@@ -838,7 +838,7 @@ class FleetAPI:
             print()
             print("         Try deleting your Fleet API config file and re-running setup:")
             print(f"           rm {self.configfile}")
-            print("           python3 -m pypowerwall setup")
+            print("           python3 -m pypowerwall setup -fleetapi")
             return False
         sites = [s for s in raw_sites if s.get('energy_site_id') is not None]
         sel = 0

--- a/pypowerwall/fleetapi/fleetapi.py
+++ b/pypowerwall/fleetapi/fleetapi.py
@@ -828,7 +828,19 @@ class FleetAPI:
         if self.site_id:
             print(f"  Previous site_id: {self.site_id}")
         # Get list of sites and filter out those without energy_site_id
-        sites = [s for s in self.getsites() if s.get('energy_site_id') is not None]
+        raw_sites = self.getsites()
+        if not raw_sites:
+            print("  ERROR: Unable to retrieve sites from Tesla Fleet API.")
+            print("         This usually means:")
+            print("           1. Your partner account is not registered in the current region")
+            print("           2. Your access token does not have the required permissions")
+            print("           3. Your Tesla account has no energy sites")
+            print()
+            print("         Try deleting your Fleet API config file and re-running setup:")
+            print(f"           rm {self.configfile}")
+            print("           python3 -m pypowerwall setup")
+            return False
+        sites = [s for s in raw_sites if s.get('energy_site_id') is not None]
         sel = 0
         # If not set, pick first site
         if not self.site_id and sites:

--- a/pypowerwall/fleetapi/fleetapi.py
+++ b/pypowerwall/fleetapi/fleetapi.py
@@ -837,10 +837,18 @@ class FleetAPI:
             print("           3. Your Tesla account has no energy sites")
             print()
             print("         Try deleting your Fleet API config file and re-running setup:")
-            print(f"           rm {self.configfile}")
+            print(f'           rm "{self.configfile}"')
             print("           python3 -m pypowerwall setup -fleetapi")
             return False
         sites = [s for s in raw_sites if s.get('energy_site_id') is not None]
+        if not sites:
+            print("  ERROR: No energy sites with a Powerwall found in your Tesla account.")
+            print("         Your Tesla account may have vehicles but no Powerwall energy sites.")
+            print()
+            print("         Try deleting your Fleet API config file and re-running setup:")
+            print(f'           rm "{self.configfile}"')
+            print("           python3 -m pypowerwall setup -fleetapi")
+            return False
         sel = 0
         # If not set, pick first site
         if not self.site_id and sites:


### PR DESCRIPTION
## Summary

When  returns  (e.g., due to a 412 region registration error), the list comprehension on line 831 crashes with .

This PR adds a  check before the list comprehension and prints a helpful error message explaining the most common causes.

## Testing

- Verified the error message prints correctly when  returns 
- Normal flow (valid sites returned) is unchanged

Related: #318