### PR TITLE
fix: set_operation partial payloads — stop reserve-0 → False coercion (PW3 mode-persistence race)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 # RELEASE NOTES
 
+## v0.17.1 - set_operation Partial Payload Fix (PW3 Mode-Persistence Race)
+
+* fix(core): `set_operation()` no longer back-fills `/api/operation` payloads for partial-payload backends (cloud, fleetapi, tedapi) — only the fields the caller actually set are written. Tesla applies BACKUP_RESERVE and OPERATION_MODE as two asynchronous commands, so a back-filled reserve write raced a mode-only change and the mode command could be silently dropped on Powerwall 3 (most reproducible when the current reserve is 0). Local gateway writes keep the full-overwrite back-fill behavior, as before.
+* fix(core): an explicit `level=0` is no longer coerced to boolean `False` — numeric `0` is preserved through payload construction, and the cloud/fleetapi "missing parameters" guards now treat `0` as present (`is None` checks)
+* fix(core): calling `set_operation()` with neither `level` nor `mode` on a non-local backend now logs an error and returns `None` instead of posting an empty payload that would raise
+* chore: corrected the cloud/fleetapi invalid-payload error message quoting and grammar
+* tests: payload-construction regression tests across local vs non-local semantics, reserve-0 acceptance (cloud + new FleetAPI suite), and empty-payload soft-fail
+* Library version bumped to `0.17.1`
+
 ## v0.17.0 - TEDAPI Bearer Authentication Mode
 
 * feat(tedapi): new `bearer` authentication mode — logs in via `POST /api/login/Basic` with the installer credentials (full gateway password from the QR sticker) to obtain a Bearer token, then wraps every TEDAPI query in a protobuf `AuthEnvelope` with `externalAuth.type = PRESENCE`. Unlike `basic` (HTTP Basic Auth to `192.168.91.1`, which is only reachable over the Gateway's Wi-Fi), bearer also works over the Gateway's wired LAN IP. Hardware-verified on PW2 and solar-only inverters over both a WiFi static route and the hardwired LAN IP. **Not supported on Powerwall 3** — for PW3 wired access use v1r mode (`rsa_key_path`).

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -89,7 +89,7 @@ import sys
 import time
 from typing import Optional, Union
 
-version_tuple = (0, 17, 0)
+version_tuple = (0, 17, 1)
 version = __version__ = '%d.%d.%d' % version_tuple
 __author__ = 'jasonacox'
 
@@ -850,6 +850,13 @@ class Powerwall(object):
             mode = self.get_mode()
             if mode:
                 payload['real_mode'] = mode
+
+        if not payload and not full_overwrite:
+            # Partial-payload backends raise on an empty body; without a
+            # caller-set field there is nothing to write, so fail soft like
+            # the other invalid-input paths instead of raising.
+            log.error("No operation to set - pass level and/or mode.")
+            return None
 
         log.debug(f"Setting operation: {payload}")
 

--- a/pypowerwall/__init__.py
+++ b/pypowerwall/__init__.py
@@ -816,23 +816,41 @@ class Powerwall(object):
             log.error("Level can be in range of 0 to 100 only.")
             return None
 
-        if level is None:
-            # Back-fill the current reserve so the write does not change it. The scale must
-            # match the write path: the local backend passes the payload verbatim to the
-            # gateway's raw-scale /api/operation, while cloud/fleetapi/tedapi writes expect
-            # the Tesla-app scale (tedapi converts app->raw internally on write).
-            level = self.get_reserve(scale=not isinstance(self.client, PyPowerwallLocal))
+        # The local gateway /api/operation is a full overwrite: an omitted field
+        # would clobber the current setting, so back-fill from the live values.
+        # Cloud/fleetapi/tedapi accept partial payloads, and back-filling there is
+        # actively harmful: Tesla applies BACKUP_RESERVE and OPERATION_MODE as two
+        # asynchronous commands, so a back-filled reserve write races the mode
+        # change and the mode command can be silently dropped (observed on PW3
+        # whenever the current reserve is 0). Partial-payload backends therefore
+        # write only the fields the caller actually set.
+        full_overwrite = isinstance(self.client, PyPowerwallLocal)
+
+        payload = {}
+        if level is not None:
+            # Explicit reserve: keep the numeric value. In particular 0 must stay
+            # 0 - the legacy coercion of 0 to boolean False (a v1-local-API-era
+            # "leave unchanged" marker) made the cloud path treat every
+            # reserve-0 write as a real BACKUP_RESERVE=0 command racing any mode
+            # change in the same call.
+            payload['backup_reserve_percent'] = level
+        elif full_overwrite:
+            # Back-fill the current reserve so the write does not change it. The
+            # local backend passes the payload verbatim to the gateway's raw-scale
+            # /api/operation, so read it back raw.
+            level = self.get_reserve(scale=False)
             if level is None:
                 log.error("Unable to determine current reserve level - unable to set operation.")
                 return None
+            payload['backup_reserve_percent'] = level
 
-        if not mode:
+        if mode:
+            payload['real_mode'] = mode
+        elif full_overwrite:
             mode = self.get_mode()
+            if mode:
+                payload['real_mode'] = mode
 
-        payload = {
-            'backup_reserve_percent': level if level > 0 else False,
-            'real_mode': mode
-        }
         log.debug(f"Setting operation: {payload}")
 
         result = self.post(api='/api/operation', payload=payload, din=self.din(), jsonformat=jsonformat)

--- a/pypowerwall/cloud/pypowerwall_cloud.py
+++ b/pypowerwall/cloud/pypowerwall_cloud.py
@@ -1200,7 +1200,7 @@ class PyPowerwallCloud(PyPowerwallBase):
 
         if payload.get('backup_reserve_percent') is None and payload.get('real_mode') is None:
             raise PyPowerwallCloudInvalidPayload("/api/operation payload missing required parameters. Either "
-                                                 "'backup_reserve_percent or 'real_mode', or both must present.")
+                                                 "'backup_reserve_percent' or 'real_mode', or both, must be present.")
 
         if not din:
             log.warning("No valid DIN provided, will adjust the first battery on site.")

--- a/pypowerwall/cloud/pypowerwall_cloud.py
+++ b/pypowerwall/cloud/pypowerwall_cloud.py
@@ -1198,7 +1198,7 @@ class PyPowerwallCloud(PyPowerwallBase):
         payload = kwargs.get('payload', {})
         din = kwargs.get('din')
 
-        if not payload.get('backup_reserve_percent') and not payload.get('real_mode'):
+        if payload.get('backup_reserve_percent') is None and payload.get('real_mode') is None:
             raise PyPowerwallCloudInvalidPayload("/api/operation payload missing required parameters. Either "
                                                  "'backup_reserve_percent or 'real_mode', or both must present.")
 

--- a/pypowerwall/fleetapi/pypowerwall_fleetapi.py
+++ b/pypowerwall/fleetapi/pypowerwall_fleetapi.py
@@ -750,7 +750,7 @@ class PyPowerwallFleetAPI(PyPowerwallBase):
 
         if payload.get('backup_reserve_percent') is None and payload.get('real_mode') is None:
             raise PyPowerwallFleetAPIInvalidPayload("/api/operation payload missing required parameters. Either "
-                                                 "'backup_reserve_percent or 'real_mode', or both must present.")
+                                                 "'backup_reserve_percent' or 'real_mode', or both, must be present.")
 
         if din:
             log.debug("FleetAPI mode operates on entire site, not din. Ignoring din parameter.")

--- a/pypowerwall/fleetapi/pypowerwall_fleetapi.py
+++ b/pypowerwall/fleetapi/pypowerwall_fleetapi.py
@@ -748,7 +748,7 @@ class PyPowerwallFleetAPI(PyPowerwallBase):
         din = kwargs.get('din')
         resp = {}
 
-        if not payload.get('backup_reserve_percent') and not payload.get('real_mode'):
+        if payload.get('backup_reserve_percent') is None and payload.get('real_mode') is None:
             raise PyPowerwallFleetAPIInvalidPayload("/api/operation payload missing required parameters. Either "
                                                  "'backup_reserve_percent or 'real_mode', or both must present.")
 

--- a/pypowerwall/tests/unit/test_cloud_regressions.py
+++ b/pypowerwall/tests/unit/test_cloud_regressions.py
@@ -72,6 +72,19 @@ class TestPostApiOperation:
         battery.set_backup_reserve_percent.assert_called_once_with(30)
         battery.set_operation.assert_not_called()
 
+    def test_reserve_zero_only_not_rejected_as_empty(self, cloud):
+        # Regression (PW3 mode-persistence race): {'backup_reserve_percent': 0}
+        # alone used to fail the truthiness-based "missing parameters" guard.
+        battery = self._make_battery()
+        cloud.tesla = MagicMock()
+        cloud.tesla.battery_list.return_value = [battery]
+
+        resp = cloud.post_api_operation(payload={'backup_reserve_percent': 0})
+        assert 'error' not in resp
+        assert resp['set_backup_reserve_percent']['backup_reserve_percent'] == 0
+        battery.set_backup_reserve_percent.assert_called_once_with(0)
+        battery.set_operation.assert_not_called()
+
     def test_false_reserve_normalized_to_zero(self, cloud):
         battery = self._make_battery()
         cloud.tesla = MagicMock()

--- a/pypowerwall/tests/unit/test_fleetapi_operation_payload.py
+++ b/pypowerwall/tests/unit/test_fleetapi_operation_payload.py
@@ -1,0 +1,53 @@
+"""Regression tests for fleetapi post_api_operation partial-payload handling.
+
+A reserve-only payload of 0 used to be rejected by the truthiness-based
+"missing parameters" guard ('not 0' is True). See PW3 mode-persistence race
+reported in pypowerwall-server PR #85.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from pypowerwall.fleetapi.pypowerwall_fleetapi import (
+    PyPowerwallFleetAPI,
+    PyPowerwallFleetAPIInvalidPayload,
+)
+
+
+def _make_fleetapi():
+    # Construct via __new__ to skip __init__ network/token-file side effects.
+    fleet = PyPowerwallFleetAPI.__new__(PyPowerwallFleetAPI)
+    fleet.fleet = MagicMock()
+    fleet.fleet.set_battery_reserve.return_value = 200
+    fleet.fleet.set_operating_mode.return_value = 200
+    return fleet
+
+
+def test_reserve_zero_only_not_rejected_as_empty(tmp_path):
+    fleet = _make_fleetapi()
+
+    resp = fleet.post_api_operation(payload={'backup_reserve_percent': 0})
+    assert 'error' not in resp
+    assert resp['set_backup_reserve_percent']['backup_reserve_percent'] == 0
+    fleet.fleet.set_battery_reserve.assert_called_once_with(0)
+    fleet.fleet.set_operating_mode.assert_not_called()
+
+
+def test_mode_only_payload_single_command(tmp_path):
+    fleet = PyPowerwallFleetAPI.__new__(PyPowerwallFleetAPI)
+    fleet.fleet = MagicMock()
+    fleet.fleet.set_battery_reserve.return_value = 200
+    fleet.fleet.set_operating_mode.return_value = 200
+
+    resp = fleet.post_api_operation(payload={'real_mode': 'autonomous'})
+    assert 'error' not in resp
+    assert resp['set_operation']['real_mode'] == 'autonomous'
+    fleet.fleet.set_operating_mode.assert_called_once_with('autonomous')
+    fleet.fleet.set_battery_reserve.assert_not_called()
+
+
+def test_empty_payload_still_rejected(tmp_path):
+    fleet = PyPowerwallFleetAPI.__new__(PyPowerwallFleetAPI)
+    fleet.fleet = MagicMock()
+    with pytest.raises(PyPowerwallFleetAPIInvalidPayload):
+        fleet.post_api_operation(payload={})

--- a/pypowerwall/tests/unit/test_powerwall_core.py
+++ b/pypowerwall/tests/unit/test_powerwall_core.py
@@ -326,6 +326,17 @@ class TestSetOperationPayload:
         payload = pw.client.calls[-1][2]
         assert payload == {'backup_reserve_percent': 0}
 
+    def test_empty_payload_non_local_returns_none(self, pw):
+        # Regression (Copilot review): with neither level nor mode set on a
+        # partial-payload backend, set_operation() must not post an empty
+        # body (backends reject it by raising). Fail soft like the other
+        # invalid-input paths.
+        calls_before = len(pw.client.calls)
+        assert pw.set_operation() is None
+        assert len(pw.client.calls) == calls_before
+        assert pw.set_operation(mode='') is None
+        assert len(pw.client.calls) == calls_before
+
     def test_backfill_uses_raw_scale_for_local(self, pw):
         from unittest.mock import patch
         # Local backend passes the payload verbatim to the gateway's raw-scale API

--- a/pypowerwall/tests/unit/test_powerwall_core.py
+++ b/pypowerwall/tests/unit/test_powerwall_core.py
@@ -47,9 +47,9 @@ class StubClient(PyPowerwallBase):
 
     def post(self, api: str, payload, din: str, recursive: bool = False, raw: bool = False):
         self.calls.append(('post', api, payload))
-        # Simulate modifying backup_reserve_percent
+        # Simulate modifying backup_reserve_percent (partial payloads honored)
         if api == '/api/operation' and payload:
-            if payload.get('backup_reserve_percent') is not False:
+            if 'backup_reserve_percent' in payload:
                 self._poll_map['/api/operation']['backup_reserve_percent'] = payload['backup_reserve_percent']
             if payload.get('real_mode'):
                 self._poll_map['/api/operation']['real_mode'] = payload['real_mode']
@@ -282,35 +282,77 @@ class TestTEDAPIv1rReserveScaling:
 
 
 # ---------------------------------------------------------------------------
-# set_operation() reserve back-fill regression tests
+# set_operation() payload construction tests
 # ---------------------------------------------------------------------------
 
-class TestSetOperationBackfill:
-    """Verify set_operation() back-fills the reserve in the scale the backend expects."""
+class TestSetOperationPayload:
+    """Partial-payload semantics per backend (PW3 mode-persistence race fix).
 
-    def test_backfill_uses_app_scale_for_non_local(self, pw):
-        # Non-local backends (cloud/fleetapi/tedapi) expect Tesla-app scale on write.
-        # Raw 20% -> app scale (20/0.95) - (5/0.95) = 15.789...
+    Tesla applies BACKUP_RESERVE and OPERATION_MODE as two async commands, so a
+    back-filled reserve write raced a mode-only change and the mode command could
+    be silently dropped. Non-local backends now write only the requested fields.
+    """
+
+    def test_mode_only_non_local_omits_reserve(self, pw):
+        # Non-local backends accept partial payloads: a mode-only write must not
+        # back-fill (and therefore not race) the reserve.
         resp = pw.set_operation(mode='backup')
         assert resp['ok'] is True
         payload = pw.client.calls[-1][2]
-        assert payload['real_mode'] == 'backup'
-        assert payload['backup_reserve_percent'] == pytest.approx((20 / 0.95) - (5 / 0.95))
+        assert payload == {'real_mode': 'backup'}
+        assert 'backup_reserve_percent' not in payload
+
+    def test_reserve_only_non_local_omits_mode(self, pw):
+        resp = pw.set_reserve(40)
+        assert resp['ok'] is True
+        payload = pw.client.calls[-1][2]
+        assert payload == {'backup_reserve_percent': 40}
+        assert 'real_mode' not in payload
+
+    def test_explicit_zero_level_stays_numeric(self, pw):
+        # Regression (nesys, pypowerwall-server PR #85): an explicit reserve of 0
+        # was coerced to boolean False, which the cloud path split into two
+        # racing Owner API commands and could drop the mode change.
+        resp = pw.set_operation(level=0, mode='autonomous')
+        assert resp['ok'] is True
+        payload = pw.client.calls[-1][2]
+        assert payload['backup_reserve_percent'] == 0
+        assert payload['backup_reserve_percent'] is not False
+        assert payload['real_mode'] == 'autonomous'
+
+    def test_explicit_zero_reserve_only(self, pw):
+        resp = pw.set_reserve(0)
+        assert resp['ok'] is True
+        payload = pw.client.calls[-1][2]
+        assert payload == {'backup_reserve_percent': 0}
 
     def test_backfill_uses_raw_scale_for_local(self, pw):
         from unittest.mock import patch
-        # Local backend passes the payload verbatim to the gateway's raw-scale API,
-        # so the back-fill must not apply the Tesla-app scale conversion.
+        # Local backend passes the payload verbatim to the gateway's raw-scale API
+        # and is a full overwrite, so mode-only writes still back-fill both fields.
         with patch('pypowerwall.PyPowerwallLocal', StubClient):
             resp = pw.set_operation(mode='backup')
         assert resp['ok'] is True
         payload = pw.client.calls[-1][2]
         assert payload['backup_reserve_percent'] == 20
+        assert payload['real_mode'] == 'backup'
 
-    def test_backfill_none_returns_none(self, pw):
+    def test_backfill_local_explicit_zero_writes_zero(self, pw):
+        # On the local path, 0 used to become False (= "leave unchanged" marker)
+        # which silently no-opped set_reserve(0). It now writes a real 0.
+        from unittest.mock import patch
+        with patch('pypowerwall.PyPowerwallLocal', StubClient):
+            resp = pw.set_operation(level=0, mode='backup')
+        assert resp['ok'] is True
+        payload = pw.client.calls[-1][2]
+        assert payload['backup_reserve_percent'] == 0
+
+    def test_backfill_none_returns_none_local(self, pw):
         # Gateway unreachable: get_reserve() returns None - must not raise TypeError
-        del pw.client._poll_map['/api/operation']
-        resp = pw.set_operation(mode='backup')
+        from unittest.mock import patch
+        with patch('pypowerwall.PyPowerwallLocal', StubClient):
+            del pw.client._poll_map['/api/operation']
+            resp = pw.set_operation(mode='backup')
         assert resp is None
 
 


### PR DESCRIPTION
Closes the library-side follow-up promised in jasonacox/pypowerwall-server#85.

## Problem

Hardware testing of the hybrid mode in pypowerwall-server PR #85 (big thanks to @nesys for the PW3 test matrix) surfaced two cloud-control failures that trace back to this library:

1. **`set_mode()` alone did not persist the mode change** — HTTP 200, `"Operation mode updated"`, but Tesla silently dropped it.
2. **`set_operation(0, mode)` (reserve 0) reported success without persisting the mode** — while `set_operation(1, mode)` worked.

## Root cause

Tesla's cloud applies `BACKUP_RESERVE` and `OPERATION_MODE` as **two asynchronous commands**. The shared `set_operation()` always sent both payload fields — back-filling whichever the caller omitted, and coercing an explicit reserve of `0` to boolean `False` (a v1-local-API-era marker). So a mode-only write whose back-filled reserve was 0 (and any explicit `level=0` write) fired two racing Owner API commands, and the mode command could be silently dropped:

```python
payload = {
    'backup_reserve_percent': level if level > 0 else False,   # 0 → JSON false
    'real_mode': mode
}
```

## Fix

- **Partial payloads for partial-capable backends** (cloud, fleetapi, tedapi): `set_operation()` now writes only the fields the caller set. A mode-only write sends a **single `OPERATION_MODE` command**; a reserve-only write a single `BACKUP_RESERVE` command — no back-fill race, and fewer duplicate Tesla audit-log entries.
- **Local gateway path unchanged in spirit**: `/api/operation` there is a full overwrite, so omitted fields are still back-filled with current values (raw scale, passed verbatim).
- **Explicit `level=0` stays numeric `0`** — no `False` coercion. This also fixes `set_reserve(0)` silently no-opping on the local path (where `False` means "leave unchanged").
- **cloud + fleetapi `post_api_operation()`**: the truthiness-based "missing parameters" guard now checks `is None`, so a legitimate `{'backup_reserve_percent': 0}` partial payload is no longer rejected. The `False`→`0` normalization inside the backends is kept defensively for direct raw-post callers.
- tedapi `post_api_operation` already handles key-presence partial payloads and app→raw scale conversion — no change needed there.

## Tests

- Mode-only / reserve-only / explicit-0 payload construction per backend (local vs non-local)
- Local back-fill keeps raw scale; unreachable-gateway `None` reserve still returns `None` instead of raising
- Cloud: reserve-0-only accepted, single command per partial payload
- FleetAPI: same partial-payload coverage plus empty-payload still rejected
- Full suite: **404 passed, 10 skipped**

## Compatibility notes

- Responses from partial writes now contain only the executed command's key(s) (`set_operation` / `set_backup_reserve_percent`) — both keys were always conditional in the backends, but callers indexing the *other* key on a partial write would have already been broken by the pre-existing partial-payload support.
- `set_reserve()`/`set_mode()` wrappers keep their signatures and return shapes.

Would appreciate a real-rig sanity pass on v1 local (PW2) and FleetAPI control paths before merge — the PW3 cloud path is the one validated end-to-end on hardware via the pypowerwall-server PR above.

— Sam 🔌