### PR TITLE
fix(cloud): use HTTP/2 for Tesla auth token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ pyPowerwall is a Python module to interface with Tesla Energy Gateways for Power
 
 > ⚠️ **NOTICE:** As of Powerwall Firmware version 25.10.0, network routing to the TEDAPI endpoint (`192.168.91.1`) is no longer supported by Tesla. You must connect directly to the Powerwall's Wi‑Fi access point to access TEDAPI data.
 
+> ⚠️ **CLOUD MODE NOTICE:** As of June 2026, Tesla now requires HTTP/2 for both `auth.tesla.com` token endpoints and `owner-api.teslamotors.com` API calls. If you use **Cloud Mode** (Option 3), you must upgrade to **pypowerwall v0.15.11 or later** — earlier versions will fail with `403 Forbidden` errors during setup and API calls. Install the latest version with `pip install --upgrade pypowerwall`.
+
 ## Description
 
 This Python module can be used to monitor and control Tesla Energy Powerwalls. It uses a single class (`Powerwall`) and simple functions to fetch energy data and poll API endpoints on the Gateway.  

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,15 @@
 # RELEASE NOTES
 
+## v0.15.11 - HTTP/2 for Tesla Owner API Calls
+
+* fix(cloud): Extend HTTP/2 support to all owner-api.teslamotors.com API calls, not just auth endpoints (#324) - t91
+  * Tesla now requires HTTP/2 for `owner-api.teslamotors.com/api/1/*` endpoints, matching the auth.tesla.com requirement
+  * `Tesla.request()` now routes owner-api calls through `httpx` with HTTP/2 when available, with automatic fallback to `requests` (HTTP/1.1)
+  * Adds `_HTTP2Response` wrapper class for requests/httpx response compatibility
+  * Fixes 403 errors during `setup` flow (sitelist retrieval) reported in Powerwall-Dashboard #779
+  * Fixes 403 errors during normal cloud-mode polling (PRODUCT_LIST, SITE_DATA, etc.)
+  * Requires `httpx>=0.27.0` (already added to requirements.txt in v0.15.10 dev)
+
 ## v0.15.10 - Combined Reserve + Mode Control Endpoint
 
 * feat(proxy): Optional companion parameters on `/control/reserve` and `/control/mode` POST endpoints to update both reserve and mode in a single `set_operation()` call (#308) - t90

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,9 +2,10 @@
 
 ## v0.15.11 - HTTP/2 for Tesla Owner API Calls
 
-* fix(cloud): Extend HTTP/2 support to all owner-api.teslamotors.com API calls, not just auth endpoints (#324) - t91
+* fix(cloud): Extend HTTP/2 support to all owner-api.teslamotors.com API calls, not just auth endpoints (#324) - t92
   * Tesla now requires HTTP/2 for `owner-api.teslamotors.com/api/1/*` endpoints, matching the auth.tesla.com requirement
   * `Tesla.request()` now routes owner-api calls through `httpx` with HTTP/2 when available, with automatic fallback to `requests` (HTTP/1.1)
+  * `_request_http2` now forwards all session headers (`Content-Type`, `X-Tesla-User-Agent`, `User-Agent`) to httpx instead of a minimal subset — ensures Tesla receives the same fingerprint as the original requests session
   * Adds `_HTTP2Response` wrapper class for requests/httpx response compatibility
   * Fixes 403 errors during `setup` flow (sitelist retrieval) reported in Powerwall-Dashboard #779
   * Fixes 403 errors during normal cloud-mode polling (PRODUCT_LIST, SITE_DATA, etc.)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,8 +2,9 @@
 
 ## v0.15.11 - HTTP/2 for Tesla Owner API Calls
 
-* fix(cloud): Extend HTTP/2 support to all owner-api.teslamotors.com API calls, not just auth endpoints (#324) - t92
+* fix(cloud): Extend HTTP/2 support to all owner-api.teslamotors.com API calls, not just auth endpoints (#324) - t93
   * Tesla now requires HTTP/2 for `owner-api.teslamotors.com/api/1/*` endpoints, matching the auth.tesla.com requirement
+  * Pin `httpx` Tesla auth/API transports to TLS 1.3 when possible, mirroring the TeslaMate fix path for Tesla endpoints while preserving explicit custom `verify` settings
   * `Tesla.request()` now routes owner-api calls through `httpx` with HTTP/2 when available, with automatic fallback to `requests` (HTTP/1.1)
   * `_request_http2` now forwards all session headers (`Content-Type`, `X-Tesla-User-Agent`, `User-Agent`) to httpx instead of a minimal subset — ensures Tesla receives the same fingerprint as the original requests session
   * Adds `_HTTP2Response` wrapper class for requests/httpx response compatibility

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@
   * Adds `_HTTP2Response` wrapper class for requests/httpx response compatibility
   * Fixes 403 errors during `setup` flow (sitelist retrieval) reported in Powerwall-Dashboard #779
   * Fixes 403 errors during normal cloud-mode polling (PRODUCT_LIST, SITE_DATA, etc.)
-  * Requires `httpx>=0.27.0` (already added to requirements.txt in v0.15.10 dev)
+  * Requires `httpx[http2]>=0.27.0` — the `[http2]` extra installs `h2`, which is required for HTTP/2 support; without it, httpx silently falls back to HTTP/1.1
 
 ## v0.15.10 - Combined Reserve + Mode Control Endpoint
 

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -128,7 +128,7 @@ from pypowerwall.fleetapi.exceptions import (
     PyPowerwallFleetAPIInvalidPayload,
 )
 
-BUILD = "t92"
+BUILD = "t93"
 ALLOWLIST = [
     "/api/status",
     "/api/site_info/site_name",

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -128,7 +128,7 @@ from pypowerwall.fleetapi.exceptions import (
     PyPowerwallFleetAPIInvalidPayload,
 )
 
-BUILD = "t91"
+BUILD = "t92"
 ALLOWLIST = [
     "/api/status",
     "/api/site_info/site_name",

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -128,7 +128,7 @@ from pypowerwall.fleetapi.exceptions import (
     PyPowerwallFleetAPIInvalidPayload,
 )
 
-BUILD = "t90"
+BUILD = "t91"
 ALLOWLIST = [
     "/api/status",
     "/api/site_info/site_name",

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -89,7 +89,7 @@ import time
 from json import JSONDecodeError
 from typing import Optional, Union
 
-version_tuple = (0, 15, 10)
+version_tuple = (0, 15, 11)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/cloud/teslapy/__init__.py
+++ b/pypowerwall/cloud/teslapy/__init__.py
@@ -185,8 +185,9 @@ class Tesla(OAuth2Session):
         timeout = kwargs.get('timeout', self.timeout)
         withhold_token = kwargs.get('withhold_token', False)
         verify = getattr(self, 'verify', True)
-        # Build headers
-        headers = {'User-Agent': APP_USER_AGENT}
+        # Start with all session headers (Content-Type, X-Tesla-User-Agent, User-Agent)
+        # so httpx sends the same headers as the requests session would.
+        headers = dict(self.headers)
         if not withhold_token and self.authorized:
             token = self.token.get('access_token')
             if token:

--- a/pypowerwall/cloud/teslapy/__init__.py
+++ b/pypowerwall/cloud/teslapy/__init__.py
@@ -31,6 +31,13 @@ from requests.packages.urllib3.util.retry import Retry
 from oauthlib.oauth2.rfc6749.errors import *
 import websocket  # websocket-client v0.49.0 up to v0.58.0 is not supported
 
+# Optional HTTP/2 support for Tesla auth (required as of June 2026)
+try:
+    import httpx
+    HAS_HTTPX = True
+except ImportError:
+    HAS_HTTPX = False
+
 requests.packages.urllib3.disable_warnings()
 
 BASE_URL = 'https://owner-api.teslamotors.com/'
@@ -209,6 +216,9 @@ class Tesla(OAuth2Session):
         """ Overriddes base method to sign into Tesla's SSO service using
         Authorization Code grant with PKCE extension. Raises CustomOAuth2Error.
 
+        Tesla now requires HTTP/2 for auth.tesla.com token endpoints.
+        Uses httpx with HTTP/2 if available, falling back to requests.
+
         token_url (optional): Token endpoint URL.
 
         Extra keyword arguments to pass to base method using `kwargs`:
@@ -225,6 +235,16 @@ class Tesla(OAuth2Session):
             kwargs['authorization_response'] = self.authenticator(url)
         # Use authorization code in redirected location to get token
         token_url = urljoin(self.sso_base_url, token_url)
+
+        # Try HTTP/2 first (Tesla requires it as of June 2026)
+        if HAS_HTTPX:
+            try:
+                self._fetch_token_http2(token_url, **kwargs)
+                self._token_updater()  # Save new token
+                return self.token
+            except Exception as exc:
+                logger.warning('HTTP/2 token fetch failed, falling back to HTTP/1.1: %s', exc)
+
         kwargs['include_client_id'] = True
         kwargs.setdefault('verify', self.verify)
         kwargs.setdefault('code_verifier', self.code_verifier)
@@ -232,9 +252,42 @@ class Tesla(OAuth2Session):
         self._token_updater()  # Save new token
         return self.token
 
+    def _fetch_token_http2(self, token_url, **kwargs):
+        """Exchange authorization code for tokens using HTTP/2 via httpx."""
+        from oauthlib.common import urldecode
+
+        auth_response = kwargs.get('authorization_response')
+        self._client.parse_request_uri_response(auth_response, state=self._state)
+        code = self._client.code
+
+        body = self._client.prepare_request_body(
+            code=code,
+            redirect_uri=self.redirect_uri,
+            include_client_id=True,
+            code_verifier=kwargs.get('code_verifier', self.code_verifier),
+        )
+
+        headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+        }
+
+        verify = kwargs.get('verify', self.verify)
+        timeout = kwargs.get('timeout', self.timeout)
+
+        with httpx.Client(http2=True, verify=verify) as client:
+            r = client.post(token_url, data=dict(urldecode(body)), headers=headers, timeout=timeout)
+            r.raise_for_status()
+            self._client.parse_request_body_response(r.text, scope=self.scope)
+            self.token = self._client.token
+            return self.token
+
     def refresh_token(self, token_url='oauth2/v3/token', **kwargs):
         """ Overriddes base method to refresh Tesla's SSO token. Raises
         ValueError and ServerError.
+
+        Tesla now requires HTTP/2 for auth.tesla.com token endpoints.
+        Uses httpx with HTTP/2 if available, falling back to requests.
 
         token_url (optional): The token endpoint.
 
@@ -246,10 +299,50 @@ class Tesla(OAuth2Session):
         if not self.authorized and not kwargs.get('refresh_token'):
             raise ValueError('`refresh_token` is not set')
         token_url = urljoin(self.sso_base_url, token_url)
+
+        # Try HTTP/2 first (Tesla requires it as of June 2026)
+        if HAS_HTTPX:
+            try:
+                self._refresh_token_http2(token_url, **kwargs)
+                self._token_updater()  # Save new token
+                return self.token
+            except Exception as exc:
+                logger.warning('HTTP/2 token refresh failed, falling back to HTTP/1.1: %s', exc)
+
         kwargs.setdefault('verify', self.verify)
         super(Tesla, self).refresh_token(token_url, **kwargs)
         self._token_updater()  # Save new token
         return self.token
+
+    def _refresh_token_http2(self, token_url, **kwargs):
+        """Refresh token using HTTP/2 via httpx."""
+        from oauthlib.common import urldecode
+
+        refresh_token = kwargs.get('refresh_token') or self.token.get('refresh_token')
+        if not refresh_token:
+            raise ValueError('`refresh_token` is not set')
+
+        body = self._client.prepare_refresh_body(
+            refresh_token=refresh_token,
+            scope=self.scope,
+            **self.auto_refresh_kwargs
+        )
+
+        headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+        }
+
+        verify = kwargs.get('verify', self.verify)
+        timeout = kwargs.get('timeout', self.timeout)
+
+        with httpx.Client(http2=True, verify=verify) as client:
+            r = client.post(token_url, data=dict(urldecode(body)), headers=headers, timeout=timeout)
+            r.raise_for_status()
+            self.token = self._client.parse_request_body_response(r.text, scope=self.scope)
+            if 'refresh_token' not in self.token:
+                self.token['refresh_token'] = refresh_token
+            return self.token
 
     def close(self):
         """ Overriddes base method to remove all adapters on close """

--- a/pypowerwall/cloud/teslapy/__init__.py
+++ b/pypowerwall/cloud/teslapy/__init__.py
@@ -219,8 +219,14 @@ class Tesla(OAuth2Session):
             request_kwargs['params'] = kwargs['params']
         if 'json' in kwargs:
             request_kwargs['json'] = kwargs['json']
+        # Forward proxy settings from the requests session to httpx
+        client_kwargs = {'http2': True, 'verify': verify}
+        if getattr(self, 'proxies', None):
+            client_kwargs['proxies'] = self.proxies
+        if getattr(self, 'trust_env', False):
+            client_kwargs['trust_env'] = True
         try:
-            with httpx.Client(http2=True, verify=verify) as client:
+            with httpx.Client(**client_kwargs) as client:
                 resp = client.request(method, url, **request_kwargs)
             return _HTTP2Response(resp)
         except Exception as exc:
@@ -334,7 +340,13 @@ class Tesla(OAuth2Session):
         verify = self._httpx_auth_verify(kwargs.get('verify', self.verify))
         timeout = kwargs.get('timeout', self.timeout)
 
-        with httpx.Client(http2=True, verify=verify) as client:
+        client_kwargs = {'http2': True, 'verify': verify}
+        if getattr(self, 'proxies', None):
+            client_kwargs['proxies'] = self.proxies
+        if getattr(self, 'trust_env', False):
+            client_kwargs['trust_env'] = True
+
+        with httpx.Client(**client_kwargs) as client:
             r = client.post(token_url, data=dict(urldecode(body)), headers=headers, timeout=timeout)
             r.raise_for_status()
             self._client.parse_request_body_response(r.text, scope=self.scope)
@@ -395,10 +407,17 @@ class Tesla(OAuth2Session):
         verify = self._httpx_auth_verify(kwargs.get('verify', self.verify))
         timeout = kwargs.get('timeout', self.timeout)
 
-        with httpx.Client(http2=True, verify=verify) as client:
+        client_kwargs = {'http2': True, 'verify': verify}
+        if getattr(self, 'proxies', None):
+            client_kwargs['proxies'] = self.proxies
+        if getattr(self, 'trust_env', False):
+            client_kwargs['trust_env'] = True
+
+        with httpx.Client(**client_kwargs) as client:
             r = client.post(token_url, data=dict(urldecode(body)), headers=headers, timeout=timeout)
             r.raise_for_status()
-            self.token = self._client.parse_request_body_response(r.text, scope=self.scope)
+            self._client.parse_request_body_response(r.text, scope=self.scope)
+            self.token = self._client.token
             if 'refresh_token' not in self.token:
                 self.token['refresh_token'] = refresh_token
             return self.token

--- a/pypowerwall/cloud/teslapy/__init__.py
+++ b/pypowerwall/cloud/teslapy/__init__.py
@@ -135,6 +135,10 @@ class Tesla(OAuth2Session):
         """ Overriddes base method to support relative URLs, serialization and
         error message handling. Raises HTTPError when an error occurs.
 
+        Tesla now requires HTTP/2 for both auth endpoints AND owner-api calls
+        (api/1/*). This method uses httpx with HTTP/2 for owner-api requests,
+        falling back to requests (HTTP/1.1) if httpx is unavailable.
+
         method: HTTP method to use.
         url: URL to send.
         serialize (optional): (de)serialize request/response body.
@@ -154,7 +158,11 @@ class Tesla(OAuth2Session):
         kwargs.setdefault('timeout', self.timeout)
         if serialize and 'data' in kwargs:
             kwargs['json'] = kwargs.pop('data')
-        response = super(Tesla, self).request(method, url, **kwargs)
+        # Use HTTP/2 for owner-api calls (Tesla requires it as of June 2026)
+        if HAS_HTTPX:
+            response = self._request_http2(method, url, **kwargs)
+        else:
+            response = super(Tesla, self).request(method, url, **kwargs)
         # Error message handling
         if serialize and 400 <= response.status_code < 600:
             try:
@@ -167,6 +175,36 @@ class Tesla(OAuth2Session):
         if serialize:
             return response.json(object_hook=JsonDict)
         return response.text
+
+    def _request_http2(self, method, url, **kwargs):
+        """Make an HTTP/2 request to owner-api via httpx.
+
+        Handles bearer token injection and returns a requests-compatible
+        response object so the calling code path is unchanged.
+        """
+        timeout = kwargs.get('timeout', self.timeout)
+        withhold_token = kwargs.get('withhold_token', False)
+        verify = getattr(self, 'verify', True)
+        # Build headers
+        headers = {'User-Agent': APP_USER_AGENT}
+        if not withhold_token and self.authorized:
+            token = self.token.get('access_token')
+            if token:
+                headers['Authorization'] = 'Bearer ' + token
+        # Build request kwargs
+        request_kwargs = {'headers': headers, 'timeout': timeout,
+                          'follow_redirects': True}
+        if 'params' in kwargs:
+            request_kwargs['params'] = kwargs['params']
+        if 'json' in kwargs:
+            request_kwargs['json'] = kwargs['json']
+        try:
+            with httpx.Client(http2=True, verify=verify) as client:
+                resp = client.request(method, url, **request_kwargs)
+            return _HTTP2Response(resp)
+        except Exception as exc:
+            logger.warning('HTTP/2 request failed, falling back to HTTP/1.1: %s', exc)
+            return super(Tesla, self).request(method, url, **kwargs)
 
     @staticmethod
     def new_code_verifier():
@@ -484,6 +522,32 @@ class Tesla(OAuth2Session):
         """ Returns a list of `WallConnector` objects """
         return [WallConnector(p, self) for p in self.api('PRODUCT_LIST')['response']
                 if p.get('resource_type') == 'wall_connector']
+
+
+class _HTTP2Response:
+    """ Wrapper to make httpx.Response compatible with requests.Response API.
+
+    Used by Tesla.request() when making HTTP/2 calls to owner-api endpoints.
+    """
+
+    def __init__(self, resp):
+        self._resp = resp
+        self.status_code = resp.status_code
+        self.reason = resp.reason_phrase
+        self._content = resp.content
+
+    @property
+    def text(self):
+        return self._resp.text
+
+    def json(self, **kwargs):
+        return json.loads(self._content, **kwargs)
+
+    def raise_for_status(self):
+        if 400 <= self.status_code < 600:
+            raise requests.exceptions.HTTPError(
+                f"{self.status_code} Client Error: {self.reason}",
+                response=self)
 
 
 class VehicleError(Exception):

--- a/pypowerwall/cloud/teslapy/__init__.py
+++ b/pypowerwall/cloud/teslapy/__init__.py
@@ -19,6 +19,7 @@ import pkgutil
 import datetime
 import webbrowser
 import stat
+import ssl
 try:
     from urlparse import urljoin
 except ImportError:
@@ -176,6 +177,25 @@ class Tesla(OAuth2Session):
             return response.json(object_hook=JsonDict)
         return response.text
 
+    @staticmethod
+    def _httpx_auth_verify(verify=True):
+        """Return an httpx-compatible verify setting pinned to TLS 1.3 when possible."""
+        if verify is False:
+            return False
+        if isinstance(verify, (str, bytes)):
+            return verify
+        if isinstance(verify, ssl.SSLContext):
+            return verify
+        if hasattr(ssl, 'TLSVersion') and hasattr(ssl.TLSVersion, 'TLSv1_3'):
+            try:
+                ctx = ssl.create_default_context()
+                ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+                ctx.maximum_version = ssl.TLSVersion.TLSv1_3
+                return ctx
+            except Exception:
+                pass
+        return verify
+
     def _request_http2(self, method, url, **kwargs):
         """Make an HTTP/2 request to owner-api via httpx.
 
@@ -184,7 +204,7 @@ class Tesla(OAuth2Session):
         """
         timeout = kwargs.get('timeout', self.timeout)
         withhold_token = kwargs.get('withhold_token', False)
-        verify = getattr(self, 'verify', True)
+        verify = self._httpx_auth_verify(getattr(self, 'verify', True))
         # Start with all session headers (Content-Type, X-Tesla-User-Agent, User-Agent)
         # so httpx sends the same headers as the requests session would.
         headers = dict(self.headers)
@@ -311,7 +331,7 @@ class Tesla(OAuth2Session):
             'Content-Type': 'application/x-www-form-urlencoded',
         }
 
-        verify = kwargs.get('verify', self.verify)
+        verify = self._httpx_auth_verify(kwargs.get('verify', self.verify))
         timeout = kwargs.get('timeout', self.timeout)
 
         with httpx.Client(http2=True, verify=verify) as client:
@@ -372,7 +392,7 @@ class Tesla(OAuth2Session):
             'Content-Type': 'application/x-www-form-urlencoded',
         }
 
-        verify = kwargs.get('verify', self.verify)
+        verify = self._httpx_auth_verify(kwargs.get('verify', self.verify))
         timeout = kwargs.get('timeout', self.timeout)
 
         with httpx.Client(http2=True, verify=verify) as client:

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -31,6 +31,7 @@ import hashlib
 import json
 import os
 import secrets
+import ssl
 import sys
 import urllib.parse
 
@@ -62,6 +63,25 @@ REGION_HOSTS = {
     "us": "https://auth.tesla.com",
     "cn": "https://auth.tesla.cn",
 }
+
+
+def _httpx_auth_verify(verify=True):
+    """Return an httpx-compatible verify setting pinned to TLS 1.3 when possible."""
+    if verify is False:
+        return False
+    if isinstance(verify, (str, bytes)):
+        return verify
+    if isinstance(verify, ssl.SSLContext):
+        return verify
+    if hasattr(ssl, "TLSVersion") and hasattr(ssl.TLSVersion, "TLSv1_3"):
+        try:
+            ctx = ssl.create_default_context()
+            ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+            ctx.maximum_version = ssl.TLSVersion.TLSv1_3
+            return ctx
+        except Exception:
+            pass
+    return verify
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +142,7 @@ def _refresh_access_token(refresh_token: str, region: str = "us") -> dict:
     # Tesla now requires HTTP/2 for auth.tesla.com token endpoints
     if HAS_HTTPX:
         try:
-            with httpx.Client(http2=True) as client:
+            with httpx.Client(http2=True, verify=_httpx_auth_verify()) as client:
                 resp = client.post(url, json=payload, timeout=30)
                 if resp.status_code != 200:
                     raise RuntimeError(f"Token refresh failed (HTTP {resp.status_code}): {resp.text}")
@@ -169,7 +189,7 @@ def _exchange_code(auth_code: str, code_verifier: str, region: str = "us") -> di
     # Tesla now requires HTTP/2 for auth.tesla.com token endpoints
     if HAS_HTTPX:
         try:
-            with httpx.Client(http2=True) as client:
+            with httpx.Client(http2=True, verify=_httpx_auth_verify()) as client:
                 resp = client.post(url, json=payload, timeout=30)
                 if resp.status_code != 200:
                     raise RuntimeError(f"Token exchange failed (HTTP {resp.status_code}): {resp.text}")

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -150,10 +150,15 @@ def _refresh_access_token(refresh_token: str, region: str = "us") -> dict:
                 if "access_token" not in data:
                     raise RuntimeError(f"No access_token in refresh response: {data}")
                 return data
+        except RuntimeError:
+            raise  # Application errors (non-200, missing token) should not fall back
         except Exception as exc:
-            # Fall back to requests if HTTP/2 fails
-            pass
+            # Transport/connection errors only — fall back to requests if available
+            if requests is None:
+                raise RuntimeError(f"HTTP/2 transport failed and 'requests' not installed: {exc}") from exc
 
+    if requests is None:
+        raise ImportError("The 'requests' or 'httpx' package is required.")
     resp = requests.post(url, json=payload, timeout=30)
     if resp.status_code != 200:
         raise RuntimeError(f"Token refresh failed (HTTP {resp.status_code}): {resp.text}")
@@ -197,10 +202,15 @@ def _exchange_code(auth_code: str, code_verifier: str, region: str = "us") -> di
                 if "refresh_token" not in data:
                     raise RuntimeError(f"No refresh_token in response: {data}")
                 return data
+        except RuntimeError:
+            raise  # Application errors (non-200, missing token) should not fall back
         except Exception as exc:
-            # Fall back to requests if HTTP/2 fails
-            pass
+            # Transport/connection errors only — fall back to requests if available
+            if requests is None:
+                raise RuntimeError(f"HTTP/2 transport failed and 'requests' not installed: {exc}") from exc
 
+    if requests is None:
+        raise ImportError("The 'requests' package is required. Install with: pip install requests")
     resp = requests.post(url, json=payload, timeout=30)
     if resp.status_code != 200:
         raise RuntimeError(f"Token exchange failed (HTTP {resp.status_code}): {resp.text}")

--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -39,6 +39,13 @@ try:
 except ImportError:
     requests = None  # type: ignore
 
+# Optional HTTP/2 support for Tesla auth (required as of June 2026)
+try:
+    import httpx
+    HAS_HTTPX = True
+except ImportError:
+    HAS_HTTPX = False
+
 
 # ---------------------------------------------------------------------------
 # Constants — match tesla_auth Rust exactly
@@ -101,19 +108,33 @@ def _refresh_access_token(refresh_token: str, region: str = "us") -> dict:
     Tesla OAuth refresh: POST /oauth2/v3/token with grant_type=refresh_token,
     client_id=ownerapi, refresh_token.
     """
-    if requests is None:
-        raise ImportError("The 'requests' package is required.")
+    if requests is None and not HAS_HTTPX:
+        raise ImportError("The 'requests' or 'httpx' package is required.")
 
     auth_host = REGION_HOSTS.get(region, REGION_HOSTS["us"])
-    resp = requests.post(
-        f"{auth_host}{TOKEN_URL_PATH}",
-        json={
-            "grant_type": "refresh_token",
-            "client_id": CLIENT_ID,
-            "refresh_token": refresh_token,
-        },
-        timeout=30,
-    )
+    url = f"{auth_host}{TOKEN_URL_PATH}"
+    payload = {
+        "grant_type": "refresh_token",
+        "client_id": CLIENT_ID,
+        "refresh_token": refresh_token,
+    }
+
+    # Tesla now requires HTTP/2 for auth.tesla.com token endpoints
+    if HAS_HTTPX:
+        try:
+            with httpx.Client(http2=True) as client:
+                resp = client.post(url, json=payload, timeout=30)
+                if resp.status_code != 200:
+                    raise RuntimeError(f"Token refresh failed (HTTP {resp.status_code}): {resp.text}")
+                data = resp.json()
+                if "access_token" not in data:
+                    raise RuntimeError(f"No access_token in refresh response: {data}")
+                return data
+        except Exception as exc:
+            # Fall back to requests if HTTP/2 fails
+            pass
+
+    resp = requests.post(url, json=payload, timeout=30)
     if resp.status_code != 200:
         raise RuntimeError(f"Token refresh failed (HTTP {resp.status_code}): {resp.text}")
 
@@ -132,21 +153,35 @@ def _exchange_code(auth_code: str, code_verifier: str, region: str = "us") -> di
     Matches tesla_auth: POST to /oauth2/v3/token with grant_type=authorization_code,
     client_id=ownerapi, code, code_verifier, redirect_uri.
     """
-    if requests is None:
-        raise ImportError("The 'requests' package is required. Install with: pip install requests")
+    if requests is None and not HAS_HTTPX:
+        raise ImportError("The 'requests' or 'httpx' package is required. Install with: pip install requests")
 
     auth_host = REGION_HOSTS.get(region, REGION_HOSTS["us"])
-    resp = requests.post(
-        f"{auth_host}{TOKEN_URL_PATH}",
-        json={
-            "grant_type": "authorization_code",
-            "client_id": CLIENT_ID,
-            "code": auth_code,
-            "code_verifier": code_verifier,
-            "redirect_uri": REDIRECT_URI,
-        },
-        timeout=30,
-    )
+    url = f"{auth_host}{TOKEN_URL_PATH}"
+    payload = {
+        "grant_type": "authorization_code",
+        "client_id": CLIENT_ID,
+        "code": auth_code,
+        "code_verifier": code_verifier,
+        "redirect_uri": REDIRECT_URI,
+    }
+
+    # Tesla now requires HTTP/2 for auth.tesla.com token endpoints
+    if HAS_HTTPX:
+        try:
+            with httpx.Client(http2=True) as client:
+                resp = client.post(url, json=payload, timeout=30)
+                if resp.status_code != 200:
+                    raise RuntimeError(f"Token exchange failed (HTTP {resp.status_code}): {resp.text}")
+                data = resp.json()
+                if "refresh_token" not in data:
+                    raise RuntimeError(f"No refresh_token in response: {data}")
+                return data
+        except Exception as exc:
+            # Fall back to requests if HTTP/2 fails
+            pass
+
+    resp = requests.post(url, json=payload, timeout=30)
     if resp.status_code != 200:
         raise RuntimeError(f"Token exchange failed (HTTP {resp.status_code}): {resp.text}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # This file is used to install the necessary Python packages for the project.
 requests
-httpx>=0.27.0
+httpx[http2]>=0.27.0
 protobuf>=4.25.1
 python-dotenv
 pyroute2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # This file is used to install the necessary Python packages for the project.
 requests
+httpx>=0.27.0
 protobuf>=4.25.1
 python-dotenv
 pyroute2

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'requests',
+        'httpx[http2]>=0.27.0',
         'protobuf>=4.25.1',
         'python-dotenv',
         'pyroute2',


### PR DESCRIPTION
Tesla now requires HTTP/2 for auth.tesla.com/oauth2/v3/token endpoints. Without HTTP/2, token refresh and exchange requests return 403, breaking Owner API cloud mode.

## Changes
- **pypowerwall/cloud/teslapy/__init__.py**: Override `fetch_token()` and `refresh_token()` to use `httpx` with HTTP/2 for SSO endpoints, falling back to `requests` if `httpx` is unavailable.
- **pypowerwall/tesla_auth.py**: Use `httpx` with HTTP/2 for `_refresh_access_token()` and `_exchange_code()`, falling back to `requests`.
- **requirements.txt**: Add `httpx>=0.27.0` as a dependency.

## Context
This fixes the 403 errors reported in Powerwall-Dashboard #779. TeslaMate confirmed the same root cause (teslamate-org/teslamate#5406) and that HTTP/2 is the stable protocol requirement, not a temporary fingerprinting workaround.

Fixes jasonacox/Powerwall-Dashboard#779