### PR TITLE
fix: add HEALTHCHECK using curl to Dockerfiles (#346)

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 
 # Install system dependencies (package manager differs by base image).
 # tini is a tiny init that, as PID 1, reaps orphaned child processes (e.g. the
-# wget spawned by the container HEALTHCHECK) and forwards signals. This is
+# curl spawned by the container HEALTHCHECK) and forwards signals. This is
 # defense-in-depth alongside the SIGCHLD reaper in server.py, and also covers
 # any future child processes regardless of how the operator runs the image.
 RUN if command -v apk > /dev/null; then \
@@ -36,6 +36,12 @@ RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 COPY server.py transform.py __init__.py /app/
 COPY web/ /app/web/
 EXPOSE 8675
+
+# Default healthcheck — uses curl (already installed) to hit the /health endpoint.
+# Compose files that set their own healthcheck will override this.
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=60s \
+    CMD curl -sf http://localhost:8675/health > /dev/null || exit 1
+
 # Run under tini as PID 1 so orphaned children are reaped and signals forwarded.
 ENTRYPOINT ["tini", "--"]
 CMD ["python3", "server.py"]

--- a/proxy/Dockerfile.beta
+++ b/proxy/Dockerfile.beta
@@ -18,7 +18,7 @@ WORKDIR /app
 
 # Install system dependencies (package manager differs by base image).
 # tini is a tiny init that, as PID 1, reaps orphaned child processes (e.g. the
-# wget spawned by the container HEALTHCHECK) and forwards signals. This is
+# curl spawned by the container HEALTHCHECK) and forwards signals. This is
 # defense-in-depth alongside the SIGCHLD reaper in server.py, and also covers
 # any future child processes regardless of how the operator runs the image.
 RUN if command -v apk > /dev/null; then \
@@ -36,6 +36,12 @@ COPY web/ /app/web/
 # Copy local pypowerwall source for beta testing (placed here by upload-beta.sh)
 COPY pypowerwall/ /app/pypowerwall/
 EXPOSE 8675
+
+# Default healthcheck — uses curl (already installed) to hit the /health endpoint.
+# Compose files that set their own healthcheck will override this.
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=60s \
+    CMD curl -sf http://localhost:8675/health > /dev/null || exit 1
+
 # Run under tini as PID 1 so orphaned children are reaped and signals forwarded.
 ENTRYPOINT ["tini", "--"]
 CMD ["python3", "server.py"]

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,12 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t96 (12 Jul 2026)
+
+* Added built-in `HEALTHCHECK` instruction to `Dockerfile` and `Dockerfile.beta` using `curl` (already installed) instead of `wget`
+* Fixes the "unhealthy - wget missing" issue ([#346](https://github.com/jasonacox/pypowerwall/issues/346)): the switch from Alpine to Debian-slim in t94 removed `wget`, but many compose files still referenced it in their healthcheck definition
+* The image now reports its own health via `curl -sf http://localhost:8675/health`, which works out of the box without requiring compose-level healthcheck configuration
+* Compose-level healthchecks still override this if defined
+
 ### Proxy t95 (4 Jul 2026)
 
 * Upgraded to pyPowerwall v0.16.0 (code review sweep — see library release notes)

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -130,7 +130,7 @@ from pypowerwall.fleetapi.exceptions import (
     PyPowerwallFleetAPIInvalidPayload,
 )
 
-BUILD = "t95"
+BUILD = "t96"
 ALLOWLIST = [
     "/api/status",
     "/api/site_info/site_name",
@@ -809,13 +809,12 @@ signal.signal(signal.SIGTERM, sig_term_handle)
 
 # Reap terminated child processes to prevent zombie (<defunct>) accumulation.
 #
-# In the Docker image this server runs as PID 1. The container HEALTHCHECK
-# (curl -sf ... /health, every 30s) executes inside the container, so each curl
-# is an orphaned child that the kernel reparents to PID 1. As the init process,
-# PID 1 is responsible for wait()-ing on such children; a bare Python process
-# installs no SIGCHLD handler and never reaps them, so every terminated
-# healthcheck becomes an unreaped zombie that accumulates over the life of the
-# container and can eventually exhaust the PID table.
+# When this server runs as PID 1 (e.g. without an init wrapper), the container
+# HEALTHCHECK (curl -sf ... /health, every 30s) spawns curl as a child process.
+# Without a SIGCHLD handler, terminated children accumulate as zombies and can
+# eventually exhaust the PID table. The Docker image uses tini as PID 1, which
+# handles reaping automatically; this handler is kept as a safety net for bare
+# invocations where the server itself is PID 1.
 #
 # This server currently spawns no child processes of its own. The WNOHANG flag
 # ensures only already-exited children are collected; if subprocess use is added

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -810,12 +810,12 @@ signal.signal(signal.SIGTERM, sig_term_handle)
 # Reap terminated child processes to prevent zombie (<defunct>) accumulation.
 #
 # In the Docker image this server runs as PID 1. The container HEALTHCHECK
-# (wget --spider ... /api/site_info, every 30s) executes inside the container,
-# so each wget is an orphaned child that the kernel reparents to PID 1. As the
-# init process, PID 1 is responsible for wait()-ing on such children; a bare
-# Python process installs no SIGCHLD handler and never reaps them, so every
-# terminated healthcheck becomes an unreaped zombie that accumulates over the
-# life of the container and can eventually exhaust the PID table.
+# (curl -sf ... /health, every 30s) executes inside the container, so each curl
+# is an orphaned child that the kernel reparents to PID 1. As the init process,
+# PID 1 is responsible for wait()-ing on such children; a bare Python process
+# installs no SIGCHLD handler and never reaps them, so every terminated
+# healthcheck becomes an unreaped zombie that accumulates over the life of the
+# container and can eventually exhaust the PID table.
 #
 # This server currently spawns no child processes of its own. The WNOHANG flag
 # ensures only already-exited children are collected; if subprocess use is added


### PR DESCRIPTION
## Summary

Fixes the `wget: not found` healthcheck failure reported in #346.

The proxy Docker image switched from Alpine to `python:3.10-slim` (Debian) in v0.15.13 to fix Tesla TLS token refresh `403` errors (#344/#345). Alpine ships `wget`; Debian-slim does not — only `curl` is installed. The Dockerfiles had no built-in `HEALTHCHECK`, so the healthcheck came from external compose files that used `wget`.

Powerwall-Dashboard already fixed this on the compose side ([ce8810a](https://github.com/jasonacox/Powerwall-Dashboard/commit/ce8810a) → [304bfc0](https://github.com/jasonacox/Powerwall-Dashboard/commit/304bfc0)). This PR brings the fix into the pypowerwall Docker image itself.

## Changes

- **`proxy/Dockerfile`** — Added `HEALTHCHECK` directive using `curl -sf http://localhost:8675/health`, matching the Powerwall-Dashboard compose healthcheck. Compose files that define their own healthcheck override this, so existing setups are unaffected.
- **`proxy/Dockerfile.beta`** — Same `HEALTHCHECK` added for parity.
- **`proxy/server.py`** — Updated stale comments referencing `wget --spider ... /api/site_info` to reflect the current `curl -sf ... /health` healthcheck.
- Updated `wget` → `curl` in Dockerfile comments about `tini`.

## Why a Dockerfile HEALTHCHECK?

Without a `HEALTHCHECK` in the image, any user running the container without a compose file (or with a compose file that does not set one) gets no health status at all. Adding it to the Dockerfile gives every deployment a sensible default that uses the already-installed `curl`.

Fixes #346