### PR TITLE
feat(tedapi): merge lifetime energy accumulators into /api/meters/aggregates

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 # RELEASE NOTES
 
+## v0.16.5 - PW3 Lifetime Energy Accumulators via Gateway Local API
+
+* feat(tedapi): lifetime `energy_imported` / `energy_exported` accumulators are now merged into the synthesized `/api/meters/aggregates` response for Powerwall 3 systems — resolving dashboards showing zero cumulative energy. (#221, #372)
+  * PW3 firmware still serves the classic `/api/meters/aggregates` endpoint behind the customer login (`POST /api/login/Basic` → Bearer token); the TEDAPI adapter now fetches that native payload and overlays the energy fields (site/battery/load/solar) that the TEDAPI payloads do not carry
+  * Works in both v1r wired-LAN mode and WiFi full-tedapi mode; password auto-derived the same way the library already does it
+  * Merged sections carry a provenance note in their `disclaimer` (`…; energy from gateway local API`)
+  * Gateways without the endpoint degrade gracefully — values stay `0` exactly as before, with a 5-minute retry backoff so unsupported firmware isn't hammered; successful fetches are cached on the normal poll cadence
+  * Verified against a live Powerwall 3 (firmware 26.x): values cross-check against solar/grid/battery/load power flows and tick upward between polls
+
 ## v0.16.4 - TEDAPI Auto-Recovery Wedge Fix
 
 * fix: `Powerwall.connect()` now restores `tedapi`/`tedapi_mode` along with `mode`/`cloudmode`/`fleetapi` when all connection modes fail. Previously a fully-failed `connect(retry=False)` left `tedapi=False` behind (the local-mode fallback handler zeroes it), which permanently wedged the proxy's TEDAPI auto-recovery thread — its `pw.tedapi` gate short-circuited every iteration, so no further recovery attempt was ever made until restart. (#366)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
   * Works in both v1r wired-LAN mode and WiFi full-tedapi mode; password auto-derived the same way the library already does it
   * Merged sections carry a provenance note in their `disclaimer` (`…; energy from gateway local API`)
   * Gateways without the endpoint degrade gracefully — values stay `0` exactly as before, with a 5-minute retry backoff so unsupported firmware isn't hammered; successful fetches are cached on the normal poll cadence
+  * Thread-safety hardening for the proxy's multi-threaded use: bounded lock acquisition with stale-cache fallback on contention (no unbounded queuing behind a slow fetch), double-checked cache inside the lock (no thundering-herd refetch on cache expiry), and last-good-host/`lan_failed`-aware host ordering so a dead wired LAN doesn't add a full timeout to every poll
   * Verified against a live Powerwall 3 (firmware 26.x): values cross-check against solar/grid/battery/load power flows and tick upward between polls
 
 ## v0.16.4 - TEDAPI Auto-Recovery Wedge Fix

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -89,7 +89,7 @@ import sys
 import time
 from typing import Optional, Union
 
-version_tuple = (0, 16, 4)
+version_tuple = (0, 16, 5)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -37,6 +37,8 @@
     get_pw3_vitals() - Get the Powerwall 3 Vitals Information
     get_device_controller() - Get the Powerwall Device Controller Status
     get_fan_speed() - Get the fan speeds in RPM
+    get_native_api(path) - Fetch a classic gateway /api/* endpoint via customer login
+    get_native_meters_aggregates() - Get the gateway's native /api/meters/aggregates
 
  Note:
     This module requires access to the Powerwall Gateway. You can add a route to
@@ -187,7 +189,8 @@ class TEDAPI:
         self.customer_token_time: float = 0.0
         self.customer_host: Optional[str] = None
         self.api_session: Optional[requests.Session] = None
-        self._customer_lock = threading.Lock()
+        # Reentrant so get_native_meters_aggregates can hold it across get_native_api
+        self._customer_lock = threading.RLock()
         self._native_fail_until: float = 0.0  # backoff when endpoint unavailable
         if v1r:
             if not password or not rsa_key_path:
@@ -2667,16 +2670,29 @@ class TEDAPI:
         hosts = [self.gw_ip]
         if self.wifi_host and self.wifi_host != self.gw_ip:
             hosts.append(self.wifi_host)
-        for host in hosts:
-            try:
-                with self._customer_lock:
+        if len(hosts) > 1:
+            if self.customer_host in hosts:
+                # Last host that served us goes first - a dead primary would
+                # otherwise cost a full timeout on every fetch
+                hosts.sort(key=lambda h: h != self.customer_host)
+            elif self.lan_failed:
+                hosts.reverse()
+        # Bounded acquisition - don't pile threads up behind a slow fetch
+        if not self._customer_lock.acquire(timeout=self.timeout):
+            log.debug(f"Gateway local API busy - skipping {path}")
+            return None
+        try:
+            for host in hosts:
+                try:
                     data = self._native_get(host, path)
-            except Exception as e:
-                log.debug(f"Gateway local API {path} on {host} failed: {e}")
-                data = None
-            if data is not None:
-                return data
-        return None
+                except Exception as e:
+                    log.debug(f"Gateway local API {path} on {host} failed: {e}")
+                    data = None
+                if data is not None:
+                    return data
+            return None
+        finally:
+            self._customer_lock.release()
 
     def get_native_meters_aggregates(self, force: bool = False) -> Optional[Dict[Any, Any]]:
         """
@@ -2694,15 +2710,29 @@ class TEDAPI:
                 return self.pwcache.get(key)
             if self._native_fail_until > time.time():
                 return self.pwcache.get(key)
-        data = self.get_native_api("/api/meters/aggregates")
-        if isinstance(data, dict) and all(
-            isinstance(data.get(s), dict) for s in ("site", "battery", "load", "solar")
-        ):
-            self.pwcachetime[key] = time.time()
-            self.pwcache[key] = data
-            return data
-        # Endpoint missing/blocked - backoff before trying again
-        self._native_fail_until = time.time() + NATIVE_FAIL_RETRY
-        return None
+        # Bounded acquisition - on contention serve cached data instead of queuing
+        if not self._customer_lock.acquire(timeout=self.timeout):
+            log.debug("Gateway local API busy - returning cached aggregates")
+            return self.pwcache.get(key)
+        try:
+            # Double-check after acquiring - another thread may have refreshed
+            if not force:
+                if key in self.pwcachetime and \
+                        time.time() - self.pwcachetime[key] < self.pwcacheexpire:
+                    return self.pwcache.get(key)
+                if self._native_fail_until > time.time():
+                    return self.pwcache.get(key)
+            data = self.get_native_api("/api/meters/aggregates")
+            if isinstance(data, dict) and all(
+                isinstance(data.get(s), dict) for s in ("site", "battery", "load", "solar")
+            ):
+                self.pwcachetime[key] = time.time()
+                self.pwcache[key] = data
+                return data
+            # Endpoint missing/blocked - backoff before trying again
+            self._native_fail_until = time.time() + NATIVE_FAIL_RETRY
+            return None
+        finally:
+            self._customer_lock.release()
 
     # End of TEDAPI Class

--- a/pypowerwall/tedapi/__init__.py
+++ b/pypowerwall/tedapi/__init__.py
@@ -82,6 +82,12 @@ urllib3.disable_warnings(InsecureRequestWarning)
 # TEDAPI Fixed Gateway IP Address
 GW_IP = "192.168.91.1"
 
+# Gateway local API (customer login) constants - see issue #221
+# Bearer tokens from /api/login/Basic live ~1h; refresh well before that
+CUSTOMER_TOKEN_EXPIRE: Final[float] = 3000.0
+# Backoff before retrying an unavailable local API endpoint
+NATIVE_FAIL_RETRY: Final[float] = 300.0
+
 # Rate Limit Codes
 BUSY_CODES: Final[List[HTTPStatus]] = [HTTPStatus.TOO_MANY_REQUESTS, HTTPStatus.SERVICE_UNAVAILABLE]
 RETRY_FORCE_CODES: Final[List[int]] = [int(i) for i in [
@@ -174,6 +180,15 @@ class TEDAPI:
         self.lan_fail_count = 0     # consecutive LAN failures
         self.lan_recover_after = 0  # timestamp after which to retry LAN
         self.lan_last_success = 0   # timestamp of last successful LAN call
+        # Gateway local API (classic /api/* endpoints) customer-login state.
+        # PW3 firmware still serves /api/meters/aggregates and friends behind a
+        # customer Bearer token from POST /api/login/Basic - see issue #221.
+        self.customer_token: Optional[str] = None
+        self.customer_token_time: float = 0.0
+        self.customer_host: Optional[str] = None
+        self.api_session: Optional[requests.Session] = None
+        self._customer_lock = threading.Lock()
+        self._native_fail_until: float = 0.0  # backoff when endpoint unavailable
         if v1r:
             if not password or not rsa_key_path:
                 raise ValueError("v1r mode requires password and rsa_key_path")
@@ -2549,5 +2564,145 @@ class TEDAPI:
                         }
 
         return block
+
+    # ------------------------------------------------------------------
+    # Gateway Local API (classic /api/* endpoints via customer login)
+    # ------------------------------------------------------------------
+
+    def _customer_password(self) -> Optional[str]:
+        """
+        Customer password for the gateway local API.
+        Tesla derives it from the last 5 characters of the gateway password.
+        """
+        if self.v1r and self.v1r_transport is not None and self.v1r_transport.password:
+            return self.v1r_transport.password
+        if self.gw_pwd and len(self.gw_pwd) >= 5:
+            return self.gw_pwd[-5:]
+        return None
+
+    def _customer_login(self, host: str) -> bool:
+        """Login via POST /api/login/Basic and cache the Bearer token."""
+        password = self._customer_password()
+        if not password:
+            log.debug("No customer password available for gateway local API login")
+            return False
+        if self.api_session is None:
+            self.api_session = requests.Session()
+            self.api_session.verify = False
+        payload = {
+            "username": "customer",
+            "password": password,
+            "email": "nobody@nowhere.com",
+            "clientInfo": {"timezone": "UTC"},
+        }
+        try:
+            r = self.api_session.post(
+                f"https://{host}/api/login/Basic",
+                data=payload,
+                timeout=self.timeout,
+            )
+        except Exception as e:
+            log.debug(f"Gateway local API login error on {host}: {e}")
+            return False
+        if r.status_code != HTTPStatus.OK:
+            log.debug(f"Gateway local API login failed ({r.status_code}) on {host}")
+            return False
+        try:
+            token = r.json().get("token")
+        except ValueError:
+            token = None
+        if not token:
+            return False
+        self.customer_token = token
+        self.customer_token_time = time.time()
+        self.customer_host = host
+        log.debug(f"Gateway local API login ok on {host}")
+        return True
+
+    def _native_get(self, host: str, path: str) -> Optional[Dict[Any, Any]]:
+        """GET a local API path with the cached customer Bearer token."""
+        for attempt in (1, 2):  # one retry with a fresh token on auth failure
+            if (
+                not self.customer_token
+                or self.customer_host != host
+                or time.time() - self.customer_token_time > CUSTOMER_TOKEN_EXPIRE
+            ):
+                if not self._customer_login(host):
+                    return None
+            if self.api_session is None:
+                self.api_session = requests.Session()
+                self.api_session.verify = False
+            try:
+                r = self.api_session.get(
+                    f"https://{host}{path}",
+                    headers={"Authorization": f"Bearer {self.customer_token}"},
+                    timeout=self.timeout,
+                )
+            except Exception as e:
+                log.debug(f"Gateway local API GET {path} on {host} error: {e}")
+                return None
+            if r.status_code == HTTPStatus.OK:
+                try:
+                    return r.json()
+                except ValueError:
+                    log.debug(f"Gateway local API GET {path} on {host} - non-JSON payload")
+                    return None
+            if r.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN) and attempt == 1:
+                # Token may be stale or issued for a different host - retry once
+                self.customer_token = None
+                continue
+            log.debug(f"Gateway local API GET {path} on {host} -> {r.status_code} - not available")
+            return None
+        return None
+
+    def get_native_api(self, path: str) -> Optional[Dict[Any, Any]]:
+        """
+        Fetch a classic gateway local API endpoint (e.g. /api/meters/aggregates)
+        using the customer login (Bearer token). Tries the primary gateway and,
+        when configured, the WiFi fallback host. Returns a dict or None when the
+        endpoint is not available on this firmware.
+        """
+        if not self._customer_password():
+            return None
+        hosts = [self.gw_ip]
+        if self.wifi_host and self.wifi_host != self.gw_ip:
+            hosts.append(self.wifi_host)
+        for host in hosts:
+            try:
+                with self._customer_lock:
+                    data = self._native_get(host, path)
+            except Exception as e:
+                log.debug(f"Gateway local API {path} on {host} failed: {e}")
+                data = None
+            if data is not None:
+                return data
+        return None
+
+    def get_native_meters_aggregates(self, force: bool = False) -> Optional[Dict[Any, Any]]:
+        """
+        Fetch the gateway's native /api/meters/aggregates payload.
+
+        PW3 firmware (25.x+) still serves this endpoint behind the customer
+        Bearer token - including the lifetime energy_imported / energy_exported
+        accumulators that the TEDAPI payloads do not carry (issue #221).
+        Returns None when the endpoint is unavailable, with a retry backoff so
+        unsupported gateways are not hammered on every poll.
+        """
+        key = "native_meters_aggregates"
+        if not force:
+            if key in self.pwcachetime and time.time() - self.pwcachetime[key] < self.pwcacheexpire:
+                return self.pwcache.get(key)
+            if self._native_fail_until > time.time():
+                return self.pwcache.get(key)
+        data = self.get_native_api("/api/meters/aggregates")
+        if isinstance(data, dict) and all(
+            isinstance(data.get(s), dict) for s in ("site", "battery", "load", "solar")
+        ):
+            self.pwcachetime[key] = time.time()
+            self.pwcache[key] = data
+            return data
+        # Endpoint missing/blocked - backoff before trying again
+        self._native_fail_until = time.time() + NATIVE_FAIL_RETRY
+        return None
 
     # End of TEDAPI Class

--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -408,6 +408,27 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
         for section in (data['site'], data['load'], data['solar'], data['battery']):
             section['last_communication_time'] = timestamp
 
+        # Merge lifetime energy accumulators from the gateway's local API when
+        # available. PW3 firmware still serves /api/meters/aggregates behind the
+        # customer login and it carries energy_imported/energy_exported values
+        # that the TEDAPI payloads do not (see issue #221).
+        native = self.tedapi.get_native_meters_aggregates(force=force)
+        if isinstance(native, dict):
+            for section in ("site", "battery", "load", "solar"):
+                native_section = native.get(section)
+                if not isinstance(native_section, dict):
+                    continue
+                merged = False
+                for field in ("energy_exported", "energy_imported"):
+                    value = native_section.get(field)
+                    if isinstance(value, (int, float)):
+                        data[section][field] = value
+                        merged = True
+                if merged:
+                    note = "energy from gateway local API"
+                    existing = data[section].get("disclaimer")
+                    data[section]["disclaimer"] = f"{existing}; {note}" if existing else note
+
         return data
 
     def _extract_site_section(self, status, config, force):

--- a/pypowerwall/tedapi/pypowerwall_tedapi.py
+++ b/pypowerwall/tedapi/pypowerwall_tedapi.py
@@ -421,7 +421,8 @@ class PyPowerwallTEDAPI(PyPowerwallBase):
                 merged = False
                 for field in ("energy_exported", "energy_imported"):
                     value = native_section.get(field)
-                    if isinstance(value, (int, float)):
+                    # bool is an int subclass - exclude it
+                    if isinstance(value, (int, float)) and not isinstance(value, bool):
                         data[section][field] = value
                         merged = True
                 if merged:

--- a/pypowerwall/tests/unit/test_native_energy_merge.py
+++ b/pypowerwall/tests/unit/test_native_energy_merge.py
@@ -7,9 +7,12 @@
   original disclaimers untouched
 - TEDAPI.get_native_meters_aggregates() backs off for NATIVE_FAIL_RETRY seconds
   when the endpoint is unavailable, and caches successful fetches
+- Customer login/token plumbing: 401 -> re-login retry, tokenless login,
+  last-good-host ordering, and stale-cache fallback on lock contention
 """
+import threading
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from pypowerwall.tedapi import TEDAPI
 from pypowerwall.tedapi.pypowerwall_tedapi import PyPowerwallTEDAPI
@@ -98,6 +101,10 @@ class TestNativeEnergyMerge:
                 "energy_exported": None,
                 "energy_imported": "n/a",
             },
+            "load": {
+                "energy_exported": True,   # bool is an int subclass - must not merge
+                "energy_imported": False,
+            },
         }
 
         data = backend.get_api_meters_aggregates()
@@ -105,6 +112,9 @@ class TestNativeEnergyMerge:
         assert data['site']['energy_imported'] == 0
         assert data['site']['energy_exported'] == 0
         assert "energy from gateway local API" not in data['site']['disclaimer']
+        assert data['load']['energy_exported'] == 0
+        assert data['load']['energy_imported'] == 0
+        assert "energy from gateway local API" not in data['load']['disclaimer']
 
     def test_endpoint_unavailable_keeps_zeros(self):
         backend = self._make_backend()
@@ -175,3 +185,111 @@ class TestNativeMetersAggregatesBackoff:
             # force=True bypasses the cache
             ted.get_native_meters_aggregates(force=True)
             assert mock_get.call_count == 2
+
+    def test_lock_contention_serves_cached_data(self):
+        # A thread that cannot get the lock within timeout must serve stale
+        # cache instead of queuing behind a slow fetch
+        ted = self._make_tedapi()
+        ted.timeout = 0.05
+        ted.pwcache["native_meters_aggregates"] = {"cached": True}
+        held = threading.Event()
+        release = threading.Event()
+
+        def holder():
+            with ted._customer_lock:
+                held.set()
+                release.wait(5)
+
+        t = threading.Thread(target=holder)
+        t.start()
+        assert held.wait(5)
+        try:
+            with patch.object(ted, 'get_native_api') as mock_get:
+                assert ted.get_native_meters_aggregates(force=True) == {"cached": True}
+                mock_get.assert_not_called()
+        finally:
+            release.set()
+            t.join()
+
+
+def _resp(status, json_data=None):
+    r = MagicMock()
+    r.status_code = status
+    if json_data is not None:
+        r.json.return_value = json_data
+    else:
+        r.json.side_effect = ValueError("no json")
+    return r
+
+
+class TestCustomerLoginPath:
+    """TEDAPI._customer_login / _native_get auth plumbing and host ordering."""
+
+    def _make_tedapi(self, **kwargs):
+        with patch.object(TEDAPI, 'connect', return_value=True):
+            ted = TEDAPI(gw_pwd='gateway-password', **kwargs)
+        ted.api_session = MagicMock()
+        return ted
+
+    def test_auth_failure_retries_with_fresh_login(self):
+        # 401 on a stale token -> one re-login -> retried GET succeeds
+        ted = self._make_tedapi()
+        ted.customer_token = "stale"
+        ted.customer_host = ted.gw_ip
+        ted.customer_token_time = time.time()
+        ted.api_session.get.side_effect = [_resp(401), _resp(200, {"ok": 1})]
+        ted.api_session.post.return_value = _resp(200, {"token": "fresh"})
+
+        assert ted.get_native_api("/api/meters/aggregates") == {"ok": 1}
+        assert ted.customer_token == "fresh"
+        assert ted.api_session.post.call_count == 1
+        # Bearer header on the retried GET carries the fresh token
+        headers = ted.api_session.get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer fresh"
+
+    def test_persistent_auth_failure_returns_none(self):
+        ted = self._make_tedapi()
+        ted.api_session.get.return_value = _resp(403)
+        ted.api_session.post.return_value = _resp(200, {"token": "tok"})
+        assert ted.get_native_api("/api/meters/aggregates") is None
+
+    def test_login_without_token_returns_none(self):
+        ted = self._make_tedapi()
+        ted.api_session.post.return_value = _resp(200, {})   # 200 but no token
+        assert ted.get_native_api("/api/meters/aggregates") is None
+        ted.api_session.get.assert_not_called()
+
+    def test_non_json_payload_returns_none(self):
+        ted = self._make_tedapi()
+        ted.api_session.post.return_value = _resp(200, {"token": "tok"})
+        ted.api_session.get.return_value = _resp(200)        # 200 but not JSON
+        assert ted.get_native_api("/api/meters/aggregates") is None
+
+    def test_last_good_host_ordered_first(self):
+        # customer_host (last host that served us) must be tried first
+        ted = self._make_tedapi()
+        ted.gw_ip = "192.168.1.50"
+        ted.wifi_host = "192.168.91.1"
+        ted.customer_host = "192.168.91.1"
+        calls = []
+        with patch.object(ted, '_native_get',
+                          side_effect=lambda h, p: calls.append(h) or {"ok": 1}):
+            assert ted.get_native_api("/api/x") == {"ok": 1}
+        assert calls == ["192.168.91.1"]
+
+    def test_lan_failed_prefers_wifi_host(self):
+        # With no last-good host yet, a known-dead LAN goes last
+        ted = self._make_tedapi()
+        ted.gw_ip = "192.168.1.50"
+        ted.wifi_host = "192.168.91.1"
+        ted.lan_failed = True
+        calls = []
+        with patch.object(ted, '_native_get', side_effect=lambda h, p: calls.append(h)):
+            assert ted.get_native_api("/api/x") is None
+        assert calls == ["192.168.91.1", "192.168.1.50"]
+
+    def test_no_customer_password_short_circuits(self):
+        ted = self._make_tedapi()
+        ted.gw_pwd = None
+        assert ted.get_native_api("/api/meters/aggregates") is None
+        ted.api_session.post.assert_not_called()

--- a/pypowerwall/tests/unit/test_native_energy_merge.py
+++ b/pypowerwall/tests/unit/test_native_energy_merge.py
@@ -1,0 +1,177 @@
+"""Regression tests for the gateway local API energy accumulator merge (#221):
+
+- get_api_meters_aggregates() merges lifetime energy_imported/energy_exported
+  from the native /api/meters/aggregates payload and appends a provenance note
+  to each merged section's disclaimer
+- A missing/unavailable native endpoint leaves the synthesized 0 values and
+  original disclaimers untouched
+- TEDAPI.get_native_meters_aggregates() backs off for NATIVE_FAIL_RETRY seconds
+  when the endpoint is unavailable, and caches successful fetches
+"""
+import time
+from unittest.mock import patch
+
+from pypowerwall.tedapi import TEDAPI
+from pypowerwall.tedapi.pypowerwall_tedapi import PyPowerwallTEDAPI
+
+VALID_NATIVE = {
+    "site": {
+        "instant_power": -51,
+        "energy_exported": 1469391,
+        "energy_imported": 4902666.25,
+    },
+    "battery": {
+        "instant_power": 1455,
+        "energy_exported": 4712126,
+        "energy_imported": 4803385,
+    },
+    "load": {
+        "instant_power": 1425,
+        "energy_exported": 0,
+        "energy_imported": 11679089,
+    },
+    "solar": {
+        "instant_power": 0,
+        "energy_exported": 8337073,
+        "energy_imported": 0,
+    },
+}
+
+
+class TestNativeEnergyMerge:
+    """PyPowerwallTEDAPI.get_api_meters_aggregates() merge behavior."""
+
+    def _make_backend(self):
+        with patch('pypowerwall.tedapi.pypowerwall_tedapi.TEDAPI') as mock_tedapi_class:
+            backend = PyPowerwallTEDAPI(gw_pwd='password')
+        backend.tedapi.pw3 = False
+        backend.tedapi.current_power.return_value = 0
+        backend.tedapi.get_config.return_value = {'vin': 'GW--123'}
+        backend.tedapi.get_status.return_value = {
+            'system': {'time': '2026-08-16T04:00:00Z'},
+            'esCan': {'bus': {}},
+        }
+        return backend
+
+    def test_merge_success_values_and_disclaimer(self):
+        backend = self._make_backend()
+        backend.tedapi.get_native_meters_aggregates.return_value = VALID_NATIVE
+
+        data = backend.get_api_meters_aggregates()
+
+        # Lifetime accumulators overlaid on every section
+        assert data['site']['energy_imported'] == 4902666.25
+        assert data['site']['energy_exported'] == 1469391
+        assert data['load']['energy_imported'] == 11679089
+        assert data['solar']['energy_exported'] == 8337073
+        assert data['battery']['energy_exported'] == 4712126
+        # Provenance note appended after the existing synthesized disclaimer
+        assert data['site']['disclaimer'] == \
+            "site: voltage/current from unknown; energy from gateway local API"
+        assert data['load']['disclaimer'].endswith("; energy from gateway local API")
+        assert data['solar']['disclaimer'].endswith("; energy from gateway local API")
+        assert data['battery']['disclaimer'].endswith("; energy from gateway local API")
+
+    def test_merge_partial_native_payload_untouched_sections(self):
+        # Native payload only carrying some sections (e.g. gateway meter set)
+        backend = self._make_backend()
+        backend.tedapi.get_native_meters_aggregates.return_value = {
+            "site": VALID_NATIVE["site"],
+        }
+
+        data = backend.get_api_meters_aggregates()
+
+        assert data['site']['energy_imported'] == 4902666.25
+        assert data['site']['disclaimer'].endswith("; energy from gateway local API")
+        # Sections absent from the native payload keep synthesized 0s and
+        # their original disclaimer - no provenance note added
+        for section in ("battery", "load", "solar"):
+            assert data[section]['energy_imported'] == 0
+            assert data[section]['energy_exported'] == 0
+            assert "energy from gateway local API" not in data[section]['disclaimer']
+
+    def test_merge_ignores_non_numeric_energy_values(self):
+        backend = self._make_backend()
+        backend.tedapi.get_native_meters_aggregates.return_value = {
+            "site": {
+                "instant_power": -51,
+                "energy_exported": None,
+                "energy_imported": "n/a",
+            },
+        }
+
+        data = backend.get_api_meters_aggregates()
+
+        assert data['site']['energy_imported'] == 0
+        assert data['site']['energy_exported'] == 0
+        assert "energy from gateway local API" not in data['site']['disclaimer']
+
+    def test_endpoint_unavailable_keeps_zeros(self):
+        backend = self._make_backend()
+        backend.tedapi.get_native_meters_aggregates.return_value = None
+
+        data = backend.get_api_meters_aggregates()
+
+        # Gateway without the native endpoint: values stay 0 exactly as before
+        for section in ("site", "battery", "load", "solar"):
+            assert data[section]['energy_imported'] == 0
+            assert data[section]['energy_exported'] == 0
+            assert "energy from gateway local API" not in data[section]['disclaimer']
+
+
+class TestNativeMetersAggregatesBackoff:
+    """TEDAPI.get_native_meters_aggregates() caching and backoff."""
+
+    def _make_tedapi(self):
+        with patch.object(TEDAPI, 'connect', return_value=True):
+            ted = TEDAPI(gw_pwd='gateway-password')
+        return ted
+
+    def test_unavailable_endpoint_backs_off(self):
+        ted = self._make_tedapi()
+        with patch.object(ted, 'get_native_api', return_value=None) as mock_get:
+            assert ted.get_native_meters_aggregates() is None
+            assert mock_get.call_count == 1
+            # Backoff window armed
+            assert ted._native_fail_until > time.time()
+
+            # Retries within the backoff window are suppressed entirely -
+            # the gateway is not hammered on every poll
+            assert ted.get_native_meters_aggregates() is None
+            assert mock_get.call_count == 1
+
+    def test_malformed_payload_triggers_backoff(self):
+        ted = self._make_tedapi()
+        # Missing the four required sections - treated as unavailable
+        malformed = {"site": {"energy_imported": 123}}
+        with patch.object(ted, 'get_native_api', return_value=malformed) as mock_get:
+            assert ted.get_native_meters_aggregates() is None
+            assert ted._native_fail_until > time.time()
+            assert mock_get.call_count == 1
+
+    def test_backoff_expiry_retries_endpoint(self):
+        ted = self._make_tedapi()
+        responses = [None, VALID_NATIVE]
+        with patch.object(ted, 'get_native_api', side_effect=responses) as mock_get:
+            assert ted.get_native_meters_aggregates() is None  # sets backoff
+            # Simulate the NATIVE_FAIL_RETRY window elapsing
+            ted._native_fail_until = time.time() - 1
+            result = ted.get_native_meters_aggregates()
+            assert result == VALID_NATIVE
+            assert mock_get.call_count == 2
+
+    def test_successful_fetch_is_cached(self):
+        ted = self._make_tedapi()
+        with patch.object(ted, 'get_native_api', return_value=VALID_NATIVE) as mock_get:
+            first = ted.get_native_meters_aggregates()
+            assert first == VALID_NATIVE
+            assert mock_get.call_count == 1
+
+            # Subsequent polls within the cache TTL reuse the fetch
+            second = ted.get_native_meters_aggregates()
+            assert second == VALID_NATIVE
+            assert mock_get.call_count == 1
+
+            # force=True bypasses the cache
+            ted.get_native_meters_aggregates(force=True)
+            assert mock_get.call_count == 2


### PR DESCRIPTION
## Summary

PW3 firmware still serves the classic `/api/meters/aggregates` endpoint behind the **customer login** (`POST /api/login/Basic` → Bearer token) — and unlike the TEDAPI payloads, it carries the lifetime `energy_imported` / `energy_exported` accumulators for site, battery, load and solar. This was surfaced by @cavedon in #221 and confirmed here on real hardware.

This PR makes the TEDAPI adapter fetch that native payload and overlay the two energy fields onto the synthesized Powerwall-style aggregates response:

* New customer-login session in the `TEDAPI` class (`_customer_login` / `get_native_api` / `get_native_meters_aggregates`) — password is auto-derived (last 5 chars of the gateway password, same derivation the library already uses), works in both **v1r wired-LAN** mode and **WiFi full-tedapi** mode, with WiFi-host fallback.
* `get_api_meters_aggregates()` now merges `energy_imported` / `energy_exported` per section when the native endpoint is reachable, and annotates the section `disclaimer` (`…; energy from gateway local API`) so the provenance is visible.
* Gateways without the endpoint degrade gracefully — values stay `0` exactly as before, with a 5-minute retry backoff so unsupported firmware isn't hammered. Successful fetches are cached on the normal poll cadence.

## Hardware verification (Powerwall 3, firmware 26.x)

```
pw.poll("/api/meters/aggregates")  # v1r mode
site     instant_power=-51    energy_exported=1469391    energy_imported=4902666.25
battery  instant_power=1455   energy_exported=4712126    energy_imported=4803385
load     instant_power=1425   energy_imported=11679089
solar    instant_power=0      energy_exported=8337073
```

The lifetime values cross-check: load (11.68 MWh) ≈ solar (8.34) + grid import (4.90) − grid export (1.47) − battery net (−0.09). Values tick upward between polls — live accumulators, not stubs. Same result in WiFi full-tedapi mode. Full library test suite passes (277 passed, 10 skipped).

Fixes #221

## Notes

* Battery energy counters appear to be lifetime totals (Wh) as on PW2 — same semantics, so dashboards graphing daily energy will need to delta them as they already do for PW2.
* Older PW3 firmware that truly lacks the endpoint simply keeps prior behavior.