### PR TITLE
fix(tedapi): Correct Content-type typo, octet-string -> octet-stream

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## Unreleased
+
+* fix(tedapi): correct Content-type request header typo `application/octet-string` → `application/octet-stream` (RFC 2046); gateway does not validate the header (#364)
+
 ## v0.16.2 - TEDAPI Fallback, v1r Diagnostics, and Firmware Version Improvements
 
 * feat(proxy): TEDAPI SolarOnly fallback mode — when TEDAPI connectivity is lost, the proxy automatically continues serving solar data without interruption. Enabled via `PW_TEDAPI_RECOVERY=yes`. (#361)

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -1269,7 +1269,7 @@ class TEDAPI:
             session.headers.update({'Connection': 'close'})  # This disables keep-alive
         session.verify = False
         session.auth = ('Tesla_Energy_Device', self.gw_pwd)
-        session.headers.update({'Content-type': 'application/octet-string'})
+        session.headers.update({'Content-type': 'application/octet-stream'})
         return session
 
     def _init_wifi_session(self, gw_pwd: str):
@@ -1288,7 +1288,7 @@ class TEDAPI:
             session.headers.update({'Connection': 'close'})
         session.verify = False
         session.auth = ('Tesla_Energy_Device', gw_pwd)
-        session.headers.update({'Content-type': 'application/octet-string'})
+        session.headers.update({'Content-type': 'application/octet-stream'})
         self.wifi_session = session
         log.debug(f"WiFi fallback session initialized for {self.wifi_host}")
 

--- a/tools/tedapi/ComponentsQuery.py
+++ b/tools/tedapi/ComponentsQuery.py
@@ -58,7 +58,7 @@ pb.message.config.send.file = "config.json"
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 #print(f"Response Code: {r.status_code}")
 # Decode response
@@ -90,7 +90,7 @@ pb.message.firmware.request = ""
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 print(f"Response Code: {r.status_code}")
 # write raw response to file
@@ -118,7 +118,7 @@ pb.message.payload.send.b.value = "{\"pwsComponentsFilter\":{\"types\":[\"PW3SAF
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 print(f"Response Code: {r.status_code}")
 # Decode response
@@ -155,7 +155,7 @@ for battery in battery_blocks:
     pb.tail.value = 1
     url = f'https://{GW_IP}/tedapi/v1'
     r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-        headers={'Content-type': 'application/octet-string'},
+        headers={'Content-type': 'application/octet-stream'},
         data=pb.SerializeToString(), timeout=5)
     print(f"Response Code: {r.status_code}")
     if r.status_code == 200:

--- a/tools/tedapi/PW3_Strings.py
+++ b/tools/tedapi/PW3_Strings.py
@@ -58,7 +58,7 @@ pb.message.config.send.file = "config.json"
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 #print(f"Response Code: {r.status_code}")
 # Decode response
@@ -90,7 +90,7 @@ pb.message.firmware.request = ""
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 print(f"Response Code: {r.status_code}")
 # write raw response to file
@@ -118,7 +118,7 @@ pb.message.payload.send.b.value = "{\"pwsComponentsFilter\":{\"types\":[\"PW3SAF
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 print(f"Response Code: {r.status_code}")
 # Decode response
@@ -165,7 +165,7 @@ for battery in battery_blocks:
     pb.tail.value = 1
     url = f'https://{GW_IP}/tedapi/v1'
     r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-        headers={'Content-type': 'application/octet-string'},
+        headers={'Content-type': 'application/octet-stream'},
         data=pb.SerializeToString(), timeout=5)
     if r.status_code == 200:
         # Decode response

--- a/tools/tedapi/PW3_Vitals.py
+++ b/tools/tedapi/PW3_Vitals.py
@@ -59,7 +59,7 @@ pb.message.config.send.file = "config.json"
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 #print(f"Response Code: {r.status_code}")
 # Decode response
@@ -91,7 +91,7 @@ pb.message.firmware.request = ""
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 print(f"Response Code: {r.status_code}")
 # write raw response to file
@@ -119,7 +119,7 @@ pb.message.payload.send.b.value = "{\"pwsComponentsFilter\":{\"types\":[\"PW3SAF
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 print(f"Response Code: {r.status_code}")
 # Decode response
@@ -192,7 +192,7 @@ def get_pw3_vitals(components=None, config=None, din=None, gw_pwd=None):
         pb.tail.value = 1
         url = f'https://{GW_IP}/tedapi/v1'
         r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-                        headers={'Content-type': 'application/octet-string'},
+                        headers={'Content-type': 'application/octet-stream'},
                         data=pb.SerializeToString(), timeout=10)
         if r.status_code == 200:
             # Decode response

--- a/tools/tedapi/README.md
+++ b/tools/tedapi/README.md
@@ -149,7 +149,7 @@ This appears to be the workhorse function. It uses basic auth that appears to be
 python create_request.py
 
 # Request config
-curl -v -k -H 'Content-type: application/octet-string' -u "Tesla_Energy_Device:GW_PWD" --data-binary @request.bin https://192.168.91.1/tedapi/v1
+curl -v -k -H 'Content-type: application/octet-stream' -u "Tesla_Energy_Device:GW_PWD" --data-binary @request.bin https://192.168.91.1/tedapi/v1
 ```
 
 Payloads are binary Protocol Buffers (protobufs). 
@@ -166,7 +166,7 @@ There appear to be different types of request sent. One is for `config` which ge
 python create_request.py
 
 # Request Config Data from Powerwall
-curl -v -k -H 'Content-type: application/octet-string' -u "Tesla_Energy_Device:GW_PWD" --data-binary @request.bin https://192.168.91.1/tedapi/v1 > response.bin
+curl -v -k -H 'Content-type: application/octet-stream' -u "Tesla_Energy_Device:GW_PWD" --data-binary @request.bin https://192.168.91.1/tedapi/v1 > response.bin
 
 # Decode Config Data
 python3 decode.py response.bin
@@ -225,7 +225,7 @@ tail {
 
 ```bash
 # Request Status Data from Powerwall
-curl -v -k -H 'Content-type: application/octet-string' -u "Tesla_Energy_Device:GW_PWD" --data-binary @query.bin https://192.168.91.1/tedapi/v1 > response.bin
+curl -v -k -H 'Content-type: application/octet-stream' -u "Tesla_Energy_Device:GW_PWD" --data-binary @query.bin https://192.168.91.1/tedapi/v1 > response.bin
 
 # Decode Config Data
 python3 decode.py response.bin

--- a/tools/tedapi/create_request.py
+++ b/tools/tedapi/create_request.py
@@ -17,7 +17,7 @@ Usage:
     # Follow prompts for DIN and output file name
 
 Example:
-   curl -v -k -H 'Content-type: application/octet-string' -u "Tesla_Energy_Device:GW_PWD" --data-binary @request.bin https://192.168.91.1/tedapi/v1
+   curl -v -k -H 'Content-type: application/octet-stream' -u "Tesla_Energy_Device:GW_PWD" --data-binary @request.bin https://192.168.91.1/tedapi/v1
 
 """
 

--- a/tools/tedapi/status.py
+++ b/tools/tedapi/status.py
@@ -62,7 +62,7 @@ pb.message.config.send.file = "config.json"
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 #print(f"Response Code: {r.status_code}")
 # Decode response
@@ -91,7 +91,7 @@ pb.message.payload.send.b.value = "{\"pwsComponentsFilter\":{\"types\":[\"PW3SAF
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 print(f"Response Code: {r.status_code}")
 # Decode response
@@ -123,7 +123,7 @@ pb.message.payload.send.b.value = "{}"
 pb.tail.value = 1
 url = f'https://{GW_IP}/tedapi/v1'
 r = requests.post(url, auth=('Tesla_Energy_Device', gw_pwd), verify=False,
-    headers={'Content-type': 'application/octet-string'},
+    headers={'Content-type': 'application/octet-stream'},
     data=pb.SerializeToString(), timeout=5)
 # print(f"Response Code: {r.status_code}")
 # Decode response

--- a/tools/tedapi/tedapi_orig.py
+++ b/tools/tedapi/tedapi_orig.py
@@ -168,7 +168,7 @@ class TEDAPI:
         pb.tail.value = 1
         url = f'https://{GW_IP}/tedapi/v1'
         r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
-            headers={'Content-type': 'application/octet-string'},
+            headers={'Content-type': 'application/octet-stream'},
             data=pb.SerializeToString())
         log.debug(f"Response Code: {r.status_code}")
         if r.status_code in BUSY_CODES:
@@ -259,7 +259,7 @@ class TEDAPI:
         pb.tail.value = 1
         url = f'https://{GW_IP}/tedapi/v1'
         r = requests.post(url, auth=('Tesla_Energy_Device', self.gw_pwd), verify=False,
-            headers={'Content-type': 'application/octet-string'},
+            headers={'Content-type': 'application/octet-stream'},
             data=pb.SerializeToString())
         log.debug(f"Response Code: {r.status_code}")
         if r.status_code in BUSY_CODES:


### PR DESCRIPTION
# Summary

`application/octet-string` is not a media type. The binary-payload type is `application/octet-stream` (RFC 2046); the TEDAPI request headers have carried the typo since the endpoint was first added.

Replaces all 23 occurrences across the library, the tools/tedapi scripts, and their documented curl examples.

This is a correctness and consistency fix rather than a behavior change: the gateway evidently does not validate the header — the bogus value has been accepted for years without issue. Fixing the typo means the documented curl commands can be pasted somewhere stricter without mystifying failures, and the repo is no longer inconsistent with itself.

No functional change intended; no test asserted on the old value.

**Hardware validation (PW3, fw 26.18.3):** All TEDAPI calls (`get_config`, `get_status`, `vitals`, `get_firmware_version`) return identical payloads with the corrected header across both the primary WiFi path and the v1r WiFi fallback path. See [test results](https://github.com/jasonacox/pypowerwall/pull/364#issuecomment-5153220265).

Note: This is also a "parted out" change from https://github.com/jasonacox/pypowerwall/pull/359

# Supposition

How was this introduced? The likely confusion is real and understandable: OCTET STRING is a genuine ASN.1 universal type (tag 4, used throughout X.509/DER). Someone deep in binary-protocol work reaches for "octet string" from that vocabulary while writing an HTTP header. Fittingly, the Tesla bundle contains ASN.1 code with exactly that terminology — "Multi-octet tag encoding unsupported", tagClassByName["universal"] — so both words live in this problem space.