### PR TITLE
fix(v1r): surface key auth warnings without debug mode

### DIFF
--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -1476,7 +1476,13 @@ class TEDAPI:
             # here surfaces the warning at init time instead of silently returning
             # None on every subsequent data call.
             probe = self.v1r_transport.get_config_v1r(self.din)
-            if probe is None:
+            if probe:
+                # Seed the config cache with the probe result so the probe is
+                # not a wasted fetch — the first get_config() after connect
+                # will be served from cache.
+                self.pwcache["config"] = probe
+                self.pwcachetime["config"] = time.time()
+            else:
                 if self.v1r_transport.pending_verification:
                     log.error(
                         "v1r: RSA key is PENDING_VERIFICATION — data calls will return None. "
@@ -1485,9 +1491,12 @@ class TEDAPI:
                 elif self.v1r_transport.key_unknown:
                     log.error(
                         "v1r: RSA key not recognized by gateway — data calls will return None. "
-                        "Check that the key file matches the registered key. "
+                        "Check that the key file matches the registered key "
+                        f"(fingerprint in use: {getattr(self.v1r_transport, 'key_fingerprint', 'unknown')}). "
                         "Run 'python -m pypowerwall register' to verify."
                     )
+                else:
+                    log.debug("v1r: key probe returned no data (possibly transient) - continuing")
             # Test WiFi fallback path if configured
             if self.wifi_session:
                 self._test_wifi_path()

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -1470,6 +1470,16 @@ class TEDAPI:
             self.lan_failed = False
             self.lan_fail_count = 0
             self.lan_recover_after = 0
+            # Probe key verification state. Login and DIN both succeed even when the
+            # RSA key is registered but not yet verified (PENDING_VERIFICATION). A test
+            # read here surfaces the warning at init time instead of silently returning
+            # None on every subsequent data call.
+            probe = self.v1r_transport.get_config_v1r(self.din)
+            if probe is None and self.v1r_transport.pending_verification:
+                log.error(
+                    "v1r: RSA key is PENDING_VERIFICATION — data calls will return None. "
+                    "Toggle a Powerwall circuit breaker OFF then back ON to trigger verification."
+                )
             # Test WiFi fallback path if configured
             if self.wifi_session:
                 self._test_wifi_path()

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -1471,15 +1471,23 @@ class TEDAPI:
             self.lan_fail_count = 0
             self.lan_recover_after = 0
             # Probe key verification state. Login and DIN both succeed even when the
-            # RSA key is registered but not yet verified (PENDING_VERIFICATION). A test
-            # read here surfaces the warning at init time instead of silently returning
+            # RSA key is registered but not yet verified (PENDING_VERIFICATION), or
+            # when the wrong key file is being used (UNKNOWN_KEY_ID). A test read
+            # here surfaces the warning at init time instead of silently returning
             # None on every subsequent data call.
             probe = self.v1r_transport.get_config_v1r(self.din)
-            if probe is None and self.v1r_transport.pending_verification:
-                log.error(
-                    "v1r: RSA key is PENDING_VERIFICATION — data calls will return None. "
-                    "Toggle a Powerwall circuit breaker OFF then back ON to trigger verification."
-                )
+            if probe is None:
+                if self.v1r_transport.pending_verification:
+                    log.error(
+                        "v1r: RSA key is PENDING_VERIFICATION — data calls will return None. "
+                        "Toggle a Powerwall circuit breaker OFF then back ON to trigger verification."
+                    )
+                elif self.v1r_transport.key_unknown:
+                    log.error(
+                        "v1r: RSA key not recognized by gateway — data calls will return None. "
+                        "Check that the key file matches the registered key. "
+                        "Run 'python -m pypowerwall register' to verify."
+                    )
             # Test WiFi fallback path if configured
             if self.wifi_session:
                 self._test_wifi_path()

--- a/pypowerwall/tedapi/tedapi_v1r.py
+++ b/pypowerwall/tedapi/tedapi_v1r.py
@@ -11,6 +11,7 @@ signatures embedded in RoutableMessage protobufs for authentication.
 Requires a pre-registered RSA-4096 key pair (see v1r_register.py).
 """
 
+import hashlib
 import json
 import logging
 import math
@@ -73,6 +74,12 @@ class TEDAPIv1r:
             serialization.Encoding.DER,
             serialization.PublicFormat.PKCS1
         )
+        # SHA-256 fingerprint of the public key in use. Included in key-auth
+        # failure messages so users can compare against the fingerprint printed
+        # by 'python -m pypowerwall register' — key mismatches from multiple
+        # registration attempts are a common root cause (see issue #352).
+        self.key_fingerprint = hashlib.sha256(self._public_key_der).hexdigest()
+        log.debug(f"v1r RSA public key fingerprint (SHA256): {self.key_fingerprint}")
         # HTTP session (no Basic auth — v1r uses RSA signatures)
         self.session = self._init_session()
 
@@ -166,6 +173,18 @@ class TEDAPIv1r:
 
     # ── v1r POST ─────────────────────────────────────────────────────
 
+    def _key_auth_warning(self, flag: str, msg: str) -> None:
+        """Log a key-auth failure and emit a UserWarning once per failure episode.
+
+        The flag ('pending_verification' or 'key_unknown') suppresses repeat
+        warnings while the condition persists; it is cleared by post_v1r() on
+        the next successful response so a later recurrence warns again.
+        """
+        log.error("v1r: %s", msg)
+        if not getattr(self, flag):
+            setattr(self, flag, True)
+            warnings.warn(msg, UserWarning, stacklevel=3)
+
     def post_v1r(self, envelope_bytes: bytes, din: str) -> Optional[bytes]:
         """
         Wrap envelope_bytes in a signed RoutableMessage and POST to /tedapi/v1r.
@@ -230,13 +249,11 @@ class TEDAPIv1r:
                         "v1r RSA key is not recognized by the gateway (UNKNOWN_KEY_ID). "
                         "The key file may not match the registered key, or no key has been "
                         "registered. Run 'python -m pypowerwall register' to register or "
-                        f"verify your key. Gateway payload ({response_size} bytes): {raw_preview} "
+                        f"verify your key. Key fingerprint in use (SHA256): {self.key_fingerprint} "
+                        f"Gateway payload ({response_size} bytes): {raw_preview} "
                         "See: https://github.com/jasonacox/pypowerwall/issues/274"
                     )
-                    log.error("v1r: %s", msg)
-                    if not self.key_unknown:
-                        self.key_unknown = True
-                        warnings.warn(msg, UserWarning, stacklevel=4)
+                    self._key_auth_warning('key_unknown', msg)
                 elif fault == combined_pb2.MESSAGEFAULT_ERROR_TIMEOUT:
                     log.debug(f"v1r response fault: {fault_name} (sub-device may not be routable via v1r)")
                 else:
@@ -263,10 +280,7 @@ class TEDAPIv1r:
                     f"Gateway payload ({response_size} bytes): {raw_preview} "
                     "See: https://github.com/jasonacox/pypowerwall/issues/274"
                 )
-                log.error("v1r: %s", msg)
-                if not self.pending_verification:
-                    self.pending_verification = True
-                    warnings.warn(msg, UserWarning, stacklevel=4)
+                self._key_auth_warning('pending_verification', msg)
                 return None
 
             if not inner:
@@ -279,14 +293,20 @@ class TEDAPIv1r:
                     f"response ({response_size} bytes) with no data. "
                     f"Gateway payload: {raw_preview} "
                     "The RSA key may not be registered or recognized by this gateway. "
+                    f"Key fingerprint in use (SHA256): {self.key_fingerprint} "
                     "Run 'python -m pypowerwall register' to register or verify your key. "
                     "See: https://github.com/jasonacox/pypowerwall/issues/274"
                 )
-                log.error("v1r: %s", msg)
-                if not self.key_unknown:
-                    self.key_unknown = True
-                    warnings.warn(msg, UserWarning, stacklevel=4)
+                self._key_auth_warning('key_unknown', msg)
                 return None
+
+            # Success — if a previous call flagged a key-auth failure, the key
+            # has since been verified/recognized (e.g., breaker toggle completed
+            # while running). Clear the flags so any future failure warns again.
+            if self.pending_verification or self.key_unknown:
+                log.info("v1r: key authentication recovered — gateway accepted signed request")
+                self.pending_verification = False
+                self.key_unknown = False
 
             return inner
 

--- a/pypowerwall/tedapi/tedapi_v1r.py
+++ b/pypowerwall/tedapi/tedapi_v1r.py
@@ -18,6 +18,7 @@ import ssl
 import struct
 import time
 import uuid
+import warnings
 from typing import Optional
 
 import requests
@@ -42,6 +43,8 @@ class TEDAPIv1r:
         self.poolmaxsize = poolmaxsize
         self.token: Optional[str] = None
         self.din: Optional[str] = None
+        # Tracks whether the registered key is stuck in PENDING_VERIFICATION
+        self.pending_verification: bool = False
 
         # Load RSA private key
         from cryptography.hazmat.primitives import serialization
@@ -229,12 +232,20 @@ class TEDAPIv1r:
             # instead of a valid protobuf payload.
             # Check in bytes first to avoid decoding large protobuf blobs on every call.
             if b'authorization not verified' in inner.lower():
-                log.error("v1r: RSA key not yet VERIFIED by the gateway.")
-                log.error("  The key is registered but not yet VERIFIED (may be PENDING or PENDING_VERIFICATION).")
-                log.error("  1. Toggle ONE Powerwall breaker OFF, wait 2 seconds, then back ON.")
-                log.error("  2. Wait 30-60 seconds, then retry.")
-                log.error("  Re-run 'python -m pypowerwall register' to inspect registration and verification state.")
-                log.error("  See: https://github.com/jasonacox/pypowerwall/issues/274")
+                msg = (
+                    "v1r RSA key is registered but not yet VERIFIED by the gateway "
+                    "(PENDING_VERIFICATION). "
+                    "Toggle ONE Powerwall circuit breaker OFF, wait 2 seconds, then back ON. "
+                    "Wait 30-60 seconds, then retry. "
+                    "Run 'python -m pypowerwall register' to check key state. "
+                    "See: https://github.com/jasonacox/pypowerwall/issues/274"
+                )
+                log.error("v1r: %s", msg)
+                if not self.pending_verification:
+                    # Emit a visible warning the first time this is detected so users
+                    # see it without needing debug logging enabled.
+                    self.pending_verification = True
+                    warnings.warn(msg, UserWarning, stacklevel=4)
                 return None
 
             return inner

--- a/pypowerwall/tedapi/tedapi_v1r.py
+++ b/pypowerwall/tedapi/tedapi_v1r.py
@@ -32,6 +32,17 @@ urllib3.disable_warnings(InsecureRequestWarning)
 log = logging.getLogger(__name__)
 
 
+def _decode_payload_preview(raw: bytes, max_len: int = 200) -> str:
+    """Return a human-readable preview of a raw gateway response for diagnostics."""
+    try:
+        text = raw.decode('utf-8', errors='replace').strip()
+        if text and any(32 <= ord(c) < 127 for c in text[:20]):
+            return repr(text[:max_len])
+    except Exception:
+        pass
+    return raw[:max_len].hex()
+
+
 class TEDAPIv1r:
     """RSA-signed transport for Powerwall /tedapi/v1r endpoint."""
 
@@ -203,6 +214,8 @@ class TEDAPIv1r:
                 log.error(f"v1r POST failed ({r.status_code})")
                 return None
 
+            response_size = len(r.content)
+
             # Parse response RoutableMessage
             resp_msg = combined_pb2.RoutableMessage()
             resp_msg.ParseFromString(r.content)
@@ -212,11 +225,13 @@ class TEDAPIv1r:
             if fault != combined_pb2.MESSAGEFAULT_ERROR_NONE:
                 fault_name = combined_pb2.MessageFault_E.Name(fault)
                 if fault == combined_pb2.MESSAGEFAULT_ERROR_UNKNOWN_KEY_ID:
+                    raw_preview = _decode_payload_preview(r.content)
                     msg = (
                         "v1r RSA key is not recognized by the gateway (UNKNOWN_KEY_ID). "
                         "The key file may not match the registered key, or no key has been "
                         "registered. Run 'python -m pypowerwall register' to register or "
-                        "verify your key. See: https://github.com/jasonacox/pypowerwall/issues/274"
+                        f"verify your key. Gateway payload ({response_size} bytes): {raw_preview} "
+                        "See: https://github.com/jasonacox/pypowerwall/issues/274"
                     )
                     log.error("v1r: %s", msg)
                     if not self.key_unknown:
@@ -230,35 +245,46 @@ class TEDAPIv1r:
 
             # Extract inner protobuf bytes
             inner = resp_msg.protobuf_message_as_bytes
-            if not inner:
-                # Empty inner payload with no fault code — unusual but should not
-                # pass silently.  Log the response size for diagnostic context.
-                log.error(
-                    "v1r response has no protobuf_message_as_bytes "
-                    "(response size: %d bytes)", len(r.content)
-                )
-                return None
+            raw_lower = r.content.lower()
 
-            # Check for plain-text authorization errors in the inner payload.
+            # Check for plain-text authorization errors in raw response or inner payload.
             # When the RSA key is registered but not yet verified, the gateway
-            # returns HTTP 200 with MESSAGEFAULT_ERROR_NONE but the inner bytes
-            # contain a plain-text error like "v1r: client authorization not verified"
-            # instead of a valid protobuf payload.
-            # Check in bytes first to avoid decoding large protobuf blobs on every call.
-            if b'authorization not verified' in inner.lower():
+            # returns HTTP 200 with MESSAGEFAULT_ERROR_NONE but the payload
+            # contains a plain-text error like "v1r: client authorization not verified"
+            # instead of a valid protobuf inner payload.
+            if b'authorization not verified' in raw_lower or (inner and b'authorization not verified' in inner.lower()):
+                raw_preview = _decode_payload_preview(r.content)
                 msg = (
                     "v1r RSA key is registered but not yet VERIFIED by the gateway "
                     "(PENDING_VERIFICATION). "
                     "Toggle ONE Powerwall circuit breaker OFF, wait 2 seconds, then back ON. "
                     "Wait 30-60 seconds, then retry. "
                     "Run 'python -m pypowerwall register' to check key state. "
+                    f"Gateway payload ({response_size} bytes): {raw_preview} "
                     "See: https://github.com/jasonacox/pypowerwall/issues/274"
                 )
                 log.error("v1r: %s", msg)
                 if not self.pending_verification:
-                    # Emit a visible warning the first time this is detected so users
-                    # see it without needing debug logging enabled.
                     self.pending_verification = True
+                    warnings.warn(msg, UserWarning, stacklevel=4)
+                return None
+
+            if not inner:
+                # Empty inner payload with no recognized fault code — the response
+                # may be a plain-text or binary auth rejection the gateway didn't
+                # encode as a fault.  Reveal the raw payload so users can troubleshoot.
+                raw_preview = _decode_payload_preview(r.content)
+                msg = (
+                    f"v1r key authentication failed — gateway returned an unexpected "
+                    f"response ({response_size} bytes) with no data. "
+                    f"Gateway payload: {raw_preview} "
+                    "The RSA key may not be registered or recognized by this gateway. "
+                    "Run 'python -m pypowerwall register' to register or verify your key. "
+                    "See: https://github.com/jasonacox/pypowerwall/issues/274"
+                )
+                log.error("v1r: %s", msg)
+                if not self.key_unknown:
+                    self.key_unknown = True
                     warnings.warn(msg, UserWarning, stacklevel=4)
                 return None
 

--- a/pypowerwall/tedapi/tedapi_v1r.py
+++ b/pypowerwall/tedapi/tedapi_v1r.py
@@ -43,8 +43,9 @@ class TEDAPIv1r:
         self.poolmaxsize = poolmaxsize
         self.token: Optional[str] = None
         self.din: Optional[str] = None
-        # Tracks whether the registered key is stuck in PENDING_VERIFICATION
+        # Tracks key-auth failure state so warnings fire once per session
         self.pending_verification: bool = False
+        self.key_unknown: bool = False
 
         # Load RSA private key
         from cryptography.hazmat.primitives import serialization
@@ -211,8 +212,16 @@ class TEDAPIv1r:
             if fault != combined_pb2.MESSAGEFAULT_ERROR_NONE:
                 fault_name = combined_pb2.MessageFault_E.Name(fault)
                 if fault == combined_pb2.MESSAGEFAULT_ERROR_UNKNOWN_KEY_ID:
-                    log.error(f"v1r response fault: {fault_name}")
-                    log.error("RSA key not registered. Run v1r_register.py (or: python -m pypowerwall register) to register your key.")
+                    msg = (
+                        "v1r RSA key is not recognized by the gateway (UNKNOWN_KEY_ID). "
+                        "The key file may not match the registered key, or no key has been "
+                        "registered. Run 'python -m pypowerwall register' to register or "
+                        "verify your key. See: https://github.com/jasonacox/pypowerwall/issues/274"
+                    )
+                    log.error("v1r: %s", msg)
+                    if not self.key_unknown:
+                        self.key_unknown = True
+                        warnings.warn(msg, UserWarning, stacklevel=4)
                 elif fault == combined_pb2.MESSAGEFAULT_ERROR_TIMEOUT:
                     log.debug(f"v1r response fault: {fault_name} (sub-device may not be routable via v1r)")
                 else:
@@ -222,7 +231,12 @@ class TEDAPIv1r:
             # Extract inner protobuf bytes
             inner = resp_msg.protobuf_message_as_bytes
             if not inner:
-                log.error("v1r response has no protobuf_message_as_bytes")
+                # Empty inner payload with no fault code — unusual but should not
+                # pass silently.  Log the response size for diagnostic context.
+                log.error(
+                    "v1r response has no protobuf_message_as_bytes "
+                    "(response size: %d bytes)", len(r.content)
+                )
                 return None
 
             # Check for plain-text authorization errors in the inner payload.

--- a/pypowerwall/tests/unit/test_v1r_warnings.py
+++ b/pypowerwall/tests/unit/test_v1r_warnings.py
@@ -1,0 +1,235 @@
+"""Unit tests for v1r key-auth warning behavior.
+
+Covers two new code paths added in fix/v1r-pending-verification-warning:
+  1. TEDAPI._connect_v1r() probes key state at init and logs an error if
+     PENDING_VERIFICATION is detected.
+  2. TEDAPIv1r.post_v1r() emits a warnings.warn() exactly once when the
+     gateway returns an "authorization not verified" inner payload.
+"""
+import logging
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pypowerwall.tedapi.protobuf.V2024_06 import tedapi_combined_pb2 as combined_pb2
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_routable_message(
+    fault=combined_pb2.MESSAGEFAULT_ERROR_NONE,
+    inner_bytes: bytes = b"",
+) -> bytes:
+    """Return serialized RoutableMessage bytes for use as a mock HTTP response."""
+    msg = combined_pb2.RoutableMessage()
+    msg.signed_message_status.message_fault = fault
+    msg.protobuf_message_as_bytes = inner_bytes
+    return msg.SerializeToString()
+
+
+# ---------------------------------------------------------------------------
+# Tests: TEDAPI._connect_v1r() — connect-time probe
+# ---------------------------------------------------------------------------
+
+class TestConnectV1rProbe:
+    """TEDAPI._connect_v1r() probes key state and logs an error on PENDING_VERIFICATION."""
+
+    def _make_tedapi(self):
+        """Build a TEDAPI instance with all network I/O mocked out."""
+        with patch("pypowerwall.tedapi.TEDAPI.connect", return_value="TEST_DIN"):
+            from pypowerwall.tedapi import TEDAPI
+            ted = TEDAPI(gw_pwd="testpassword")
+        ted.gw_ip = "10.42.1.1"
+        ted.v1r = True
+        ted.wifi_session = None
+        return ted
+
+    def test_connect_v1r_logs_error_when_pending_verification(self, caplog):
+        """When probe returns None and pending_verification is True, an error is logged."""
+        ted = self._make_tedapi()
+
+        mock_transport = MagicMock()
+        mock_transport.login.return_value = True
+        mock_transport.get_din.return_value = "TEST_DIN"
+        mock_transport.get_config_v1r.return_value = None
+        mock_transport.pending_verification = True
+        ted.v1r_transport = mock_transport
+
+        with caplog.at_level(logging.ERROR):
+            result = ted._connect_v1r()
+
+        assert result == "TEST_DIN", "_connect_v1r() must still return the DIN"
+        assert any(
+            "PENDING_VERIFICATION" in record.message for record in caplog.records
+        ), "Expected PENDING_VERIFICATION error to be logged"
+
+    def test_connect_v1r_no_log_when_probe_succeeds(self, caplog):
+        """When the probe returns data, no PENDING_VERIFICATION error is logged."""
+        ted = self._make_tedapi()
+
+        mock_transport = MagicMock()
+        mock_transport.login.return_value = True
+        mock_transport.get_din.return_value = "TEST_DIN"
+        mock_transport.get_config_v1r.return_value = {"vin": "GW--123"}
+        mock_transport.pending_verification = False
+        ted.v1r_transport = mock_transport
+
+        with caplog.at_level(logging.ERROR):
+            result = ted._connect_v1r()
+
+        assert result == "TEST_DIN"
+        assert not any(
+            "PENDING_VERIFICATION" in record.message for record in caplog.records
+        )
+
+    def test_connect_v1r_logs_error_when_key_unknown(self, caplog):
+        """When probe returns None and key_unknown is True, an error is logged."""
+        ted = self._make_tedapi()
+
+        mock_transport = MagicMock()
+        mock_transport.login.return_value = True
+        mock_transport.get_din.return_value = "TEST_DIN"
+        mock_transport.get_config_v1r.return_value = None
+        mock_transport.pending_verification = False
+        mock_transport.key_unknown = True
+        ted.v1r_transport = mock_transport
+
+        with caplog.at_level(logging.ERROR):
+            result = ted._connect_v1r()
+
+        assert result == "TEST_DIN"
+        assert any(
+            "key" in record.message.lower() and "not recognized" in record.message.lower()
+            for record in caplog.records
+        ), "Expected UNKNOWN_KEY_ID error to be logged"
+
+    def test_connect_v1r_no_log_when_probe_none_but_not_pending(self, caplog):
+        """When probe returns None but both flags are False, no error is logged."""
+        ted = self._make_tedapi()
+
+        mock_transport = MagicMock()
+        mock_transport.login.return_value = True
+        mock_transport.get_din.return_value = "TEST_DIN"
+        mock_transport.get_config_v1r.return_value = None
+        mock_transport.pending_verification = False
+        mock_transport.key_unknown = False
+        ted.v1r_transport = mock_transport
+
+        with caplog.at_level(logging.ERROR):
+            result = ted._connect_v1r()
+
+        assert result == "TEST_DIN"
+        assert not any(
+            "PENDING_VERIFICATION" in record.message or "not recognized" in record.message
+            for record in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: TEDAPIv1r.post_v1r() — warning-once behavior
+# ---------------------------------------------------------------------------
+
+class TestPostV1rWarnings:
+    """TEDAPIv1r.post_v1r() emits a UserWarning exactly once per 'authorization not verified' error."""
+
+    def _make_transport(self):
+        """Build a TEDAPIv1r with all I/O mocked (no real socket, no real RSA key)."""
+        from pypowerwall.tedapi.tedapi_v1r import TEDAPIv1r
+
+        with patch.object(TEDAPIv1r, "__init__", lambda self, *a, **kw: None):
+            transport = TEDAPIv1r.__new__(TEDAPIv1r)
+        # Minimal attribute setup matching the real __init__
+        transport.pending_verification = False
+        transport.key_unknown = False
+        transport.host = "10.42.1.1"
+        transport.timeout = 5
+        transport.token = "fake-token"
+        transport.din = "TEST_DIN"
+        # Stub out RSA signing so we don't need a real key
+        transport._private_key = MagicMock()
+        transport._private_key.sign.return_value = b"\x00" * 64
+        transport._public_key_der = b"\x00" * 32
+
+        # Mock the session so we can control the HTTP response
+        transport.session = MagicMock()
+        return transport
+
+    def _mock_response(self, payload_bytes: bytes, status_code: int = 200):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.content = _make_routable_message(inner_bytes=payload_bytes)
+        return resp
+
+    def test_pending_verification_emits_warning_once(self):
+        """First 'authorization not verified' call emits UserWarning; second does not."""
+        transport = self._make_transport()
+        inner = b"v1r: client authorization not verified"
+        transport.session.post.return_value = self._mock_response(inner)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result1 = transport.post_v1r(b"fake-payload", "TEST_DIN")
+            result2 = transport.post_v1r(b"fake-payload", "TEST_DIN")
+
+        assert result1 is None, "post_v1r must return None on auth failure"
+        assert result2 is None
+
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user_warnings) == 1, (
+            f"Expected exactly one UserWarning across two calls, got {len(user_warnings)}"
+        )
+        assert "PENDING_VERIFICATION" in str(user_warnings[0].message)
+
+    def test_pending_verification_flag_is_set(self):
+        """pending_verification flag must be True after the first auth failure."""
+        transport = self._make_transport()
+        inner = b"authorization not verified"
+        transport.session.post.return_value = self._mock_response(inner)
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            transport.post_v1r(b"fake-payload", "TEST_DIN")
+
+        assert transport.pending_verification is True
+
+    def test_unknown_key_emits_warning_once(self):
+        """UNKNOWN_KEY_ID fault emits UserWarning exactly once across repeated calls."""
+        transport = self._make_transport()
+        bad_resp = MagicMock()
+        bad_resp.status_code = 200
+        msg = combined_pb2.RoutableMessage()
+        msg.signed_message_status.message_fault = combined_pb2.MESSAGEFAULT_ERROR_UNKNOWN_KEY_ID
+        bad_resp.content = msg.SerializeToString()
+        transport.session.post.return_value = bad_resp
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result1 = transport.post_v1r(b"fake-payload", "TEST_DIN")
+            result2 = transport.post_v1r(b"fake-payload", "TEST_DIN")
+
+        assert result1 is None
+        assert result2 is None
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user_warnings) == 1, (
+            f"Expected exactly one UserWarning across two calls, got {len(user_warnings)}"
+        )
+        assert "UNKNOWN_KEY_ID" in str(user_warnings[0].message)
+        assert transport.key_unknown is True
+
+    def test_valid_response_returns_inner_bytes(self):
+        """A well-formed response returns the inner bytes without a warning."""
+        transport = self._make_transport()
+        inner = b"\x08\x01\x12\x03abc"  # fake valid protobuf
+        transport.session.post.return_value = self._mock_response(inner)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = transport.post_v1r(b"fake-payload", "TEST_DIN")
+
+        assert result == inner
+        assert not any(issubclass(w.category, UserWarning) for w in caught)
+        assert transport.pending_verification is False
+        assert transport.key_unknown is False

--- a/pypowerwall/tests/unit/test_v1r_warnings.py
+++ b/pypowerwall/tests/unit/test_v1r_warnings.py
@@ -219,6 +219,34 @@ class TestPostV1rWarnings:
         assert "UNKNOWN_KEY_ID" in str(user_warnings[0].message)
         assert transport.key_unknown is True
 
+    def test_empty_inner_emits_warning_once(self):
+        """Empty inner payload with no fault code fires UserWarning exactly once.
+
+        This covers the unregistered-key case where the gateway returns HTTP 200
+        with 101 bytes, MESSAGEFAULT_ERROR_NONE, and no protobuf_message_as_bytes.
+        The response does not contain 'authorization not verified' text either —
+        the error is only detectable by the empty inner payload.
+        """
+        transport = self._make_transport()
+        # Response with no inner bytes and no fault — the unregistered-key 101-byte case
+        empty_resp = MagicMock()
+        empty_resp.status_code = 200
+        empty_resp.content = _make_routable_message(inner_bytes=b"")
+        transport.session.post.return_value = empty_resp
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result1 = transport.post_v1r(b"fake-payload", "TEST_DIN")
+            result2 = transport.post_v1r(b"fake-payload", "TEST_DIN")
+
+        assert result1 is None
+        assert result2 is None
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user_warnings) == 1, (
+            f"Expected exactly one UserWarning across two calls, got {len(user_warnings)}"
+        )
+        assert transport.key_unknown is True
+
     def test_valid_response_returns_inner_bytes(self):
         """A well-formed response returns the inner bytes without a warning."""
         transport = self._make_transport()

--- a/pypowerwall/tests/unit/test_v1r_warnings.py
+++ b/pypowerwall/tests/unit/test_v1r_warnings.py
@@ -106,6 +106,24 @@ class TestConnectV1rProbe:
             for record in caplog.records
         ), "Expected UNKNOWN_KEY_ID error to be logged"
 
+    def test_connect_v1r_probe_seeds_config_cache(self):
+        """When the probe returns config data, it is stored in the config cache."""
+        ted = self._make_tedapi()
+
+        config = {"vin": "GW--123", "site_info": {}}
+        mock_transport = MagicMock()
+        mock_transport.login.return_value = True
+        mock_transport.get_din.return_value = "TEST_DIN"
+        mock_transport.get_config_v1r.return_value = config
+        mock_transport.pending_verification = False
+        ted.v1r_transport = mock_transport
+
+        result = ted._connect_v1r()
+
+        assert result == "TEST_DIN"
+        assert ted.pwcache.get("config") == config, "Probe result must seed the config cache"
+        assert "config" in ted.pwcachetime
+
     def test_connect_v1r_no_log_when_probe_none_but_not_pending(self, caplog):
         """When probe returns None but both flags are False, no error is logged."""
         ted = self._make_tedapi()
@@ -148,6 +166,7 @@ class TestPostV1rWarnings:
         transport.timeout = 5
         transport.token = "fake-token"
         transport.din = "TEST_DIN"
+        transport.key_fingerprint = "f" * 64  # fake SHA256 hex
         # Stub out RSA signing so we don't need a real key
         transport._private_key = MagicMock()
         transport._private_key.sign.return_value = b"\x00" * 64
@@ -246,6 +265,56 @@ class TestPostV1rWarnings:
             f"Expected exactly one UserWarning across two calls, got {len(user_warnings)}"
         )
         assert transport.key_unknown is True
+
+    def test_flags_reset_on_recovery(self):
+        """A successful response clears the failure flags so a later failure warns again.
+
+        This models the real-world verification flow: key is PENDING, user
+        toggles the breaker while the process is running, key becomes VERIFIED,
+        and data starts flowing. If the key later breaks again (e.g., gateway
+        factory reset), the warning must fire again rather than staying
+        suppressed for the life of the session.
+        """
+        transport = self._make_transport()
+        bad = self._mock_response(b"v1r: client authorization not verified")
+        good = self._mock_response(b"\x08\x01\x12\x03abc")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            transport.session.post.return_value = bad
+            assert transport.post_v1r(b"fake", "TEST_DIN") is None
+            assert transport.pending_verification is True
+
+            transport.session.post.return_value = good
+            assert transport.post_v1r(b"fake", "TEST_DIN") == b"\x08\x01\x12\x03abc"
+            assert transport.pending_verification is False, "Success must clear the flag"
+            assert transport.key_unknown is False
+
+            transport.session.post.return_value = bad
+            assert transport.post_v1r(b"fake", "TEST_DIN") is None
+
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user_warnings) == 2, (
+            f"Expected a warning per failure episode (2), got {len(user_warnings)}"
+        )
+
+    def test_unknown_key_warning_includes_fingerprint(self):
+        """UNKNOWN_KEY_ID warning must include the local key fingerprint for comparison."""
+        transport = self._make_transport()
+        bad_resp = MagicMock()
+        bad_resp.status_code = 200
+        msg = combined_pb2.RoutableMessage()
+        msg.signed_message_status.message_fault = combined_pb2.MESSAGEFAULT_ERROR_UNKNOWN_KEY_ID
+        bad_resp.content = msg.SerializeToString()
+        transport.session.post.return_value = bad_resp
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            transport.post_v1r(b"fake-payload", "TEST_DIN")
+
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user_warnings) == 1
+        assert transport.key_fingerprint in str(user_warnings[0].message)
 
     def test_valid_response_returns_inner_bytes(self):
         """A well-formed response returns the inner bytes without a warning."""

--- a/pypowerwall/v1r_register.py
+++ b/pypowerwall/v1r_register.py
@@ -23,6 +23,7 @@ Two authentication paths are supported:
     python -m pypowerwall register
 """
 
+import hashlib
 import json
 import os
 import sys
@@ -196,6 +197,7 @@ def generate_rsa_key(authpath=""):
             serialization.Encoding.DER,
             serialization.PublicFormat.PKCS1
         )
+        print(f"  Public key fingerprint (SHA256): {hashlib.sha256(public_key_der).hexdigest()}")
         return private_key, public_key_der
 
     print("  Generating RSA-4096 key pair...")
@@ -225,6 +227,7 @@ def generate_rsa_key(authpath=""):
 
     print(f"  Private key saved: {private_key_file}")
     print(f"  Public key saved:  {public_key_file}")
+    print(f"  Public key fingerprint (SHA256): {hashlib.sha256(public_key_der).hexdigest()}")
     return private_key, public_key_der
 
 
@@ -536,17 +539,21 @@ def step4_register_key(token, energy_site_id, public_key_der, fleet_api_base, pr
         print("  It may still be pending — check again later with list_authorized_clients.")
     if private_key_file:
         print(f"\n  RSA private key: {private_key_file}")
+    print(f"  Public key fingerprint (SHA256): {hashlib.sha256(public_key_der).hexdigest()}")
+    print("  (pypowerwall logs this same fingerprint at connect time — compare them")
+    print("   if data calls return None; a mismatch means the wrong key file is in use.)")
     print()
     print("  Next steps (library usage):")
     print("    import pypowerwall")
-    print('    pw = pypowerwall.Powerwall(host="POWERWALL_IP", password="XXXXX",')
-    print('         email="you@example.com", rsa_key_path="tedapi_rsa_private.pem")')
+    print('    pw = pypowerwall.Powerwall(host="POWERWALL_IP", gw_pwd="FULL_QR_STICKER_PASSWORD",')
+    print('         rsa_key_path="tedapi_rsa_private.pem")')
     print()
     print("  Next steps (Docker / Powerwall-Dashboard):")
     print("    1. Copy the key to your Powerwall-Dashboard .auth/ directory")
     print("    2. Set PW_RSA_KEY_PATH=/app/.auth/tedapi_rsa_private.pem")
     print("    3. Set PW_HOST to your Powerwall's wired LAN IP")
-    print("    4. Set PW_PASSWORD to your customer password")
+    print("    4. Set PW_GW_PWD to the full QR sticker password")
+    print("       (or PW_PASSWORD to the last 5 characters of it)")
     print("    5. Start the container — v1r mode is auto-detected")
     print()
 


### PR DESCRIPTION
## Summary

When a v1r RSA key is rejected by the gateway, pypowerwall currently only emits `log.debug()` / `log.error()` messages — invisible unless the user has debug logging enabled. The result is that all data calls silently return `None`, leaving users with no indication of what went wrong.

Reported in #352 by @AndrewTapp — debug output showed `POST /tedapi/v1r HTTP/1.1 200 101` on every call, but nothing surfaced to the user.

## Changes

### 1. `warnings.warn()` for "authorization not verified" (PENDING_VERIFICATION)

**File:** `pypowerwall/tedapi/tedapi_v1r.py` — `post_v1r()`

The first time `"authorization not verified"` is detected in a v1r response (the 101-byte response), a `UserWarning` is issued. This is visible without `set_debug(True)` and can be suppressed or caught by scripts. A `pending_verification` flag prevents warning spam on subsequent calls.

### 2. `warnings.warn()` for UNKNOWN_KEY_ID (wrong/unregistered key)

**File:** `pypowerwall/tedapi/tedapi_v1r.py` — `post_v1r()`

When the gateway returns `MESSAGEFAULT_ERROR_UNKNOWN_KEY_ID`, a `UserWarning` is issued with guidance. This catches the scenario where a user has a different key file than the one registered (e.g. generated on a different machine). A `key_unknown` flag prevents repeat warnings.

### 3. Key verification probe in `_connect_v1r()`

**File:** `pypowerwall/tedapi/__init__.py` — `_connect_v1r()`

After login + DIN succeed, makes a test `get_config_v1r()` call so auth failures surface at init time, not silently on the first data call. Handles both `pending_verification` and `key_unknown` states with specific remediation messages.

### 4. Response-size diagnostics

**File:** `pypowerwall/tedapi/tedapi_v1r.py` — `post_v1r()`

When the response has an empty `protobuf_message_as_bytes` with no fault code, the response size is now logged for diagnostic context.

## Before

```python
>>> pw = pypowerwall.Powerwall(host="10.42.1.16", gw_pwd="...", rsa_key_path="key.pem")
>>> print(pw.site_name(), pw.version(), pw.din())
None None None   # no indication of why
```

## After

```
UserWarning: v1r RSA key is registered but not yet VERIFIED by the gateway
(PENDING_VERIFICATION). Toggle ONE Powerwall circuit breaker OFF, wait 2 seconds,
then back ON. Wait 30-60 seconds, then retry. Run 'python -m pypowerwall register'
to check key state. See: https://github.com/jasonacox/pypowerwall/issues/274
```

Fixes #352.

— Sam ⚡