### PR TITLE
feat(proxy): track SolarOnly fallback mode and auto-recover TEDAPI connection (t97)

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -260,6 +260,8 @@ Network Robustness Settings
 * PW_GRACEFUL_DEGRADATION - Return cached data when fresh data unavailable ("yes") - Improves reliability for monitoring tools
 * PW_HEALTH_CHECK - Enable connection health monitoring and degraded mode detection ("yes")
 * PW_CACHE_TTL - Maximum age in seconds for cached data before returning null ("30") - Ensures data freshness over availability
+* PW_TEDAPI_RECOVERY - Enable automatic TEDAPI recovery when proxy enters SolarOnly fallback mode ("yes") - Only active in TEDAPI modes; no overhead for Cloud/FleetAPI/local
+* PW_TEDAPI_PROBE_INTERVAL - Seconds between TEDAPI health probes ("30") - After 3 consecutive None results the proxy enters SolarOnly fallback; recovery uses exponential backoff (60s → 300s max); minimum value is 5
 
 UI and Advanced Settings
 * PW_STYLE - Background color style for iframe [animation](http://localhost:8675/example.html) ("clear") - options:

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,17 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t97 (17 Jul 2026)
+
+* Added TEDAPI SolarOnly fallback mode tracking and auto-recovery (issue [#360](https://github.com/jasonacox/pypowerwall/issues/360))
+* Previously, when TEDAPI dropped mid-session (e.g. a gateway 403 after a firmware update or route loss), the proxy silently entered SolarOnly mode and stayed there until restarted
+* `is_fallback_mode` is now a distinct proxy state, separate from `is_degraded` (transient transport failures) — SolarOnly fallback is a semantic condition that needs recovery work, not just a health metric
+* A lightweight background thread (`tedapi-recovery`) probes TEDAPI health every `PW_TEDAPI_PROBE_INTERVAL` seconds (default 30s); after `TEDAPI_FALLBACK_THRESHOLD` (3) consecutive None results, the proxy logs a warning and enters fallback mode
+* The recovery thread then calls `pw.connect()` periodically with exponential backoff (60s → up to 300s) until TEDAPI data flows again; on success it logs recovery and resets backoff; on failure it logs the attempt and stays in SolarOnly — no restart needed and no data gap created
+* Fallback state is exposed in `/health` and `/stats` under `"fallback_mode"`: `is_fallback_mode`, `fallback_since`, `fallback_duration_seconds`, `recovery_attempts`, `last_recovery_attempt`, `recovery_enabled`
+* `/health/reset` also clears the fallback mode state
+* New environment variables: `PW_TEDAPI_RECOVERY=yes/no` (default `yes`), `PW_TEDAPI_PROBE_INTERVAL=N` (default `30`)
+* Only active when TEDAPI mode is configured — no overhead for Cloud, FleetAPI, or local-only modes
+
 ### Proxy t96 (12 Jul 2026)
 
 * Added built-in `HEALTHCHECK` instruction to `Dockerfile` and `Dockerfile.beta` using `curl` (already installed) instead of `wget`

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,6 +1,6 @@
 ## pyPowerwall Proxy Release Notes
 
-### Proxy t97 (17 Jul 2026)
+### Proxy t97 (18 Jul 2026)
 
 * Added TEDAPI SolarOnly fallback mode tracking and auto-recovery (issue [#360](https://github.com/jasonacox/pypowerwall/issues/360))
 * Previously, when TEDAPI dropped mid-session (e.g. a gateway 403 after a firmware update or route loss), the proxy silently entered SolarOnly mode and stayed there until restarted
@@ -11,6 +11,10 @@
 * `/health/reset` also clears the fallback mode state
 * New environment variables: `PW_TEDAPI_RECOVERY=yes/no` (default `yes`), `PW_TEDAPI_PROBE_INTERVAL=N` (default `30`)
 * Only active when TEDAPI mode is configured — no overhead for Cloud, FleetAPI, or local-only modes
+* Runtime-reconnect trade-off: `pw.connect()` swaps `pw.client` and transiently mutates `pw.mode`/`cloudmode`/`fleetapi` while handler threads may be live. In practice this is bounded — requests were already failing when recovery fires, the swap is atomic, and worst case a few in-flight requests see a transient wrong-mode branch before recovery completes
+* Hybrid-mode note: the probe gate is `pw.tedapi` which includes hybrid mode (v1r + WiFi fallback). In hybrid, `pw.version()` may be served by the local API, so a WiFi TEDAPI outage might not be detected by the probe; monitoring is best-effort for hybrid, with full coverage for pure TEDAPI modes
+* 429-cooldown interaction: a rate-limited gateway causes `pw.version()` to return None, driving the probe into fallback — the 60→300s recovery backoff bounds reconnect attempts to roughly once per cooldown window
+* Fixed edge case: `/health/reset` fired during a recovery backoff sleep could cause one stale `recovery_attempts` write after state was cleared; the recovery thread now re-checks `is_fallback_mode` after the backoff sleep before writing state or calling `pw.connect()`
 
 ### Proxy t96 (12 Jul 2026)
 

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -58,6 +58,16 @@
       returning null instead of stale data (default: 30)
     - Consider reducing PW_TIMEOUT to fail faster (e.g., PW_TIMEOUT=3)
 
+ TEDAPI SolarOnly Fallback Recovery (PW3/TEDAPI modes)
+    When TEDAPI drops mid-session (e.g. firmware 403 or route loss), the proxy
+    falls back to SolarOnly mode — solar data continues but battery/grid detail
+    is unavailable. The proxy now tracks this as a distinct `is_fallback_mode`
+    state (separate from `is_degraded`) and a background thread retries the
+    TEDAPI connection periodically with exponential backoff until data returns.
+    - PW_TEDAPI_RECOVERY=yes/no — enable/disable auto-recovery (default: yes)
+    - PW_TEDAPI_PROBE_INTERVAL=N — seconds between health probes (default: 30)
+    The fallback state is visible in /health and /stats under "fallback_mode".
+
  Monitoring & Health Endpoints
     - /health - returns connection health status and feature configuration
     - /health/reset - resets health counters and clears cache
@@ -130,7 +140,7 @@ from pypowerwall.fleetapi.exceptions import (
     PyPowerwallFleetAPIInvalidPayload,
 )
 
-BUILD = "t96"
+BUILD = "t97"
 ALLOWLIST = [
     "/api/status",
     "/api/site_info/site_name",
@@ -222,6 +232,13 @@ health_check_enabled = (
 degradation_cache_ttl_seconds = int(
     os.getenv("PW_CACHE_TTL", "30")
 )  # Maximum age for cached data before returning None
+tedapi_recovery_enabled = (
+    os.getenv("PW_TEDAPI_RECOVERY", "yes").lower() == "yes"
+)  # Auto-recover TEDAPI connection when proxy falls back to SolarOnly mode
+TEDAPI_PROBE_INTERVAL = int(os.getenv("PW_TEDAPI_PROBE_INTERVAL", "30"))  # seconds between probes
+TEDAPI_FALLBACK_THRESHOLD = 3  # consecutive probe failures before entering fallback mode
+TEDAPI_RECOVERY_INITIAL_INTERVAL = 60   # initial recovery retry interval (seconds)
+TEDAPI_RECOVERY_MAX_INTERVAL = 300      # cap on retry interval (seconds)
 
 # Global Stats
 proxystats = {
@@ -277,6 +294,8 @@ proxystats = {
         "PW_GRACEFUL_DEGRADATION": graceful_degradation,
         "PW_HEALTH_CHECK": health_check_enabled,
         "PW_CACHE_TTL": degradation_cache_ttl_seconds,
+        "PW_TEDAPI_RECOVERY": tedapi_recovery_enabled,
+        "PW_TEDAPI_PROBE_INTERVAL": TEDAPI_PROBE_INTERVAL,
     },
 }
 proxystats_lock = threading.RLock()
@@ -407,6 +426,17 @@ _connection_health = {
 }
 _connection_health_lock = threading.RLock()
 
+# SolarOnly fallback mode tracking (distinct from connection_health degradation)
+# is_degraded = transient transport failures; is_fallback_mode = TEDAPI fell back to SolarOnly
+_fallback_mode = {
+    "is_fallback_mode": False,
+    "fallback_since": None,       # timestamp when fallback was entered
+    "recovery_attempts": 0,
+    "last_recovery_attempt": None,
+}
+_fallback_mode_lock = threading.RLock()
+_fallback_recovery_lock = threading.Lock()  # serializes pw.connect() calls from recovery thread
+
 # Cache for last known good responses (graceful degradation)
 _last_good_responses = {}
 _last_good_responses_lock = threading.RLock()
@@ -458,6 +488,112 @@ def update_connection_health(success=True):
                         log.warning(
                             f"Connection health degraded after {HEALTH_FAILURE_THRESHOLD} consecutive failures - entering graceful degradation mode"
                         )
+
+
+def enter_fallback_mode(reason="TEDAPI data unavailable"):
+    """Signal that proxy has entered SolarOnly fallback mode (distinct from is_degraded)."""
+    with _fallback_mode_lock:
+        if not _fallback_mode["is_fallback_mode"]:
+            _fallback_mode["is_fallback_mode"] = True
+            _fallback_mode["fallback_since"] = time.time()
+            _fallback_mode["recovery_attempts"] = 0
+            log.warning(
+                f"Proxy entering SolarOnly fallback mode: {reason}. "
+                "Background recovery will retry periodically."
+            )
+
+
+def exit_fallback_mode():
+    """Signal that proxy has recovered from SolarOnly fallback mode."""
+    with _fallback_mode_lock:
+        if _fallback_mode["is_fallback_mode"]:
+            duration = time.time() - (_fallback_mode["fallback_since"] or time.time())
+            attempts = _fallback_mode["recovery_attempts"]
+            _fallback_mode["is_fallback_mode"] = False
+            _fallback_mode["fallback_since"] = None
+            log.info(
+                f"Proxy recovered from SolarOnly fallback mode after "
+                f"{duration:.0f}s and {attempts} recovery attempt(s)."
+            )
+
+
+def _tedapi_probe_and_recover():
+    """
+    Background thread: probe TEDAPI health and recover from SolarOnly fallback.
+
+    Runs only when TEDAPI mode is active. Polls pw.version() every TEDAPI_PROBE_INTERVAL
+    seconds to detect SolarOnly entry. After TEDAPI_FALLBACK_THRESHOLD consecutive None
+    results, enters fallback mode and starts attempting reconnect via pw.connect(retry=False).
+    On successful recovery, exits fallback mode and resets exponential backoff.
+    Stays in SolarOnly if recovery fails — proxy keeps serving available data.
+    """
+    consecutive_failures = 0
+    recovery_interval = TEDAPI_RECOVERY_INITIAL_INTERVAL
+
+    while True:
+        try:
+            time.sleep(TEDAPI_PROBE_INTERVAL)
+
+            # Only probe when in TEDAPI mode
+            if not getattr(pw, 'tedapi', None):
+                consecutive_failures = 0
+                continue
+
+            with _fallback_mode_lock:
+                in_fallback = _fallback_mode["is_fallback_mode"]
+
+            if not in_fallback:
+                # Healthy path: probe TEDAPI
+                version = pw.version()  # direct call — don't want safe_pw_call health side-effects
+                if version is not None:
+                    consecutive_failures = 0
+                    recovery_interval = TEDAPI_RECOVERY_INITIAL_INTERVAL
+                else:
+                    consecutive_failures += 1
+                    if consecutive_failures >= TEDAPI_FALLBACK_THRESHOLD:
+                        enter_fallback_mode(
+                            f"TEDAPI returned no data for {consecutive_failures} consecutive probes"
+                        )
+            else:
+                # Fallback path: wait the backoff interval then attempt reconnect
+                extra_wait = recovery_interval - TEDAPI_PROBE_INTERVAL
+                if extra_wait > 0:
+                    time.sleep(extra_wait)
+
+                with _fallback_mode_lock:
+                    _fallback_mode["recovery_attempts"] += 1
+                    _fallback_mode["last_recovery_attempt"] = time.time()
+                    attempt_num = _fallback_mode["recovery_attempts"]
+
+                log.info(f"TEDAPI recovery attempt #{attempt_num} (interval={recovery_interval}s)...")
+
+                recovered = False
+                with _fallback_recovery_lock:
+                    try:
+                        if pw.connect(retry=False):
+                            # Verify data flows after reconnect
+                            version = pw.version()
+                            if version is not None:
+                                recovered = True
+                    except Exception as exc:
+                        log.warning(f"TEDAPI recovery attempt #{attempt_num} exception: {exc}")
+
+                if recovered:
+                    exit_fallback_mode()
+                    consecutive_failures = 0
+                    recovery_interval = TEDAPI_RECOVERY_INITIAL_INTERVAL
+                else:
+                    next_interval = min(recovery_interval * 2, TEDAPI_RECOVERY_MAX_INTERVAL)
+                    log.warning(
+                        f"TEDAPI recovery attempt #{attempt_num} failed — "
+                        f"staying in SolarOnly, next retry in {next_interval}s"
+                    )
+                    recovery_interval = next_interval
+
+        except (KeyboardInterrupt, SystemExit):
+            break
+        except Exception as exc:
+            log.debug(f"TEDAPI probe/recovery thread unexpected error: {exc}")
 
 
 def get_cached_response(endpoint):
@@ -955,6 +1091,18 @@ if control_secret:
     else:
         log.error("Control Mode Failed: Unable to connect to cloud - Run Setup")
         control_secret = None
+
+
+# Start background TEDAPI probe/recovery thread (TEDAPI modes only)
+if tedapi_recovery_enabled and pw.tedapi:
+    _recovery_thread = threading.Thread(
+        target=_tedapi_probe_and_recover, name="tedapi-recovery", daemon=True
+    )
+    _recovery_thread.start()
+    log.info(
+        "TEDAPI probe/recovery thread started (interval=%ds, threshold=%d)",
+        TEDAPI_PROBE_INTERVAL, TEDAPI_FALLBACK_THRESHOLD
+    )
 
 
 def get_transport_health():
@@ -1481,6 +1629,16 @@ class Handler(BaseHTTPRequestHandler):
                             else 0,
                         }
 
+                # Add SolarOnly fallback mode state
+                with _fallback_mode_lock:
+                    proxystats["fallback_mode"] = {
+                        "is_fallback_mode": _fallback_mode["is_fallback_mode"],
+                        "fallback_since": _fallback_mode["fallback_since"],
+                        "recovery_attempts": _fallback_mode["recovery_attempts"],
+                        "last_recovery_attempt": _fallback_mode["last_recovery_attempt"],
+                        "recovery_enabled": tedapi_recovery_enabled,
+                    }
+
                 # Add cache memory usage statistics
                 proxystats["mem_cache"] = {}
 
@@ -1591,6 +1749,21 @@ class Handler(BaseHTTPRequestHandler):
                         - _connection_health["last_success_time"],
                     }
 
+            # SolarOnly fallback mode state (separate from connection_health degradation)
+            with _fallback_mode_lock:
+                fm = dict(_fallback_mode)
+            health_info["fallback_mode"] = {
+                "is_fallback_mode": fm["is_fallback_mode"],
+                "fallback_since": fm["fallback_since"],
+                "fallback_duration_seconds": (
+                    round(time.time() - fm["fallback_since"], 1)
+                    if fm["fallback_since"] else None
+                ),
+                "recovery_attempts": fm["recovery_attempts"],
+                "last_recovery_attempt": fm["last_recovery_attempt"],
+                "recovery_enabled": tedapi_recovery_enabled,
+            }
+
             if graceful_degradation:
                 with _last_good_responses_lock:
                     cached_endpoints = {}
@@ -1649,6 +1822,13 @@ class Handler(BaseHTTPRequestHandler):
                     _connection_health["total_successes"] = 0
                     _connection_health["is_degraded"] = False
                     _connection_health["last_success_time"] = time.time()
+
+            # Reset SolarOnly fallback mode state
+            with _fallback_mode_lock:
+                _fallback_mode["is_fallback_mode"] = False
+                _fallback_mode["fallback_since"] = None
+                _fallback_mode["recovery_attempts"] = 0
+                _fallback_mode["last_recovery_attempt"] = None
 
             if graceful_degradation:
                 with _last_good_responses_lock:

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -532,6 +532,22 @@ def _tedapi_probe_and_recover():
     results, enters fallback mode and starts attempting reconnect via pw.connect(retry=False).
     On successful recovery, exits fallback mode and resets exponential backoff.
     Stays in SolarOnly if recovery fails — proxy keeps serving available data.
+
+    Runtime-reconnect trade-off: pw.connect() swaps pw.client and transiently mutates
+    pw.mode/cloudmode/fleetapi while handler threads may be live. In practice this is
+    bounded — requests were already failing when recovery fires, the attribute swap is
+    atomic, and worst case a few in-flight requests hit a transient wrong-mode branch.
+
+    Hybrid-mode note: the gate is pw.tedapi, which includes hybrid mode (v1r + WiFi
+    fallback). In that topology pw.version() is served by the local API, so a WiFi
+    TEDAPI outage may not be detected by this probe. Monitoring is best-effort for
+    hybrid; pure TEDAPI mode (WiFi-only or v1r-only) gets full coverage.
+
+    429-cooldown interaction: during a gateway rate-limit cooldown (~5 min), pw.version()
+    returns None, which drives the probe into fallback mode and triggers reconnect
+    attempts. The 60→300s backoff bounds reconnect to roughly one attempt per cooldown
+    window, which is tolerable but does cut slightly against the "don't hammer a
+    rate-limited gateway" convention. A cooldown-aware probe is a follow-up item.
     """
     consecutive_failures = 0
     recovery_interval = TEDAPI_RECOVERY_INITIAL_INTERVAL
@@ -570,7 +586,12 @@ def _tedapi_probe_and_recover():
                 if extra_wait > 0:
                     time.sleep(extra_wait)
 
+                # Re-check after the long backoff sleep: /health/reset may have cleared state.
                 with _fallback_mode_lock:
+                    if not _fallback_mode["is_fallback_mode"]:
+                        consecutive_failures = 0
+                        recovery_interval = TEDAPI_RECOVERY_INITIAL_INTERVAL
+                        continue
                     _fallback_mode["recovery_attempts"] += 1
                     _fallback_mode["last_recovery_attempt"] = time.time()
                     attempt_num = _fallback_mode["recovery_attempts"]

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -235,7 +235,10 @@ degradation_cache_ttl_seconds = int(
 tedapi_recovery_enabled = (
     os.getenv("PW_TEDAPI_RECOVERY", "yes").lower() == "yes"
 )  # Auto-recover TEDAPI connection when proxy falls back to SolarOnly mode
-TEDAPI_PROBE_INTERVAL = int(os.getenv("PW_TEDAPI_PROBE_INTERVAL", "30"))  # seconds between probes
+try:
+    TEDAPI_PROBE_INTERVAL = max(5, int(os.getenv("PW_TEDAPI_PROBE_INTERVAL", "30")))
+except (ValueError, TypeError):
+    TEDAPI_PROBE_INTERVAL = 30  # seconds between probes; default if env var is non-integer
 TEDAPI_FALLBACK_THRESHOLD = 3  # consecutive probe failures before entering fallback mode
 TEDAPI_RECOVERY_INITIAL_INTERVAL = 60   # initial recovery retry interval (seconds)
 TEDAPI_RECOVERY_MAX_INTERVAL = 300      # cap on retry interval (seconds)
@@ -497,6 +500,7 @@ def enter_fallback_mode(reason="TEDAPI data unavailable"):
             _fallback_mode["is_fallback_mode"] = True
             _fallback_mode["fallback_since"] = time.time()
             _fallback_mode["recovery_attempts"] = 0
+            _fallback_mode["last_recovery_attempt"] = None
             log.warning(
                 f"Proxy entering SolarOnly fallback mode: {reason}. "
                 "Background recovery will retry periodically."
@@ -511,6 +515,8 @@ def exit_fallback_mode():
             attempts = _fallback_mode["recovery_attempts"]
             _fallback_mode["is_fallback_mode"] = False
             _fallback_mode["fallback_since"] = None
+            _fallback_mode["recovery_attempts"] = 0
+            _fallback_mode["last_recovery_attempt"] = None
             log.info(
                 f"Proxy recovered from SolarOnly fallback mode after "
                 f"{duration:.0f}s and {attempts} recovery attempt(s)."
@@ -543,8 +549,12 @@ def _tedapi_probe_and_recover():
                 in_fallback = _fallback_mode["is_fallback_mode"]
 
             if not in_fallback:
-                # Healthy path: probe TEDAPI
-                version = pw.version()  # direct call — don't want safe_pw_call health side-effects
+                # Healthy path: probe TEDAPI (treat exceptions as probe failures)
+                try:
+                    version = pw.version()  # direct call — don't want safe_pw_call health side-effects
+                except Exception as probe_exc:
+                    log.debug(f"TEDAPI probe exception (counts as failure): {probe_exc}")
+                    version = None
                 if version is not None:
                     consecutive_failures = 0
                     recovery_interval = TEDAPI_RECOVERY_INITIAL_INTERVAL
@@ -1631,13 +1641,18 @@ class Handler(BaseHTTPRequestHandler):
 
                 # Add SolarOnly fallback mode state
                 with _fallback_mode_lock:
-                    proxystats["fallback_mode"] = {
-                        "is_fallback_mode": _fallback_mode["is_fallback_mode"],
-                        "fallback_since": _fallback_mode["fallback_since"],
-                        "recovery_attempts": _fallback_mode["recovery_attempts"],
-                        "last_recovery_attempt": _fallback_mode["last_recovery_attempt"],
-                        "recovery_enabled": tedapi_recovery_enabled,
-                    }
+                    fm_snap = dict(_fallback_mode)
+                proxystats["fallback_mode"] = {
+                    "is_fallback_mode": fm_snap["is_fallback_mode"],
+                    "fallback_since": fm_snap["fallback_since"],
+                    "fallback_duration_seconds": (
+                        round(time.time() - fm_snap["fallback_since"], 1)
+                        if fm_snap["fallback_since"] else None
+                    ),
+                    "recovery_attempts": fm_snap["recovery_attempts"],
+                    "last_recovery_attempt": fm_snap["last_recovery_attempt"],
+                    "recovery_enabled": tedapi_recovery_enabled,
+                }
 
                 # Add cache memory usage statistics
                 proxystats["mem_cache"] = {}

--- a/proxy/tests/test_fallback_mode.py
+++ b/proxy/tests/test_fallback_mode.py
@@ -1,0 +1,334 @@
+"""Tests for SolarOnly fallback mode tracking and auto-recovery (PR #361).
+
+Covers:
+- enter_fallback_mode() / exit_fallback_mode() lifecycle
+- /health fallback_mode payload (in/out of fallback)
+- /stats fallback_mode payload (in/out of fallback)
+- /health/reset clears fallback state
+- PW_TEDAPI_PROBE_INTERVAL env var parsing (non-integer → 30, < 5 → clamped to 5)
+"""
+import json
+import os
+import time
+import unittest
+from http import HTTPStatus
+from unittest.mock import Mock, patch
+
+import proxy.server as server
+from proxy.server import (
+    _fallback_mode,
+    _fallback_mode_lock,
+    enter_fallback_mode,
+    exit_fallback_mode,
+)
+from proxy.tests.test_csv_endpoints import BaseDoGetTest, standard_test_patches
+
+
+def _reset_fallback_state():
+    """Reset _fallback_mode to its initial (non-fallback) state."""
+    with _fallback_mode_lock:
+        _fallback_mode["is_fallback_mode"] = False
+        _fallback_mode["fallback_since"] = None
+        _fallback_mode["recovery_attempts"] = 0
+        _fallback_mode["last_recovery_attempt"] = None
+
+
+class TestFallbackModeLifecycle(unittest.TestCase):
+    """enter_fallback_mode() / exit_fallback_mode() contract tests."""
+
+    def setUp(self):
+        _reset_fallback_state()
+
+    def tearDown(self):
+        _reset_fallback_state()
+
+    def test_enter_sets_state(self):
+        """enter_fallback_mode() sets is_fallback_mode, records fallback_since, zeroes counters."""
+        before = time.time()
+        enter_fallback_mode("test reason")
+
+        with _fallback_mode_lock:
+            self.assertTrue(_fallback_mode["is_fallback_mode"])
+            self.assertIsNotNone(_fallback_mode["fallback_since"])
+            self.assertGreaterEqual(_fallback_mode["fallback_since"], before)
+            self.assertEqual(_fallback_mode["recovery_attempts"], 0)
+            self.assertIsNone(_fallback_mode["last_recovery_attempt"])
+
+    def test_enter_is_idempotent(self):
+        """Double enter_fallback_mode() is a no-op — fallback_since is not reset on second call."""
+        enter_fallback_mode("first")
+        with _fallback_mode_lock:
+            first_since = _fallback_mode["fallback_since"]
+
+        time.sleep(0.02)
+        enter_fallback_mode("second")  # should not overwrite fallback_since
+
+        with _fallback_mode_lock:
+            self.assertEqual(_fallback_mode["fallback_since"], first_since)
+
+    def test_enter_resets_recovery_attempts_to_zero(self):
+        """recovery_attempts is reset to zero on enter even if non-zero before."""
+        # Simulate a previous partial state (shouldn't happen normally, but guard it anyway)
+        with _fallback_mode_lock:
+            _fallback_mode["recovery_attempts"] = 99
+
+        enter_fallback_mode("reset check")
+
+        with _fallback_mode_lock:
+            self.assertEqual(_fallback_mode["recovery_attempts"], 0)
+
+    def test_exit_clears_all_fields(self):
+        """exit_fallback_mode() clears is_fallback_mode, fallback_since, recovery_attempts, last_recovery_attempt."""
+        enter_fallback_mode("test")
+        with _fallback_mode_lock:
+            _fallback_mode["recovery_attempts"] = 5
+            _fallback_mode["last_recovery_attempt"] = time.time()
+
+        exit_fallback_mode()
+
+        with _fallback_mode_lock:
+            self.assertFalse(_fallback_mode["is_fallback_mode"])
+            self.assertIsNone(_fallback_mode["fallback_since"])
+            self.assertEqual(_fallback_mode["recovery_attempts"], 0)
+            self.assertIsNone(_fallback_mode["last_recovery_attempt"])
+
+    def test_exit_is_idempotent(self):
+        """Double exit_fallback_mode() is a no-op — no error when called outside fallback."""
+        # Call from non-fallback state — must not raise
+        exit_fallback_mode()
+
+        with _fallback_mode_lock:
+            self.assertFalse(_fallback_mode["is_fallback_mode"])
+
+    def test_full_lifecycle(self):
+        """Full enter → accumulate attempts → exit cycle resets everything."""
+        enter_fallback_mode("probe timeout")
+        with _fallback_mode_lock:
+            _fallback_mode["recovery_attempts"] = 3
+            _fallback_mode["last_recovery_attempt"] = time.time()
+
+        exit_fallback_mode()
+
+        with _fallback_mode_lock:
+            self.assertFalse(_fallback_mode["is_fallback_mode"])
+            self.assertEqual(_fallback_mode["recovery_attempts"], 0)
+            self.assertIsNone(_fallback_mode["last_recovery_attempt"])
+
+
+class TestHealthEndpointFallbackMode(BaseDoGetTest):
+    """/health endpoint includes correct fallback_mode payload."""
+
+    def setUp(self):
+        super().setUp()
+        _reset_fallback_state()
+
+    def tearDown(self):
+        super().tearDown()
+        _reset_fallback_state()
+
+    def _do_health(self):
+        """Hit /health with minimal patches required for the endpoint to render."""
+        with standard_test_patches(), \
+             patch('proxy.server.pw') as mock_pw, \
+             patch('proxy.server.health_check_enabled', False), \
+             patch('proxy.server.graceful_degradation', False), \
+             patch('proxy.server.get_transport_health', return_value={}), \
+             patch('proxy.server._endpoint_stats', {}), \
+             patch('proxy.server._endpoint_stats_lock'), \
+             patch('proxy.server.time') as mock_time:
+            mock_time.time.return_value = 2000.0
+            mock_pw.tedapi = None
+            self.handler.path = "/health"
+            self.handler.do_GET()
+
+    def test_health_not_in_fallback(self):
+        """/health fallback_mode is_fallback_mode=False when proxy is healthy."""
+        self._do_health()
+
+        self.handler.send_response.assert_called_with(HTTPStatus.OK)
+        data = self.get_written_json()
+
+        self.assertIn("fallback_mode", data)
+        fm = data["fallback_mode"]
+        self.assertFalse(fm["is_fallback_mode"])
+        self.assertIsNone(fm["fallback_since"])
+        self.assertIsNone(fm["fallback_duration_seconds"])
+        self.assertEqual(fm["recovery_attempts"], 0)
+
+    def test_health_in_fallback(self):
+        """/health fallback_mode reflects active fallback state."""
+        enter_fallback_mode("test probe failure")
+        # Align fallback_since with the mocked time.time() = 2000.0 used in _do_health()
+        # so that fallback_duration_seconds = round(2000.0 - 1900.0, 1) = 100.0
+        with _fallback_mode_lock:
+            _fallback_mode["fallback_since"] = 1900.0
+            _fallback_mode["recovery_attempts"] = 2
+
+        self._do_health()
+
+        data = self.get_written_json()
+        fm = data["fallback_mode"]
+
+        self.assertTrue(fm["is_fallback_mode"])
+        self.assertIsNotNone(fm["fallback_since"])
+        self.assertIsNotNone(fm["fallback_duration_seconds"])
+        self.assertGreaterEqual(fm["fallback_duration_seconds"], 0)
+        self.assertEqual(fm["recovery_attempts"], 2)
+
+
+class TestHealthResetClearsFallback(BaseDoGetTest):
+    """/health/reset clears fallback state."""
+
+    def setUp(self):
+        super().setUp()
+        _reset_fallback_state()
+
+    def tearDown(self):
+        super().tearDown()
+        _reset_fallback_state()
+
+    def test_health_reset_clears_fallback(self):
+        """/health/reset resets is_fallback_mode and all associated fields."""
+        enter_fallback_mode("before reset")
+        with _fallback_mode_lock:
+            _fallback_mode["recovery_attempts"] = 3
+            _fallback_mode["last_recovery_attempt"] = time.time()
+
+        with standard_test_patches(), \
+             patch('proxy.server.health_check_enabled', False), \
+             patch('proxy.server.graceful_degradation', False), \
+             patch('proxy.server._endpoint_stats', {}), \
+             patch('proxy.server._endpoint_stats_lock'), \
+             patch('proxy.server.time') as mock_time:
+            mock_time.time.return_value = 3000.0
+            self.handler.path = "/health/reset"
+            self.handler.do_GET()
+
+        self.handler.send_response.assert_called_with(HTTPStatus.OK)
+
+        with _fallback_mode_lock:
+            self.assertFalse(_fallback_mode["is_fallback_mode"])
+            self.assertIsNone(_fallback_mode["fallback_since"])
+            self.assertEqual(_fallback_mode["recovery_attempts"], 0)
+            self.assertIsNone(_fallback_mode["last_recovery_attempt"])
+
+    def test_health_reset_idempotent_when_not_in_fallback(self):
+        """/health/reset does not error when proxy is not in fallback mode."""
+        with standard_test_patches(), \
+             patch('proxy.server.health_check_enabled', False), \
+             patch('proxy.server.graceful_degradation', False), \
+             patch('proxy.server._endpoint_stats', {}), \
+             patch('proxy.server._endpoint_stats_lock'), \
+             patch('proxy.server.time') as mock_time:
+            mock_time.time.return_value = 3000.0
+            self.handler.path = "/health/reset"
+            self.handler.do_GET()
+
+        self.handler.send_response.assert_called_with(HTTPStatus.OK)
+
+        with _fallback_mode_lock:
+            self.assertFalse(_fallback_mode["is_fallback_mode"])
+
+
+class TestStatsEndpointFallbackMode(BaseDoGetTest):
+    """/stats includes correct fallback_mode payload."""
+
+    def setUp(self):
+        super().setUp()
+        _reset_fallback_state()
+
+    def tearDown(self):
+        super().tearDown()
+        _reset_fallback_state()
+
+    def _do_stats(self):
+        with standard_test_patches(), \
+             patch('proxy.server.pw') as mock_pw, \
+             patch('proxy.server.health_check_enabled', False), \
+             patch('proxy.server.graceful_degradation', False), \
+             patch('proxy.server.safe_pw_call', return_value="Test Site"), \
+             patch('proxy.server.resource') as mock_resource, \
+             patch('proxy.server.time') as mock_time, \
+             patch('proxy.server._endpoint_stats', {}), \
+             patch('proxy.server._endpoint_stats_lock'), \
+             patch('proxy.server._error_counts', {}), \
+             patch('proxy.server._error_counts_lock'):
+            mock_time.time.return_value = 2000.0
+            mock_resource.getrusage.return_value = Mock(ru_maxrss=1024)
+            mock_pw.cloudmode = False
+            mock_pw.fleetapi = False
+            self.handler.path = "/stats"
+            self.handler.do_GET()
+
+    def test_stats_fallback_mode_not_active(self):
+        """/stats includes fallback_mode with is_fallback_mode=False when healthy."""
+        self._do_stats()
+
+        data = self.get_written_json()
+        self.assertIn("fallback_mode", data)
+        fm = data["fallback_mode"]
+        self.assertFalse(fm["is_fallback_mode"])
+        self.assertIsNone(fm["fallback_duration_seconds"])
+
+    def test_stats_fallback_mode_active(self):
+        """/stats fallback_mode reflects active fallback including duration and attempt count."""
+        enter_fallback_mode("probe timeout")
+        # Align fallback_since with the mocked time.time() = 2000.0 in _do_stats()
+        with _fallback_mode_lock:
+            _fallback_mode["fallback_since"] = 1900.0
+            _fallback_mode["recovery_attempts"] = 1
+
+        self._do_stats()
+
+        data = self.get_written_json()
+        fm = data["fallback_mode"]
+
+        self.assertTrue(fm["is_fallback_mode"])
+        self.assertIsNotNone(fm["fallback_since"])
+        self.assertIsNotNone(fm["fallback_duration_seconds"])
+        self.assertGreaterEqual(fm["fallback_duration_seconds"], 0)
+        self.assertEqual(fm["recovery_attempts"], 1)
+
+
+class TestProbeIntervalEnvParsing(unittest.TestCase):
+    """PW_TEDAPI_PROBE_INTERVAL env var parsing — non-integer → 30, < 5 → clamp to 5."""
+
+    @staticmethod
+    def _parse(raw):
+        """Replicate the module-level parsing expression."""
+        try:
+            return max(5, int(raw))
+        except (ValueError, TypeError):
+            return 30
+
+    def test_default_is_30(self):
+        self.assertEqual(self._parse("30"), 30)
+
+    def test_valid_integer_used(self):
+        self.assertEqual(self._parse("60"), 60)
+
+    def test_non_integer_string_falls_back_to_30(self):
+        self.assertEqual(self._parse("bad_value"), 30)
+
+    def test_empty_string_falls_back_to_30(self):
+        self.assertEqual(self._parse(""), 30)
+
+    def test_none_falls_back_to_30(self):
+        """None (env var missing) raises TypeError → falls back to 30."""
+        self.assertEqual(self._parse(None), 30)
+
+    def test_value_below_5_clamped_to_5(self):
+        self.assertEqual(self._parse("2"), 5)
+        self.assertEqual(self._parse("1"), 5)
+        self.assertEqual(self._parse("0"), 5)
+
+    def test_exactly_5_accepted(self):
+        self.assertEqual(self._parse("5"), 5)
+
+    def test_module_constant_is_at_least_5(self):
+        """TEDAPI_PROBE_INTERVAL loaded by the running process must respect the clamp."""
+        self.assertGreaterEqual(server.TEDAPI_PROBE_INTERVAL, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements TEDAPI SolarOnly fallback mode tracking and auto-recovery, addressing the failure mode documented in #360 and [Powerwall-Dashboard#821](https://github.com/jasonacox/Powerwall-Dashboard/issues/821).

### The Problem

When TEDAPI drops mid-session (e.g. a gateway 403 after a firmware update, or a route loss), the proxy entered SolarOnly mode silently and stayed there until restarted. There was no way to distinguish "transient network blip" from "TEDAPI has fallen back and needs recovery work."

### What This Adds

**Distinct fallback mode state** — `is_fallback_mode` is tracked separately from `is_degraded`. They model two different things:
- `is_degraded` = transient transport failures (timeouts, connection resets)
- `is_fallback_mode` = TEDAPI has fallen back to SolarOnly and needs explicit recovery

**Background probe/recovery thread** (`tedapi-recovery`):
- Probes `pw.version()` every `PW_TEDAPI_PROBE_INTERVAL` seconds (default 30s)
- After `TEDAPI_FALLBACK_THRESHOLD` (3) consecutive None results → enters `is_fallback_mode`, logs a warning
- Calls `pw.connect(retry=False)` to attempt reconnect, with exponential backoff (60s → max 300s)
- On success: logs recovery, clears `is_fallback_mode`, resets backoff
- On failure: logs the attempt, stays in SolarOnly, keeps serving available data — **no restart, no data gap**

**Health surface** — `/health` and `/stats` now include `"fallback_mode"`:
```json
"fallback_mode": {
  "is_fallback_mode": false,
  "fallback_since": null,
  "fallback_duration_seconds": null,
  "recovery_attempts": 0,
  "last_recovery_attempt": null,
  "recovery_enabled": true
}
```

**New environment variables:**
| Variable | Default | Description |
|---|---|---|
| `PW_TEDAPI_RECOVERY` | `yes` | Enable/disable auto-recovery |
| `PW_TEDAPI_PROBE_INTERVAL` | `30` | Seconds between health probes |

Only active in TEDAPI modes. No overhead for Cloud, FleetAPI, or local-only.

**Proxy build:** t96 → t97

## Changes

- `proxy/server.py` — `_fallback_mode` state, `enter_fallback_mode()`, `exit_fallback_mode()`, `_tedapi_probe_and_recover()` thread, `/health` + `/stats` exposure, `/health/reset` reset, env var config, BUILD bump
- `proxy/RELEASE.md` — t97 release notes

## Test plan

- [ ] Start proxy in TEDAPI mode — confirm `tedapi-recovery` thread starts and logs
- [ ] Disable the TEDAPI route mid-session (e.g. `ip route del`) — confirm proxy logs SolarOnly fallback after 3 probe failures (~90s)
- [ ] Re-enable the route — confirm proxy logs recovery and `is_fallback_mode` clears
- [ ] Check `/health` shows `fallback_mode.is_fallback_mode: false` normally, `true` during fallback
- [ ] Confirm `PW_TEDAPI_RECOVERY=no` disables the thread entirely (non-TEDAPI modes unaffected)

Closes #360

— Sam ⚡