### PR TITLE
fix(authtoken): disable WebKit2GTK GPU compositing on Linux to prevent garbled login window

### DIFF
--- a/pypowerwall/tesla_auth.py
+++ b/pypowerwall/tesla_auth.py
@@ -733,6 +733,10 @@ def _local_login_pywebview(email: str = None, region: str = "us",
     (macOS) or the equivalent handler on other platforms, checking for tesla://
     before delegating to the original logic.
     """
+    # Force CPU rendering on Linux: GPU compositing in WebKit2GTK garbles the window on many drivers.
+    if sys.platform == "linux":
+        os.environ.setdefault("WEBKIT_DISABLE_COMPOSITING_MODE", "1")
+
     import time
     try:
         import webview


### PR DESCRIPTION
## Problem

On Linux systems where GPU drivers (Nvidia, Broadcom/RPi, and others) don't fully support WebKit2GTK's GPU compositing layer, the Tesla login window opened by `python -m pypowerwall authtoken` renders garbled — unusable for authentication.

Reported in #322 by @JonMurphy on RPi5 (Debian Trixie). Confirmed the root cause is driver-agnostic: any driver that lacks full OpenGL/Wayland compositing support can trigger this.

## Fix

Set `WEBKIT_DISABLE_COMPOSITING_MODE=1` in `_local_login_pywebview()` before pywebview/WebKit2GTK is initialized. This forces CPU rendering, bypassing the compositing layer entirely.

```python
if sys.platform == "linux":
    os.environ.setdefault("WEBKIT_DISABLE_COMPOSITING_MODE", "1")
```

- **`setdefault`** — preserves any explicit user override (e.g. if someone sets it to `0`)
- **`sys.platform == "linux"` guard** — this env var is WebKit2GTK-specific; macOS uses WKWebView via PyObjC and Windows uses WebView2 (EdgeChromium), both of which ignore this variable
- **Set before `import webview`** — ensures the flag is in the environment before any GTK/WebKit2GTK initialization occurs

## Testing

Manually verify on Linux: `WEBKIT_DISABLE_COMPOSITING_MODE` should appear in the process environment when `authtoken` runs on Linux. On macOS/Windows the variable is not set by this code path.

Closes #322