### PR TITLE
fix: TEDAPI auto-recovery wedge after fully-failed reconnect (#366)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # RELEASE NOTES
 
-## Unreleased
+## v0.16.4 - TEDAPI Auto-Recovery Wedge Fix
 
 * fix: `Powerwall.connect()` now restores `tedapi`/`tedapi_mode` along with `mode`/`cloudmode`/`fleetapi` when all connection modes fail. Previously a fully-failed `connect(retry=False)` left `tedapi=False` behind (the local-mode fallback handler zeroes it), which permanently wedged the proxy's TEDAPI auto-recovery thread — its `pw.tedapi` gate short-circuited every iteration, so no further recovery attempt was ever made until restart. (#366)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## Unreleased
+
+* fix: `Powerwall.connect()` now restores `tedapi`/`tedapi_mode` along with `mode`/`cloudmode`/`fleetapi` when all connection modes fail. Previously a fully-failed `connect(retry=False)` left `tedapi=False` behind (the local-mode fallback handler zeroes it), which permanently wedged the proxy's TEDAPI auto-recovery thread — its `pw.tedapi` gate short-circuited every iteration, so no further recovery attempt was ever made until restart. (#366)
+
 ## v0.16.3 - TEDAPI API Version Ordering and Content-Type Fix
 
 * feat(tedapi): `TEDAPIApiVersion` members are now ordered by the date their label encodes; comparing against anything that is not a known version now raises `TypeError` (previously fell back to silent lexical string comparison). (#363)

--- a/proxy/RELEASE.md
+++ b/proxy/RELEASE.md
@@ -1,5 +1,11 @@
 ## pyPowerwall Proxy Release Notes
 
+### Proxy t98 (8 Aug 2026)
+
+* Fixed TEDAPI auto-recovery sometimes stopping after a failed attempt, leaving the proxy wedged in SolarOnly fallback until restart (issue [#366](https://github.com/jasonacox/pypowerwall/issues/366))
+* Root cause was in the library: a fully-failed `pw.connect(retry=False)` left `pw.tedapi=False` behind, and the recovery loop's `pw.tedapi` gate then short-circuited every iteration — no further attempt, no log line at any level, `last_recovery_attempt` frozen at attempt #1. Fixed in `Powerwall.connect()` (tedapi state is now part of the snapshot/restore) and hardened in the proxy: the gate no longer applies while in fallback mode, so this class of wedge is structurally impossible even if `pw.tedapi` is corrupted again
+* New observability fields in `/health` and `/stats` under `"fallback_mode"`: `next_attempt_at` (timestamp the next recovery attempt is due) and `recovery_thread_alive` — operators can now spot a stalled recovery directly instead of inferring it from a frozen `recovery_attempts` counter
+
 ### Proxy t97 (18 Jul 2026)
 
 * Added TEDAPI SolarOnly fallback mode tracking and auto-recovery (issue [#360](https://github.com/jasonacox/pypowerwall/issues/360))

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,3 +1,3 @@
-pypowerwall==0.16.3
+pypowerwall==0.16.4
 bs4==0.0.2
 httpx[http2]>=0.27.0

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -502,7 +502,12 @@ def enter_fallback_mode(reason="TEDAPI data unavailable"):
             _fallback_mode["fallback_since"] = time.time()
             _fallback_mode["recovery_attempts"] = 0
             _fallback_mode["last_recovery_attempt"] = None
-            _fallback_mode["next_attempt_at"] = time.time() + TEDAPI_RECOVERY_INITIAL_INTERVAL
+            # The recovery loop always sleeps TEDAPI_PROBE_INTERVAL before it can
+            # attempt, so the real due time is floored by the probe interval -
+            # without the max() this field under-reports whenever
+            # PW_TEDAPI_PROBE_INTERVAL is set above the 60s initial interval.
+            _fallback_mode["next_attempt_at"] = time.time() + max(
+                TEDAPI_RECOVERY_INITIAL_INTERVAL, TEDAPI_PROBE_INTERVAL)
             log.warning(
                 f"Proxy entering SolarOnly fallback mode: {reason}. "
                 "Background recovery will retry periodically."
@@ -625,11 +630,16 @@ def _tedapi_probe_and_recover():
                     recovery_interval = TEDAPI_RECOVERY_INITIAL_INTERVAL
                 else:
                     next_interval = min(recovery_interval * 2, TEDAPI_RECOVERY_MAX_INTERVAL)
+                    # Elapsed time to the next attempt is probe_sleep +
+                    # max(next_interval - probe_sleep, 0) = max(next_interval,
+                    # TEDAPI_PROBE_INTERVAL) - clamp so next_attempt_at and the
+                    # log line don't under-report with a large probe interval.
+                    next_due = max(next_interval, TEDAPI_PROBE_INTERVAL)
                     with _fallback_mode_lock:
-                        _fallback_mode["next_attempt_at"] = time.time() + next_interval
+                        _fallback_mode["next_attempt_at"] = time.time() + next_due
                     log.warning(
                         f"TEDAPI recovery attempt #{attempt_num} failed — "
-                        f"staying in SolarOnly, next retry in {next_interval}s"
+                        f"staying in SolarOnly, next retry in {next_due}s"
                     )
                     recovery_interval = next_interval
 

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -140,7 +140,7 @@ from pypowerwall.fleetapi.exceptions import (
     PyPowerwallFleetAPIInvalidPayload,
 )
 
-BUILD = "t97"
+BUILD = "t98"
 ALLOWLIST = [
     "/api/status",
     "/api/site_info/site_name",
@@ -436,6 +436,7 @@ _fallback_mode = {
     "fallback_since": None,       # timestamp when fallback was entered
     "recovery_attempts": 0,
     "last_recovery_attempt": None,
+    "next_attempt_at": None,      # timestamp the next recovery attempt is due
 }
 _fallback_mode_lock = threading.RLock()
 _fallback_recovery_lock = threading.Lock()  # serializes pw.connect() calls from recovery thread
@@ -501,6 +502,7 @@ def enter_fallback_mode(reason="TEDAPI data unavailable"):
             _fallback_mode["fallback_since"] = time.time()
             _fallback_mode["recovery_attempts"] = 0
             _fallback_mode["last_recovery_attempt"] = None
+            _fallback_mode["next_attempt_at"] = time.time() + TEDAPI_RECOVERY_INITIAL_INTERVAL
             log.warning(
                 f"Proxy entering SolarOnly fallback mode: {reason}. "
                 "Background recovery will retry periodically."
@@ -517,6 +519,7 @@ def exit_fallback_mode():
             _fallback_mode["fallback_since"] = None
             _fallback_mode["recovery_attempts"] = 0
             _fallback_mode["last_recovery_attempt"] = None
+            _fallback_mode["next_attempt_at"] = None
             log.info(
                 f"Proxy recovered from SolarOnly fallback mode after "
                 f"{duration:.0f}s and {attempts} recovery attempt(s)."
@@ -556,13 +559,20 @@ def _tedapi_probe_and_recover():
         try:
             time.sleep(TEDAPI_PROBE_INTERVAL)
 
-            # Only probe when in TEDAPI mode
-            if not getattr(pw, 'tedapi', None):
-                consecutive_failures = 0
-                continue
-
             with _fallback_mode_lock:
                 in_fallback = _fallback_mode["is_fallback_mode"]
+
+            # Only probe when in TEDAPI mode — but never let this gate block
+            # recovery once in fallback. A fully-failed pw.connect(retry=False)
+            # used to leave pw.tedapi=False (fixed in Powerwall.connect(), #366),
+            # and with the gate checked first the loop short-circuited here on
+            # every iteration: no further recovery attempt, no log line at any
+            # level, is_fallback_mode stuck True until restart. Checking
+            # in_fallback first makes that wedge structurally impossible even if
+            # some future path corrupts pw.tedapi again.
+            if not in_fallback and not getattr(pw, 'tedapi', None):
+                consecutive_failures = 0
+                continue
 
             if not in_fallback:
                 # Healthy path: probe TEDAPI (treat exceptions as probe failures)
@@ -615,6 +625,8 @@ def _tedapi_probe_and_recover():
                     recovery_interval = TEDAPI_RECOVERY_INITIAL_INTERVAL
                 else:
                     next_interval = min(recovery_interval * 2, TEDAPI_RECOVERY_MAX_INTERVAL)
+                    with _fallback_mode_lock:
+                        _fallback_mode["next_attempt_at"] = time.time() + next_interval
                     log.warning(
                         f"TEDAPI recovery attempt #{attempt_num} failed — "
                         f"staying in SolarOnly, next retry in {next_interval}s"
@@ -1125,6 +1137,7 @@ if control_secret:
 
 
 # Start background TEDAPI probe/recovery thread (TEDAPI modes only)
+_recovery_thread = None
 if tedapi_recovery_enabled and pw.tedapi:
     _recovery_thread = threading.Thread(
         target=_tedapi_probe_and_recover, name="tedapi-recovery", daemon=True
@@ -1672,7 +1685,11 @@ class Handler(BaseHTTPRequestHandler):
                     ),
                     "recovery_attempts": fm_snap["recovery_attempts"],
                     "last_recovery_attempt": fm_snap["last_recovery_attempt"],
+                    "next_attempt_at": fm_snap["next_attempt_at"],
                     "recovery_enabled": tedapi_recovery_enabled,
+                    "recovery_thread_alive": (
+                        _recovery_thread.is_alive() if _recovery_thread else None
+                    ),
                 }
 
                 # Add cache memory usage statistics
@@ -1797,7 +1814,11 @@ class Handler(BaseHTTPRequestHandler):
                 ),
                 "recovery_attempts": fm["recovery_attempts"],
                 "last_recovery_attempt": fm["last_recovery_attempt"],
+                "next_attempt_at": fm["next_attempt_at"],
                 "recovery_enabled": tedapi_recovery_enabled,
+                "recovery_thread_alive": (
+                    _recovery_thread.is_alive() if _recovery_thread else None
+                ),
             }
 
             if graceful_degradation:
@@ -1865,6 +1886,7 @@ class Handler(BaseHTTPRequestHandler):
                 _fallback_mode["fallback_since"] = None
                 _fallback_mode["recovery_attempts"] = 0
                 _fallback_mode["last_recovery_attempt"] = None
+                _fallback_mode["next_attempt_at"] = None
 
             if graceful_degradation:
                 with _last_good_responses_lock:

--- a/proxy/tests/test_fallback_mode.py
+++ b/proxy/tests/test_fallback_mode.py
@@ -31,6 +31,7 @@ def _reset_fallback_state():
         _fallback_mode["fallback_since"] = None
         _fallback_mode["recovery_attempts"] = 0
         _fallback_mode["last_recovery_attempt"] = None
+        _fallback_mode["next_attempt_at"] = None
 
 
 class TestFallbackModeLifecycle(unittest.TestCase):
@@ -91,6 +92,19 @@ class TestFallbackModeLifecycle(unittest.TestCase):
             self.assertIsNone(_fallback_mode["fallback_since"])
             self.assertEqual(_fallback_mode["recovery_attempts"], 0)
             self.assertIsNone(_fallback_mode["last_recovery_attempt"])
+            self.assertIsNone(_fallback_mode["next_attempt_at"])
+
+    def test_enter_seeds_next_attempt_at(self):
+        """enter_fallback_mode() schedules the first recovery attempt (#366 observability)."""
+        before = time.time()
+        enter_fallback_mode("test")
+
+        with _fallback_mode_lock:
+            self.assertIsNotNone(_fallback_mode["next_attempt_at"])
+            self.assertGreaterEqual(
+                _fallback_mode["next_attempt_at"],
+                before + server.TEDAPI_RECOVERY_INITIAL_INTERVAL,
+            )
 
     def test_exit_is_idempotent(self):
         """Double exit_fallback_mode() is a no-op — no error when called outside fallback."""
@@ -174,6 +188,20 @@ class TestHealthEndpointFallbackMode(BaseDoGetTest):
         self.assertIsNotNone(fm["fallback_duration_seconds"])
         self.assertGreaterEqual(fm["fallback_duration_seconds"], 0)
         self.assertEqual(fm["recovery_attempts"], 2)
+
+    def test_health_includes_recovery_observability_fields(self):
+        """/health surfaces next_attempt_at and recovery_thread_alive so a wedged
+        recovery thread is visible without inferring it from a frozen counter (#366)."""
+        enter_fallback_mode("test probe failure")
+
+        self._do_health()
+
+        fm = self.get_written_json()["fallback_mode"]
+        self.assertIn("next_attempt_at", fm)
+        self.assertIsNotNone(fm["next_attempt_at"])
+        self.assertIn("recovery_thread_alive", fm)
+        # In tests no recovery thread is started -> None (n/a), never a crash
+        self.assertIsNone(fm["recovery_thread_alive"])
 
 
 class TestHealthResetClearsFallback(BaseDoGetTest):
@@ -328,6 +356,74 @@ class TestProbeIntervalEnvParsing(unittest.TestCase):
     def test_module_constant_is_at_least_5(self):
         """TEDAPI_PROBE_INTERVAL loaded by the running process must respect the clamp."""
         self.assertGreaterEqual(server.TEDAPI_PROBE_INTERVAL, 5)
+
+
+class TestRecoveryLoopGate(unittest.TestCase):
+    """Regression tests for the #366 recovery wedge: the pw.tedapi gate in
+    _tedapi_probe_and_recover() must never short-circuit the recovery branch
+    once the proxy is in fallback mode."""
+
+    def setUp(self):
+        _reset_fallback_state()
+
+    def tearDown(self):
+        _reset_fallback_state()
+
+    def _run_loop(self, mock_pw, max_sleeps=6):
+        """Run the recovery loop with sleeps mocked out, terminating via
+        SystemExit (which the loop's shutdown handler turns into a break)."""
+        sleep_count = [0]
+
+        def fake_sleep(_seconds):
+            sleep_count[0] += 1
+            if sleep_count[0] >= max_sleeps:
+                raise SystemExit
+
+        with patch.object(server, 'pw', mock_pw), \
+             patch.object(server.time, 'sleep', side_effect=fake_sleep):
+            server._tedapi_probe_and_recover()
+
+    def test_falsy_tedapi_does_not_block_recovery_in_fallback(self):
+        """#366 wedge: with pw.tedapi falsy (as a fully-failed connect used to
+        leave it) and fallback active, the loop must still reach pw.connect()
+        and recover — not spin on the gate forever."""
+        enter_fallback_mode("wedge regression")
+        mock_pw = Mock()
+        mock_pw.tedapi = False          # corrupted state from failed reconnect
+        mock_pw.connect.return_value = True
+        mock_pw.version.return_value = "25.10.1"
+
+        self._run_loop(mock_pw)
+
+        mock_pw.connect.assert_called()
+        with _fallback_mode_lock:
+            self.assertFalse(_fallback_mode["is_fallback_mode"])
+
+    def test_failed_attempt_updates_next_attempt_at(self):
+        """A failed recovery attempt schedules next_attempt_at in the future."""
+        enter_fallback_mode("backoff scheduling")
+        mock_pw = Mock()
+        mock_pw.tedapi = False
+        mock_pw.connect.return_value = False   # recovery keeps failing
+
+        self._run_loop(mock_pw)
+
+        with _fallback_mode_lock:
+            self.assertTrue(_fallback_mode["is_fallback_mode"])
+            self.assertGreater(_fallback_mode["recovery_attempts"], 0)
+            self.assertIsNotNone(_fallback_mode["next_attempt_at"])
+            self.assertGreater(_fallback_mode["next_attempt_at"], time.time())
+
+    def test_gate_still_skips_probe_when_healthy_and_no_tedapi(self):
+        """Outside fallback the gate keeps its original behavior: a falsy
+        pw.tedapi skips probing entirely (non-TEDAPI modes must not be probed)."""
+        mock_pw = Mock()
+        mock_pw.tedapi = None
+
+        self._run_loop(mock_pw)
+
+        mock_pw.version.assert_not_called()
+        mock_pw.connect.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/proxy/tests/test_fallback_mode.py
+++ b/proxy/tests/test_fallback_mode.py
@@ -106,6 +106,18 @@ class TestFallbackModeLifecycle(unittest.TestCase):
                 before + server.TEDAPI_RECOVERY_INITIAL_INTERVAL,
             )
 
+    def test_enter_next_attempt_at_floored_by_probe_interval(self):
+        """With PW_TEDAPI_PROBE_INTERVAL above the 60s initial recovery interval,
+        next_attempt_at must reflect the probe-interval floor - the loop cannot
+        attempt sooner than one probe sleep (Copilot review on #367)."""
+        before = time.time()
+        with patch.object(server, 'TEDAPI_PROBE_INTERVAL', 120):
+            enter_fallback_mode("large probe interval")
+
+        with _fallback_mode_lock:
+            self.assertGreaterEqual(
+                _fallback_mode["next_attempt_at"], before + 120)
+
     def test_exit_is_idempotent(self):
         """Double exit_fallback_mode() is a no-op — no error when called outside fallback."""
         # Call from non-fallback state — must not raise

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -258,8 +258,14 @@ class Powerwall(object):
             log.error("Unable to determine mode to connect.")
             return False
         # Snapshot the configured mode - fallback mutates self.mode/cloudmode/
-        # fleetapi, and a total failure must not leave that mutation behind
-        configured_mode = (self.mode, self.cloudmode, self.fleetapi)
+        # fleetapi/tedapi/tedapi_mode, and a total failure must not leave that
+        # mutation behind. tedapi/tedapi_mode matter as much as mode: the local-
+        # mode exception handler zeroes them, and a stale tedapi=False after a
+        # fully-failed connect(retry=False) wedged the proxy's TEDAPI recovery
+        # thread forever - its loop gate (`if not pw.tedapi: continue`) never
+        # reached the reconnect call again (#366).
+        configured_mode = (self.mode, self.cloudmode, self.fleetapi,
+                           self.tedapi, self.tedapi_mode)
         total_wait = 0
         count = 0
         while count < 3:
@@ -350,7 +356,8 @@ class Powerwall(object):
                     continue
         # Total failure - restore the configured mode so a subsequent
         # connect() retries in the configured order, not where fallback left off
-        self.mode, self.cloudmode, self.fleetapi = configured_mode
+        (self.mode, self.cloudmode, self.fleetapi,
+         self.tedapi, self.tedapi_mode) = configured_mode
         return False
 
     def _no_client(self) -> bool:

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -89,7 +89,7 @@ import sys
 import time
 from typing import Optional, Union
 
-version_tuple = (0, 16, 3)
+version_tuple = (0, 16, 4)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/tests/test_mode_selection.py
+++ b/pypowerwall/tests/test_mode_selection.py
@@ -254,3 +254,33 @@ class TestConnectFailureRestoresMode:
             mock_cls.return_value.authenticate.side_effect = None
         assert pw.connect() is True
         assert pw.mode == "local"
+
+    def test_failed_reconnect_preserves_tedapi_state(self, mock_clients):
+        """A fully-failed reconnect must not leave pw.tedapi=False behind (#366).
+
+        The local-mode exception handler zeroes tedapi/tedapi_mode while walking
+        the fallback chain; on total failure both must be restored along with
+        mode/cloudmode/fleetapi. A stale tedapi=False wedged the proxy's TEDAPI
+        recovery thread forever - its loop gate never reached the reconnect call."""
+        import pypowerwall
+        # Connect successfully in full TEDAPI mode first
+        pw = pypowerwall.Powerwall(host="192.168.91.1", password="", gw_pwd="ABCDELNDYT")
+        assert pw.tedapi
+        assert pw.tedapi_mode == "full"
+        saved_tedapi = pw.tedapi
+        # Now the gateway goes away and a reconnect fails across all modes
+        self._fail_all(mock_clients)
+        assert pw.connect(retry=False) is False
+        assert pw.tedapi is saved_tedapi
+        assert pw.tedapi_mode == "full"
+        assert pw.mode == "local"
+
+    def test_failed_initial_connect_leaves_tedapi_off(self, mock_clients):
+        """Total failure on the very first connect restores the initial
+        (tedapi=False, tedapi_mode="off") state, not a partial mutation."""
+        import pypowerwall
+        self._fail_all(mock_clients)
+        pw = pypowerwall.Powerwall(host="192.168.91.1", password="", gw_pwd="ABCDELNDYT")
+        assert pw.tedapi is False
+        assert pw.tedapi_mode == "off"
+        assert pw.mode == "local"


### PR DESCRIPTION
Fixes #366 — TEDAPI auto-recovery sometimes stopped after a failed attempt, wedging the proxy in SolarOnly fallback until restart.

## Root cause (library)

Exactly as diagnosed in the issue thread: `Powerwall.connect()`'s total-failure path restored `mode`/`cloudmode`/`fleetapi` from the `configured_mode` snapshot, but **not** `tedapi`/`tedapi_mode` — which the local-mode fallback handler zeroes on exception. After a fully-failed `connect(retry=False)`, `pw.mode` looked fine while `pw.tedapi` was left permanently `False`.

The proxy recovery thread's loop gate then short-circuited every subsequent iteration:

```python
if not getattr(pw, 'tedapi', None):
    consecutive_failures = 0
    continue
```

No further recovery attempt, no log line at any level, `recovery_attempts`/`last_recovery_attempt` frozen at attempt #1 — matching events A and C in the report, including the frozen `last_recovery_attempt` timestamp.

## Changes

**1. Library fix (`pypowerwall/__init__.py`)** — `tedapi` and `tedapi_mode` are now part of the `configured_mode` snapshot/restore, so a fully-failed `connect(retry=False)` can no longer leave `pw.tedapi` inconsistent with `pw.mode`.

**2. Proxy hardening (`proxy/server.py`, t98)** — the recovery loop checks fallback state *before* the `pw.tedapi` gate. Once in fallback, recovery can never be short-circuited by a falsy `pw.tedapi`, making this class of wedge structurally impossible even if some future path corrupts the attribute again. Healthy-path behavior is unchanged: non-TEDAPI modes still skip probing.

**3. Observability (`/health` and `/stats` → `fallback_mode`)** — as proposed in the issue:
- `next_attempt_at` — timestamp the next recovery attempt is due (seeded on fallback entry, updated after each failed attempt, cleared on exit/reset)
- `recovery_thread_alive` — `Thread.is_alive()` of the recovery thread (`null` when recovery is disabled)

## Deliberately not included

The staleness watchdog that re-creates the recovery thread. With the gate reordered, the only `continue` that could bypass the recovery branch is gone — the loop structurally cannot skip recovery while in fallback — and the library fix removes the state corruption that caused it. Re-creating threads from a watchdog adds real complexity (double-thread races, lock ownership) for a failure class this PR makes unreachable. If a new wedge variant ever shows up, `recovery_thread_alive` + a frozen `next_attempt_at` will now make it directly visible, and we can revisit.

## Why event B recovered when A/C wedged

`pw.tedapi` was only corrupted when `connect()` *raised* inside the local-mode try block (slow, exception-raising attempt — 120s in A/C). Event B's attempt failed fast (19s) via the `pw.version()` sanity check *after* a successful `connect()`, which never touches `pw.tedapi` — so the gate stayed open and attempt #2 fired on schedule. Both paths are covered by the fix.

## Tests

- `test_mode_selection.py`: failed reconnect preserves `tedapi`/`tedapi_mode` (regression for the exact #366 sequence); total failure on first-ever connect still restores the initial off state
- `test_fallback_mode.py`: new `TestRecoveryLoopGate` — with `pw.tedapi` falsy and fallback active, the loop still reaches `pw.connect()` and recovers (the wedge scenario, now impossible); failed attempts schedule `next_attempt_at`; the healthy-path gate still skips probing for non-TEDAPI modes; plus lifecycle/health-payload coverage for the new fields

`pytest -m "not live"`: **355 passed**. Pylint score unchanged from baseline.

## Hardware testing

The library fix is exercisable without hardware (all-mocked backends), but @jasonacox-sam — a live pass would be ideal since this touches the reconnect state machine: run the proxy in TEDAPI mode with `PW_TEDAPI_RECOVERY=yes`, drop the gateway route long enough for fallback + a fully-failed recovery attempt #1 (the wedge trigger), restore the route, and confirm attempt #2+ fires and recovers. @dthorndyke offered to test a patch too — this branch is ready for that (`t98`), and your every-couple-of-days natural fallback cadence is the real-world test the mocks can't replicate.

Credit: root-cause hypothesis and the `last_recovery_attempt` staleness indicator are @dthorndyke's from the issue report; code-level confirmation by @jasonacox-sam.
